### PR TITLE
feat(M10): startup-repair.ps1 + task registration — persistent battery across reboots

### DIFF
--- a/sign-and-install.ps1
+++ b/sign-and-install.ps1
@@ -55,12 +55,40 @@ pnputil /delete-driver oem53.inf /force 2>$null | Out-Null
 Write-Host "Step 8: Installing signed driver package..."
 pnputil /add-driver $INF /install /force
 
+# Step 9 - Register startup repair task (runs startup-repair.ps1 at every boot)
+Write-Host "Step 9: Registering startup repair task..."
+$repairScript = Join-Path $PSScriptRoot "startup-repair.ps1"
+if (Test-Path $repairScript) {
+    $taskName = "MagicMouseTray-StartupRepair"
+    $taskExists = Get-ScheduledTask -TaskName $taskName -ErrorAction SilentlyContinue
+    if ($taskExists) {
+        Write-Host "  Task '$taskName' already registered — skipping"
+    } else {
+        $action  = New-ScheduledTaskAction -Execute "powershell.exe" `
+            -Argument "-NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass -File `"$repairScript`""
+        $trigger = New-ScheduledTaskTrigger -AtStartup
+        $trigger.Delay = "PT30S"   # 30-second delay to let BT stack initialise
+        $settings = New-ScheduledTaskSettingsSet -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries
+        $principal = New-ScheduledTaskPrincipal -UserId "SYSTEM" -RunLevel Highest
+
+        Register-ScheduledTask -TaskName $taskName -Action $action `
+            -Trigger $trigger -Settings $settings -Principal $principal `
+            -Description "Repairs Magic Mouse COL02 battery HID collection at startup" `
+            -Force | Out-Null
+        Write-Host "  Task '$taskName' registered (runs at startup with 30s delay, as SYSTEM)"
+    }
+} else {
+    Write-Host "  WARNING: startup-repair.ps1 not found at $repairScript — skipping task registration"
+    Write-Host "  For persistent battery reading across reboots, run Register-ScheduledTask manually."
+}
+
 Write-Host ""
 Write-Host "Done. Now:"
 Write-Host "  1. Remove the Magic Mouse from Bluetooth Settings"
 Write-Host "  2. Re-pair it"
 Write-Host "  3. Test scroll"
 Write-Host "  4. Reboot normally (test signing takes effect at next boot)"
+Write-Host "     Battery reading will be auto-repaired by the startup task."
 Write-Host ""
 Write-Host "After scroll is confirmed working post-reboot:"
 Write-Host "  bcdedit /set testsigning off  (then reboot — watermark gone, driver stays)"

--- a/startup-repair.ps1
+++ b/startup-repair.ps1
@@ -1,0 +1,140 @@
+# startup-repair.ps1 — MagicMouseTray COL02 Battery Collection Repair
+# SPDX-License-Identifier: MIT
+#
+# Runs at startup via Windows Scheduled Task (SYSTEM account, 30s delay).
+# Detects whether COL02 (battery HID collection) is missing — this happens every
+# reboot when applewirelessmouse is in LowerFilters, because the filter modifies
+# the HID descriptor during fresh BTHENUM enumeration and strips the battery
+# collection. If missing, cycles the BTHENUM parent to restore COL01+COL02.
+#
+# Usage (manual): powershell -ExecutionPolicy Bypass -File startup-repair.ps1
+# Usage (scheduled task): registered by install-driver.ps1 — runs automatically.
+
+param(
+    [string]$LogFile = "C:\ProgramData\MagicMouseTray\startup-repair.log",
+    [int]$SettleSeconds = 2    # wait after re-enable before checking result
+)
+
+# Maximum log size before rotation (bytes)
+$MaxLogBytes = 512KB
+
+function Write-Log {
+    param([string]$Msg)
+    $line = "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')] $Msg"
+    Add-Content -Path $LogFile -Value $line -Encoding UTF8
+}
+
+# ---- bootstrap ----
+$logDir = Split-Path $LogFile -Parent
+if (-not (Test-Path $logDir)) {
+    New-Item -ItemType Directory -Path $logDir -Force | Out-Null
+}
+
+# Rotate log if over limit
+if ((Test-Path $LogFile) -and (Get-Item $LogFile).Length -gt $MaxLogBytes) {
+    $archive = [System.IO.Path]::ChangeExtension($LogFile, "1.log")
+    Move-Item $LogFile $archive -Force
+}
+
+Write-Log "startup-repair: begin"
+
+# Apple Magic Mouse PIDs covered by AppleWirelessMouse.inf
+# (matches DriverHealthChecker.cs KnownPids list)
+$knownPids = @("0323", "030d", "0269", "0310")
+
+$anyRepaired = $false
+
+foreach ($pid in $knownPids) {
+    # Find BTHENUM parent device for this Magic Mouse pairing
+    $btDevice = Get-PnpDevice -ErrorAction SilentlyContinue |
+        Where-Object { $_.InstanceId -match "BTHENUM" -and
+                       $_.InstanceId -match "_PID&$pid" -and
+                       $_.Status -eq 'OK' } |
+        Select-Object -First 1
+
+    if (-not $btDevice) {
+        continue  # PID not paired — normal, skip silently
+    }
+
+    Write-Log "PID 0x$($pid.ToUpper()): BTHENUM = $($btDevice.InstanceId)"
+
+    # COL02 exists when there are 2+ HID-class child devices with this PID and Status OK.
+    # One collapsed device (filter stripped COL02) = Count 1. Healthy = Count 2+.
+    $hidDevices = Get-PnpDevice -ErrorAction SilentlyContinue |
+        Where-Object { $_.Class -eq 'HIDClass' -and
+                       $_.InstanceId -match $pid -and
+                       $_.Status -eq 'OK' }
+
+    if ($hidDevices.Count -ge 2) {
+        Write-Log "PID 0x$($pid.ToUpper()): COL02 present ($($hidDevices.Count) HID device(s)) — no repair needed"
+        continue
+    }
+
+    Write-Log "PID 0x$($pid.ToUpper()): COL02 missing ($($hidDevices.Count) HID device(s)) — starting repair"
+
+    $btRegPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\" + $btDevice.InstanceId
+
+    if (-not (Test-Path $btRegPath)) {
+        Write-Log "ERROR: registry path not found: $btRegPath"
+        continue
+    }
+
+    # Read current LowerFilters (need to restore after cycling)
+    $lowerFilters = (Get-ItemProperty -Path $btRegPath -Name LowerFilters -ErrorAction SilentlyContinue).LowerFilters
+    if (-not ($lowerFilters -contains 'applewirelessmouse')) {
+        Write-Log "PID 0x$($pid.ToUpper()): applewirelessmouse not in LowerFilters — no filter conflict, skipping"
+        continue
+    }
+
+    Write-Log "LowerFilters = $($lowerFilters -join ', ')"
+
+    # Repair: remove filter → cycle BTHENUM → restore filter
+    # Cycling BTHENUM forces a fresh HID descriptor negotiation without the filter,
+    # creating COL01 (scroll) and COL02 (battery) as separate child devices.
+    # Re-adding the filter afterward adds scroll support to COL01 without collapsing COL02.
+    try {
+        Write-Log "Step 1: removing LowerFilters..."
+        Remove-ItemProperty -Path $btRegPath -Name LowerFilters -ErrorAction Stop
+
+        Write-Log "Step 2: disabling BTHENUM device..."
+        $out = pnputil /disable-device "$($btDevice.InstanceId)" 2>&1
+        Write-Log "  $($out | Select-Object -Last 2 | Out-String -NoNewline)"
+
+        Start-Sleep -Milliseconds 500
+
+        Write-Log "Step 3: enabling BTHENUM device..."
+        $out = pnputil /enable-device "$($btDevice.InstanceId)" 2>&1
+        Write-Log "  $($out | Select-Object -Last 2 | Out-String -NoNewline)"
+
+        Start-Sleep -Seconds $SettleSeconds
+
+        Write-Log "Step 4: restoring LowerFilters..."
+        Set-ItemProperty -Path $btRegPath -Name LowerFilters -Value $lowerFilters -Type MultiString -ErrorAction Stop
+
+        # Verify
+        Start-Sleep -Seconds 1
+        $hidAfter = Get-PnpDevice -ErrorAction SilentlyContinue |
+            Where-Object { $_.Class -eq 'HIDClass' -and
+                           $_.InstanceId -match $pid -and
+                           $_.Status -eq 'OK' }
+
+        if ($hidAfter.Count -ge 2) {
+            Write-Log "REPAIRED: COL02 present ($($hidAfter.Count) HID device(s)) — battery reading restored"
+            $anyRepaired = $true
+        } else {
+            Write-Log "WARNING: repair attempted — COL02 still not visible ($($hidAfter.Count) HID device(s))"
+        }
+
+    } catch {
+        Write-Log "ERROR during repair: $($_.Exception.Message)"
+        # Attempt to restore LowerFilters on error
+        try {
+            Set-ItemProperty -Path $btRegPath -Name LowerFilters -Value $lowerFilters -Type MultiString
+            Write-Log "LowerFilters restored after error"
+        } catch {
+            Write-Log "CRITICAL: could not restore LowerFilters: $($_.Exception.Message)"
+        }
+    }
+}
+
+Write-Log "startup-repair: complete (repaired=$anyRepaired)"


### PR DESCRIPTION
## Summary

Implements M10 Option C — startup remediation task for persistent battery reading across reboots.

**Root problem**: `applewirelessmouse` strips the battery HID collection (COL02) from the descriptor during every fresh BTHENUM enumeration at boot. Battery reading fails after every reboot until the disable/enable repair cycle is manually run.

**Solution**: Windows Scheduled Task (SYSTEM, AtStartup, 30s delay) that auto-runs the repair at boot, transparently restoring COL02 before the tray app's first poll.

## Changes

### New: `startup-repair.ps1`
- Checks each known Magic Mouse PID for COL02 presence (2+ HID-class Status OK devices = healthy)
- If COL02 missing: removes LowerFilters, cycles BTHENUM parent (disable/enable), restores LowerFilters
- Verifies repair succeeded and logs result
- Logs to `C:\ProgramData\MagicMouseTray\startup-repair.log` with 512KB rotation
- Safe: restores LowerFilters on error so scroll isn't permanently broken

### Modified: `sign-and-install.ps1` — Step 9 (new)
- Registers `MagicMouseTray-StartupRepair` Scheduled Task (SYSTEM, AtStartup, 30s delay)
- Points to `startup-repair.ps1` in the same directory
- Idempotent: skips if task already registered

## Test plan

- [ ] Run `startup-repair.ps1` manually while COL02 is missing — should restore it
- [ ] Run `startup-repair.ps1` while COL02 is present — should report "no repair needed"
- [ ] Run `sign-and-install.ps1` — Step 9 registers task, check Task Scheduler
- [ ] Reboot — verify battery reads successfully within 60s of login
- [ ] Check `C:\ProgramData\MagicMouseTray\startup-repair.log` for repair log

Closes #5 (resolves root cause of battery failure across reboots)
