### PR TITLE
fix(DriverHealthChecker): worst-state wins across paired devices (Issue #4)

### DIFF
--- a/MagicMouseTray/DriverHealthChecker.cs
+++ b/MagicMouseTray/DriverHealthChecker.cs
@@ -56,6 +56,7 @@ internal static class DriverHealthChecker
             bool anyAppleMouse = false;
             bool anyBound = false;
             bool anyUnknownPid = false;
+            bool anyNotBound = false;
 
             foreach (var subkeyName in btEnumKey.GetSubKeyNames())
             {
@@ -101,6 +102,7 @@ internal static class DriverHealthChecker
                     else
                     {
                         Logger.Log($"DRIVER_CHECK pid=0x{pid.ToUpper()} LowerFilters=missing");
+                        anyNotBound = true;
                     }
                 }
             }
@@ -111,20 +113,22 @@ internal static class DriverHealthChecker
                 return DriverStatus.Ok;
             }
 
-            if (anyBound)
-            {
-                Logger.Log("DRIVER_CHECK status=Ok (service + LowerFilters bound)");
-                return DriverStatus.Ok;
-            }
-
+            // Worst-state wins across all paired devices:
+            // UnknownAppleMouse > NotBound > Ok
             if (anyUnknownPid)
             {
                 Logger.Log("DRIVER_CHECK status=UnknownAppleMouse (PID not in INF)");
                 return DriverStatus.UnknownAppleMouse;
             }
 
-            Logger.Log("DRIVER_CHECK status=NotBound (service present, known PID, LowerFilters missing)");
-            return DriverStatus.NotBound;
+            if (anyNotBound)
+            {
+                Logger.Log("DRIVER_CHECK status=NotBound (service present, known PID, LowerFilters missing)");
+                return DriverStatus.NotBound;
+            }
+
+            Logger.Log("DRIVER_CHECK status=Ok (service + LowerFilters bound)");
+            return DriverStatus.Ok;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary

- **Bug**: GetStatus() returned Ok as soon as any paired Apple device had LowerFilters bound, silently hiding UnknownAppleMouse state for other paired mice
- **Fix**: Add anyNotBound tracking; reorder priority so worst state wins: UnknownAppleMouse > NotBound > Ok
- **Scope**: DriverHealthChecker.cs only

## Root cause

anyBound short-circuited before anyUnknownPid check. Known bound + unknown future Apple mouse = UnknownAppleMouse never surfaced.

## Fix

Worst-state wins across all paired devices:
- anyUnknownPid -> UnknownAppleMouse
- anyNotBound -> NotBound
- otherwise -> Ok

## Test plan

- [ ] Single known device bound -> Ok
- [ ] Single known device not bound -> NotBound
- [ ] Single unknown PID -> UnknownAppleMouse
- [ ] Known bound + unknown PID -> UnknownAppleMouse (previously Ok - fixed)
- [ ] Known bound + known not-bound -> NotBound (previously Ok - fixed)
- [ ] No Apple devices -> Ok

Closes #4
