### PR TITLE
docs: INF analysis + PSN session 6 — KMDF function driver design confirmed

### DIFF
--- a/KMDF-PLAN.md
+++ b/KMDF-PLAN.md
@@ -174,6 +174,20 @@ any manual recovery steps. This is the definitive pass criterion.
 
 ---
 
+## Apple INF Analysis (2026-04-27)
+
+Full `AppleWirelessMouse.inf` (DriverVer 04/21/2026, 6.2.0.0) reviewed. Key findings that shape our function driver INF:
+
+| Finding | Detail |
+|---------|--------|
+| `HKR` in `.HW.AddReg` | Writes `LowerFilters` to Enum key only — structurally confirms error 1077. PnP calls AddDevice (reads LowerFilters) only on fresh device construction; reboots reuse existing BTHENUM object, AddDevice never called, filter permanently skipped. |
+| `SPSVCINST_ASSOCSERVICE` absent | INF comment: "Do not specify SPSVCINST_ASSOCSERVICE on filter drivers." Our function driver INF does the opposite — uses `0x00000002` to claim device ownership. |
+| `Include=hidbth.inf` / `Needs=HIDBTH_Inst.NT` | Pulls HidBth in as function driver. Our INF omits this entirely — we become the function driver, HidBth is gone. |
+| Same four hardware IDs | VID&000205ac PID&030d/0310, VID&0001004c PID&0269/0323. Our INF matches all four; function driver takes precedence over filter INF. |
+| `.sys` modification ruled out | Windows 11 HVCI/Secure Boot validates Authenticode signature at load time. Modifying the binary invalidates Apple's signature — kernel refuses to load. Not viable. |
+
+---
+
 ## Open Questions After Reboot Test — RESOLVED
 
 All three questions answered by testing (sessions prior to 2026-04-27):

--- a/KMDF-PLAN.md
+++ b/KMDF-PLAN.md
@@ -1,0 +1,183 @@
+---
+title: KMDF Driver Plan — Apple Magic Mouse Scroll+Battery
+type: plan
+status: superseded
+created: 2026-04-26
+linked_psn: PSN-0001
+linked_repo: ReviveBusiness/magic-mouse-tray
+superseded_by: PRD-184 M12
+---
+
+# KMDF Driver Plan — Apple Magic Mouse Scroll+Battery
+
+> **SUPERSEDED — 2026-04-26**: The LowerFilter + surgical descriptor patch approach described
+> in this document was replaced by the **function driver approach in PRD #184 Milestone 12**,
+> which is the authoritative implementation plan. This file is retained as a session record of
+> the root cause investigation and startup-repair.ps1 bug fixes.
+>
+> Canonical plan: `Personal/prd/184-magic-mouse-windows-tray-battery-monitor.md` → M12
+
+## BLUF
+
+The existing `applewirelessmouse` LowerFilter works for scroll but strips COL02 (battery) during
+fresh device enumeration. A replacement KMDF **function driver** (not a LowerFilter) owns the
+full HID descriptor — implementing both scroll and battery collections without stripping either.
+See PRD #184 M12 for the implementation plan.
+
+---
+
+## Root Cause Confirmed (2026-04-26 test)
+
+| Test Phase | Result |
+|-----------|--------|
+| Phase 1: cycle BTHENUM with filter active | Filter loads, scroll works, COL02 stripped |
+| Phase 2: driver stack after filter | `HidBth → applewirelessmouse → BthEnum` confirmed |
+| Phase 3: outcome | Filter modifies descriptor during HID enumeration, strips battery collection |
+| Phase 4: &6& recovery | Cycle without filter → COL01+COL02 restored |
+
+**Core conflict**: `applewirelessmouse` replaces the entire HID descriptor. The replacement
+descriptor fixes scroll but omits the second top-level collection (COL02 = battery).
+
+---
+
+## startup-repair.ps1 Bugs Fixed (2026-04-26)
+
+Two bugs identified and fixed in the same session:
+
+### Bug 1 — `/restart-device` after filter restore (lines 123–128, removed)
+`pnputil /restart-device` triggers HID descriptor re-processing with the filter active.
+Same effect as `/disable+/enable`: strips COL02. Script was logging "REPAIRED" but battery
+was immediately broken again. **Removed.**
+
+### Bug 2 — Only Enum key written, not driver instance key (line 121, extended)
+PnP reads `LowerFilters` from `Control\Class\{GUID}\NNNN` (driver instance key) during boot,
+not from the Enum key. Writing only to Enum key caused persistent error 1077 (never attempted)
+at every boot. **Added Step 4b to write both locations.**
+
+### Expected behavior after fix
+```
+Boot N:   startup-repair detects COL02 missing
+          → cycles without filter → COL02 created
+          → restores filter to BOTH registry locations (Enum + driver instance key)
+          → logs: "REPAIRED: COL02 present. Scroll loads at next reboot."
+
+Boot N+1: PnP reads driver instance key → loads filter
+          startup-repair detects COL02 present → "no repair needed"
+          → both scroll and battery work
+```
+
+---
+
+## Reboot Test Result (ALREADY CONFIRMED — prior sessions)
+
+Error 1077 persists regardless of registry location written (Enum key, driver instance key, both).
+H-004 rejected. The applewirelessmouse approach to scroll is exhausted.
+
+**After rebooting from current state** (COL02 present, LowerFilters restored):
+- COL02 will persist — battery works
+- Filter will NOT load (error 1077) — scroll broken
+- startup-repair.ps1 will log "COL02 present — no repair needed" and exit cleanly
+
+KMDF driver is the only remaining path for scroll.
+
+---
+
+## KMDF Driver Architecture
+
+### Position
+LowerFilter on `BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&0001004C_PID&0323`
+Same stack position as `applewirelessmouse` — proven to intercept descriptor and reports.
+
+### Stack after install
+```
+HidBth (function driver)
+  ↑
+applemouse2 (lower filter — NEW, replaces applewirelessmouse)
+  ↑
+BthEnum (bus driver)
+```
+
+### Two interception points
+
+| IRP | Direction | Action |
+|-----|-----------|--------|
+| `IOCTL_HID_GET_REPORT_DESCRIPTOR` | Completion (return from below) | Surgical descriptor patch: fix scroll items in COL01, preserve all bytes from COL02 collection start onward |
+| `IOCTL_HID_READ_REPORT` | Completion (return from below) | Translate Apple multi-touch report data to standard scroll axis deltas |
+
+### Descriptor patch strategy
+
+```
+Raw descriptor structure (Magic Mouse):
+  [COL01 bytes] = mouse collection (pointer, scroll, buttons)
+  [COL02 bytes] = battery collection (Report ID 0x90, vendor usage)
+
+FindBatteryCollectionOffset() scans for the second top-level Collection(Application) item.
+PatchScrollItems() modifies only bytes [0, col02Offset) — never touches battery bytes.
+HidBth sees: fixed scroll collection + intact battery collection → creates COL01 + COL02.
+```
+
+---
+
+## Implementation Steps
+
+### Step A — Capture raw HID descriptor (before any filter)
+Uninstall `applewirelessmouse` or temporarily remove from LowerFilters (no device restart).
+Use USB Device Tree Viewer or HID Descriptor Tool on the BTHENUM HID device.
+Save hex bytes → `raw-descriptor.bin`.
+
+### Step B — Capture patched descriptor (with applewirelessmouse active)
+With filter in device stack, export descriptor again → `patched-descriptor.bin`.
+Diff the two: every changed byte is what `PatchScrollItems()` must replicate.
+
+### Step C — Capture raw input reports
+With filter uninstalled, run raw HID read loop on COL01 while moving finger on mouse surface.
+Identify: which Report ID carries touch delta data, byte offsets for X/Y velocity.
+This is what `TranslateTouchToScroll()` needs to implement.
+
+### Step D — Build and test skeleton
+1. Create project: WDK + VS, Kernel-Mode Driver (KMDF), x64
+2. Set `StartType = SERVICE_DEMAND_START` in INF
+3. Enable test signing: `bcdedit /set testsigning on`
+4. Sign with test cert (same process as `applewirelessmouse`)
+5. Install: `pnputil /add-driver applemouse2.inf /install`
+6. Verify: `sc query applemouse2` RUNNING, filter appears in `devcon stack`
+
+### Step E — Fill stubs with captured data
+Implement `PatchScrollItems()` using Step B diff.
+Implement `TranslateTouchToScroll()` using Step C captures.
+Test: scroll works + battery reads in MagicMouseTray.
+
+### Step F — Unpair/re-pair test
+Unpair mouse from Bluetooth, re-pair, verify both scroll and battery work without
+any manual recovery steps. This is the definitive pass criterion.
+
+---
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `applemouse2.c` | KMDF driver source (skeleton ready — stubs need fill-in) |
+| `applemouse2.inf` | INF for LowerFilter installation (ready) |
+| `startup-repair.ps1` | Fixed: removed /restart-device, added driver instance key write |
+| `PSN-0001-hid-battery-driver.yaml` | Problem session notes (update after reboot test) |
+
+---
+
+## Why This Is Architecturally Correct
+
+- Single driver handles both scroll and battery natively
+- No &6& recovery needed after install — descriptor is correct on first enumeration
+- Survives unpair/re-pair (fresh enumeration handled correctly)
+- `startup-repair.ps1` becomes monitoring-only — logs a warning if COL02 is missing, never auto-repairs
+- Matches how Magic Utilities achieves scroll+battery on the same device
+
+---
+
+## Open Questions After Reboot Test — RESOLVED
+
+All three questions answered by testing (sessions prior to 2026-04-27):
+
+1. Does `applewirelessmouse` load at boot with driver instance key set? → **NO** (H-004 REJECTED — error 1077 persists regardless of registry location. PnP does not call AddDevice on BTHENUM device reuse at boot.)
+2. Is two-boot convergence acceptable for daily use? → **NO** — scroll never works with this approach. KMDF function driver (PRD #184 M12) is required.
+3. Does `startup-repair.ps1` detect the correct BTHENUM instance after unpair/re-pair? → **YES** — confirmed by testing.

--- a/PSN-0001-hid-battery-driver.yaml
+++ b/PSN-0001-hid-battery-driver.yaml
@@ -8,8 +8,8 @@ linked_prd: PRD-184
 linked_repo: ReviveBusiness/magic-mouse-tray
 linked_issues: [2, 3, 4]
 opened: 2026-04-17
-last_updated: 2026-04-24
-sessions_logged: 4
+last_updated: 2026-04-26
+sessions_logged: 5
 ---
 
 # PSN-0001: Magic Mouse HID Battery Reader — Windows 11 Driver Binding
@@ -28,7 +28,8 @@ Apple Magic Mouse v2/2024 on Windows 11 requires the `AppleWirelessMouse64` HID 
 |----|-----------|--------|-------------|---------|
 | H-001 | ReportDescriptor access indicates driver bound | **REJECTED** | 2026-04-21 | False negative — descriptor can be null even when bound due to timing. See peer-review 20260421 finding #2 |
 | H-002 | worst-state-wins semantics for DriverHealthChecker returns correct binding state | **CONFIRMED** | 2026-04-22 | PR fix/issue-4-driver-priority-v2, commit cb49ece. Multiple HID devices share same VID — any unbound device = broken state. |
-| H-003 | pnputil /restart-device safe to call unconditionally after driver install | **UNDER TEST** | Opened 2026-04-24 | Investigating BTHENUM re-enumeration timing |
+| H-003 | pnputil /restart-device safe to call unconditionally after driver install | **REJECTED** | 2026-04-26 | /restart-device strips COL02 (same as /disable+/enable with filter active). Removed from startup-repair.ps1. |
+| H-004 | Writing LowerFilters to driver instance key (Control\Class\{GUID}\NNNN) resolves error 1077 at boot | **REJECTED** | Prior sessions | "LowerFilters in BOTH keys + DEMAND_START" tested — error 1077 persisted. PnP not loading filter regardless of registry location. Root cause unknown. KMDF driver required for scroll. |
 
 ## Decisions Made
 
@@ -40,19 +41,24 @@ Apple Magic Mouse v2/2024 on Windows 11 requires the `AppleWirelessMouse64` HID 
 
 ## Next Session Brief
 
-**Current blocker**: `pnputil /restart-device` safety under `BTHENUM` re-enumeration timing. Calling it during re-enumeration causes device to vanish from device manager.
+**Current state (2026-04-26)**:
+- startup-repair.ps1 fixed: removed /restart-device (Bug 1), added driver instance key write (Bug 2)
+- COL02 persistence confirmed working via &6& recovery procedure
+- Scroll via applewirelessmouse filter: BLOCKED — error 1077 persists regardless of registry writes
 
 **Files to read first**:
-- `MagicMouseTray/src/DriverHealthChecker.cs` — worst-state-wins logic
-- `MagicMouseTray/src/StartupRepair.cs` — where pnputil /restart-device is called
+- `startup-repair.ps1` — fixed version
+- `KMDF-PLAN.md` — next step architecture
+- `sre-windows/references/recovery-procedures.md` — Scroll Fix Status table
 
 **Do NOT retry**:
 - Using `ReportDescriptor` access to detect driver binding state (H-001, rejected 2026-04-21)
+- `pnputil /restart-device` anywhere near an active applewirelessmouse filter (H-003, rejected 2026-04-26)
+- Writing LowerFilters to any registry location and expecting it to fix error 1077 (H-004, rejected prior sessions)
 
-**Open questions**:
-1. Does `BTHENUM` always re-enumerate after `pnputil /restart-device` on all Windows 11 versions?
-2. Can we check if enumeration is in progress before calling restart? (WMI query?)
-3. Is there a safer alternative to `/restart-device` that achieves the same result?
+**Next step**: KMDF function driver (`KMDF-PLAN.md`). The applewirelessmouse approach is exhausted.
+Capture raw HID descriptor (before filter) + patched descriptor (after filter), then implement
+PatchScrollItems() + TranslateTouchToScroll() in the skeleton.
 
 **GitHub Issues to check**: #2 (driver not binding after suspend), #3 (BTHENUM timing), #4 (driver priority logic)
 
@@ -64,3 +70,4 @@ Apple Magic Mouse v2/2024 on Windows 11 requires the `AppleWirelessMouse64` HID 
 | 2026-04-21 | Session 2 | Peer review via NotebookLM. 3 blocking bugs filed as Issues #2, #3, #4. H-001 rejected. |
 | 2026-04-22 | Session 3 | H-002 confirmed (worst-state-wins). PR merged. |
 | 2026-04-24 | Session 4 | H-003 opened (pnputil restart safety). PSN created. |
+| 2026-04-26 | Session 5 | test-filter-stack.ps1 run. H-003 rejected (/restart-device strips COL02). H-004 rejected (driver instance key write doesn't fix 1077 — tested in prior sessions). startup-repair.ps1 fixed (Bugs 1+2). KMDF driver confirmed as only path for scroll. |

--- a/PSN-0001-hid-battery-driver.yaml
+++ b/PSN-0001-hid-battery-driver.yaml
@@ -8,8 +8,8 @@ linked_prd: PRD-184
 linked_repo: ReviveBusiness/magic-mouse-tray
 linked_issues: [2, 3, 4]
 opened: 2026-04-17
-last_updated: 2026-04-26
-sessions_logged: 5
+last_updated: 2026-04-27
+sessions_logged: 6
 ---
 
 # PSN-0001: Magic Mouse HID Battery Reader — Windows 11 Driver Binding
@@ -56,9 +56,8 @@ Apple Magic Mouse v2/2024 on Windows 11 requires the `AppleWirelessMouse64` HID 
 - `pnputil /restart-device` anywhere near an active applewirelessmouse filter (H-003, rejected 2026-04-26)
 - Writing LowerFilters to any registry location and expecting it to fix error 1077 (H-004, rejected prior sessions)
 
-**Next step**: KMDF function driver (`KMDF-PLAN.md`). The applewirelessmouse approach is exhausted.
-Capture raw HID descriptor (before filter) + patched descriptor (after filter), then implement
-PatchScrollItems() + TranslateTouchToScroll() in the skeleton.
+**Next step**: KMDF function driver — pre-build validation complete. Begin driver development:
+EWDK setup → Driver.c → HidDescriptor.c → InputHandler.c (port Linux hid-magicmouse.c) → BatteryHandler.c → INF with SPSVCINST_ASSOCSERVICE. See PRD #184 M12 for full task list.
 
 **GitHub Issues to check**: #2 (driver not binding after suspend), #3 (BTHENUM timing), #4 (driver priority logic)
 
@@ -71,3 +70,4 @@ PatchScrollItems() + TranslateTouchToScroll() in the skeleton.
 | 2026-04-22 | Session 3 | H-002 confirmed (worst-state-wins). PR merged. |
 | 2026-04-24 | Session 4 | H-003 opened (pnputil restart safety). PSN created. |
 | 2026-04-26 | Session 5 | test-filter-stack.ps1 run. H-003 rejected (/restart-device strips COL02). H-004 rejected (driver instance key write doesn't fix 1077 — tested in prior sessions). startup-repair.ps1 fixed (Bugs 1+2). KMDF driver confirmed as only path for scroll. |
+| 2026-04-27 | Session 6 | Full AppleWirelessMouse.inf (DriverVer 04/21/2026 6.2.0.0) reviewed. INF confirms error 1077 root cause: HKR in .HW.AddReg = Enum key only; PnP skips AddDevice on BTHENUM reuse at boot. Function driver INF design confirmed: SPSVCINST_ASSOCSERVICE, no Include=hidbth.inf, same four hardware IDs. Pre-build validation complete (TouchpadProbe, descriptor, stack baseline, .sys hash). KMDF-PLAN.md updated with INF analysis. |

--- a/PSN-0001-hid-battery-driver.yaml
+++ b/PSN-0001-hid-battery-driver.yaml
@@ -1,0 +1,66 @@
+---
+title: PSN-0001 — Magic Mouse HID Battery Reader Driver Binding
+type: problem-session-note
+psn_id: PSN-0001
+version: 1.0.0
+status: active
+linked_prd: PRD-184
+linked_repo: ReviveBusiness/magic-mouse-tray
+linked_issues: [2, 3, 4]
+opened: 2026-04-17
+last_updated: 2026-04-24
+sessions_logged: 4
+---
+
+# PSN-0001: Magic Mouse HID Battery Reader — Windows 11 Driver Binding
+
+## Problem Statement
+
+Apple Magic Mouse v2/2024 on Windows 11 requires the `AppleWirelessMouse64` HID driver to be bound to read battery via HID Input Report `0x90` (byte[2] = battery %). The driver doesn't reliably bind after suspend-resume or after Windows updates. PRD-184 delivers the core battery reader, but GitHub Issues #2, #3, #4 track ongoing driver binding reliability problems.
+
+## Current Working Theory
+
+`pnputil /restart-device` is unsafe to call unconditionally after driver install because it can be called during `BTHENUM` (Bluetooth Enumerator) re-enumeration, causing the HID device to disappear from Windows device manager mid-restart. Need to check enumeration state before calling restart.
+
+## Hypotheses
+
+| ID | Hypothesis | Status | Date Tested | Evidence |
+|----|-----------|--------|-------------|---------|
+| H-001 | ReportDescriptor access indicates driver bound | **REJECTED** | 2026-04-21 | False negative — descriptor can be null even when bound due to timing. See peer-review 20260421 finding #2 |
+| H-002 | worst-state-wins semantics for DriverHealthChecker returns correct binding state | **CONFIRMED** | 2026-04-22 | PR fix/issue-4-driver-priority-v2, commit cb49ece. Multiple HID devices share same VID — any unbound device = broken state. |
+| H-003 | pnputil /restart-device safe to call unconditionally after driver install | **UNDER TEST** | Opened 2026-04-24 | Investigating BTHENUM re-enumeration timing |
+
+## Decisions Made
+
+| ID | Date | Decision | Rationale | Status |
+|----|------|---------|-----------|--------|
+| D-001 | 2026-04-17 | Use HidLibrary + HID Report 0x90, not WinRT GATT | Apple devices use proprietary HID battery reporting confirmed by WinMagicBattery reverse engineering | active |
+| D-002 | 2026-04-22 | worst-state-wins semantics for DriverHealthChecker | Multiple Magic Mouse HID devices share same Vendor ID — if any one is unbound, the whole device is in broken state | active |
+| D-003 | 2026-04-21 | Do NOT use ReportDescriptor as binding signal (H-001) | Too many false negatives — descriptor can be null even when driver is bound | active |
+
+## Next Session Brief
+
+**Current blocker**: `pnputil /restart-device` safety under `BTHENUM` re-enumeration timing. Calling it during re-enumeration causes device to vanish from device manager.
+
+**Files to read first**:
+- `MagicMouseTray/src/DriverHealthChecker.cs` — worst-state-wins logic
+- `MagicMouseTray/src/StartupRepair.cs` — where pnputil /restart-device is called
+
+**Do NOT retry**:
+- Using `ReportDescriptor` access to detect driver binding state (H-001, rejected 2026-04-21)
+
+**Open questions**:
+1. Does `BTHENUM` always re-enumerate after `pnputil /restart-device` on all Windows 11 versions?
+2. Can we check if enumeration is in progress before calling restart? (WMI query?)
+3. Is there a safer alternative to `/restart-device` that achieves the same result?
+
+**GitHub Issues to check**: #2 (driver not binding after suspend), #3 (BTHENUM timing), #4 (driver priority logic)
+
+## Session History
+
+| Date | Session | What Happened |
+|------|---------|--------------|
+| 2026-04-17 | Session 1 | Initial feasibility + HID 0x90 discovery. All 7 milestones completed. |
+| 2026-04-21 | Session 2 | Peer review via NotebookLM. 3 blocking bugs filed as Issues #2, #3, #4. H-001 rejected. |
+| 2026-04-22 | Session 3 | H-002 confirmed (worst-state-wins). PR merged. |
+| 2026-04-24 | Session 4 | H-003 opened (pnputil restart safety). PSN created. |

--- a/TEST-PLAN.md
+++ b/TEST-PLAN.md
@@ -11,10 +11,95 @@ owner: Lesley Murfin
 
 # MagicMouseTray — Test Plan
 
-**BLUF**: Seven-tier test plan (BCP-STD-015) for MagicMouseTray v1.0 release. Covers unit logic,
-driver installation, HID stack integration, full E2E user journey (clean-slate and incremental),
-reboot resilience, upgrade path, and security controls. Two device targets: Magic Mouse v3 (PID
-0323) and Magic Mouse v1 (PID 030d). All tiers must pass before v1.1.0 release tag.
+## What You Need to Do (Read This First)
+
+Three test sessions required before v1.1.0 release. Do them in order.
+
+---
+
+### Session 1 — Does it work on your existing setup? (30 min, Windows, Admin)
+
+Your machine already has the driver partially configured. This session confirms the code works
+before you wipe anything.
+
+1. **Fix one code issue first** (agent does this, not you): Add a log line to `MouseBatteryReader.cs`
+   that prints the `InputReportByteLength` value. Without this, we can't confirm the battery reader
+   will work on a clean install. This is the single highest-risk unknown right now.
+2. Rebuild the binary after the fix.
+3. **You run**: Copy `\\wsl.localhost\Ubuntu\tmp\mmtray-build\MagicMouseTray.exe` to `C:\Temp\`
+4. **You run**: Start the app. Wait 10 seconds.
+5. **You check**: Does the tray icon show a battery percentage? (not "disconnected")
+6. **You check**: Open `C:\Users\<you>\AppData\Local\MagicMouseTray\debug.log` — look for:
+   - `InputReportByteLength=X` — X must be **3 or higher** (if it's 2, stop and report it)
+   - `OK path=...col02... battery=NN%`
+   - No `READ_FAILED` lines after the first 30 seconds
+7. **You test**: Does the mouse still scroll normally while the app runs?
+8. **You reboot**: Normal reboot.
+9. **You check after reboot**: Battery % still shows in tray without doing anything?
+10. **You check**: `C:\ProgramData\MagicMouseTray\startup-repair.log` — last line should say
+    `REPAIRED: COL02 present` or `COL02 present — no repair needed`
+
+**Session 1 passes when**: Battery reads in tray + `InputReportByteLength >= 3` in log + scroll works + battery persists after reboot.
+
+---
+
+### Session 2 — Clean-slate install (1 hour, Windows, Admin) — Magic Mouse v3
+
+This simulates a brand new user who just downloaded the software. Everything gets wiped first.
+
+1. **You run the teardown script** (at the bottom of this file, PowerShell as Admin)
+2. **You reboot**
+3. **You confirm clean**: No `applewirelessmouse` in `pnputil /enum-drivers`. No scheduled task. Mouse scrolls (BT still connected) but no battery.
+4. **You run**: `sign-and-install.ps1` as Administrator from the repo folder
+5. **You check**: Script completes all 9 steps with no errors
+6. **You re-pair**: Remove mouse from Bluetooth Settings → re-add it. Wait for it to reconnect.
+7. **You run**: Start the app
+8. **You check**: Battery % in tray within 10 seconds
+9. **You reboot**
+10. **You check**: Battery % shows automatically after reboot, no manual steps
+
+**Session 2 passes when**: Full cycle works from nothing → battery in tray → survives reboot, zero manual steps beyond sign-and-install + re-pair.
+
+---
+
+### Session 3 — Clean-slate install — Magic Mouse v1 (30 min, Windows, Admin)
+
+Same as Session 2 but with your v1 Magic Mouse (PID 030d). Confirms the software works for
+older hardware that many users will have.
+
+1. Repeat teardown
+2. Pair the v1 mouse
+3. Run `sign-and-install.ps1`
+4. Re-pair v1 mouse
+5. Start app
+6. Confirm battery reads (PID 030d device)
+7. Reboot → confirm battery persists
+
+**Session 3 passes when**: Same result as Session 2 but on v1 hardware.
+
+---
+
+### Before Sessions 2 and 3 — Code Fixes Required
+
+These issues were found in adversarial peer review and will cause test failures if not fixed first:
+
+| # | What's broken | Who fixes it | Blocks |
+|---|--------------|-------------|--------|
+| BLK-01 | Battery reader may silently skip COL02 if report is 2 bytes (needs log verification in Session 1) | Agent | Session 1 diagnosis |
+| BLK-02 | DriverHealthChecker returns `Ok` when zero devices found (false healthy signal) | Agent | T1 unit tests |
+| BLK-03 | Scheduled task points to wherever you ran the script from — if that's Downloads, any user can overwrite it | Agent | Session 2 security |
+| BLK-04 | Log directory not locked — privilege escalation possible via symlink | Agent | Session 3 security |
+
+BLK-03 and BLK-04 don't affect whether battery reads work — they affect whether it's safe to ship publicly. Session 1 and 2 can proceed without fixing BLK-03/04, but they must be fixed before the public v1.1.0 release.
+
+---
+
+## BLUF
+
+Seven-tier test plan (BCP-STD-015) for MagicMouseTray v1.1.0 public release. Three test sessions
+(incremental, clean v3, clean v1) must pass before release tag. Four code blockers must be resolved
+before Sessions 2–3. Goal: a new user runs `sign-and-install.ps1`, re-pairs their mouse, and gets
+battery in the tray — no manual registry edits, no debugging, no what I went through.
 
 ---
 

--- a/TEST-PLAN.md
+++ b/TEST-PLAN.md
@@ -1,0 +1,287 @@
+---
+id: TP-001
+title: "MagicMouseTray — Test Plan v1.0"
+version: 1.0.0
+bcp_ref: BCP-STD-015
+component: MagicMouseTray
+status: Active
+created: 2026-04-22
+owner: Lesley Murfin
+---
+
+# MagicMouseTray — Test Plan
+
+**BLUF**: Seven-tier test plan (BCP-STD-015) for MagicMouseTray v1.0 release. Covers unit logic,
+driver installation, HID stack integration, full E2E user journey (clean-slate and incremental),
+reboot resilience, upgrade path, and security controls. Two device targets: Magic Mouse v3 (PID
+0323) and Magic Mouse v1 (PID 030d). All tiers must pass before v1.1.0 release tag.
+
+---
+
+## Device Matrix
+
+| Label | Model | PID | VID | Notes |
+|-------|-------|-----|-----|-------|
+| **MM-V3** | Magic Mouse 2024 | `0323` | `0001004C` | Lesley's primary device |
+| **MM-V1** | Magic Mouse v1 | `030d` | `000205AC` | Older device — verify driver support |
+
+---
+
+## Test Environments
+
+| Environment | Description | When Used |
+|------------|-------------|-----------|
+| **ENV-A: Incremental** | Existing driver install, existing pairing | T1–T3, initial T4 run |
+| **ENV-B: Clean-slate** | Full teardown then fresh install from nothing | T4 E2E golden path, T8 upgrade |
+
+---
+
+## Clean-Slate Teardown Procedure
+
+Run these steps as Administrator to fully reset to pre-install state before ENV-B tests.
+
+```powershell
+# 1. Stop any running MagicMouseTray instance
+Stop-Process -Name MagicMouseTray* -Force -ErrorAction SilentlyContinue
+
+# 2. Remove scheduled startup repair task
+Unregister-ScheduledTask -TaskName "MagicMouseTray-StartupRepair" -Confirm:$false -ErrorAction SilentlyContinue
+
+# 3. Remove applewirelessmouse driver package(s)
+$pnpRaw = (pnputil /enum-drivers 2>$null) | Out-String
+$slots = ($pnpRaw -split '(?=Published Name:)') |
+    Where-Object { $_ -match 'applewirelessmouse' } |
+    ForEach-Object { if ($_ -match 'Published Name:\s+(oem\d+\.inf)') { $Matches[1] } }
+if ($slots) {
+    $slots | ForEach-Object { pnputil /delete-driver $_ /uninstall /force }
+} else { Write-Host "No applewirelessmouse driver found" }
+
+# 4. Remove LowerFilters from BTHENUM device key (for both known PIDs if present)
+@("0323","030d","0269","0310") | ForEach-Object {
+    $pid = $_
+    Get-ChildItem "HKLM:\SYSTEM\CurrentControlSet\Enum\BTHENUM" -Recurse -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -match "_PID&$pid" } |
+        ForEach-Object { Remove-ItemProperty -Path $_.PSPath -Name LowerFilters -ErrorAction SilentlyContinue }
+}
+
+# 5. Remove MagicMouseFix cert from TrustedPublisher and Root stores
+Get-ChildItem Cert:\LocalMachine\TrustedPublisher | Where-Object { $_.Subject -match "MagicMouseFix" } |
+    Remove-Item -ErrorAction SilentlyContinue
+Get-ChildItem Cert:\LocalMachine\Root | Where-Object { $_.Subject -match "MagicMouseFix" } |
+    Remove-Item -ErrorAction SilentlyContinue
+
+# 6. Disable test signing
+bcdedit /set testsigning off
+
+# 7. Clean up temp files and log directory
+Remove-Item "C:\Temp\MagicMouseFix.cer" -Force -ErrorAction SilentlyContinue
+Remove-Item "C:\ProgramData\MagicMouseTray" -Recurse -Force -ErrorAction SilentlyContinue
+
+# 8. Unpair the Magic Mouse from Bluetooth Settings (manual — do in Settings > Bluetooth)
+
+Write-Host "Teardown complete. Reboot before clean-slate test."
+```
+
+**After teardown**: Reboot, confirm no `MagicMouseTray-StartupRepair` task exists, confirm
+`applewirelessmouse` is not in `pnputil /enum-drivers`.
+
+---
+
+## Tier 1 — Unit Tests (C# Logic)
+
+**Scope**: Individual C# functions in isolation, no Windows hardware required.
+**When**: On every code change, CI/CD.
+**Owner**: Developer.
+
+| Test ID | Component | Test Case | Pass Criteria |
+|---------|-----------|-----------|---------------|
+| T1-01 | DriverHealthChecker | Zero devices found → returns `NotInstalled` (not `Ok`) | `CheckDriverHealth()` returns `DriverStatus.NotInstalled` when no BTHENUM keys match known PIDs |
+| T1-02 | DriverHealthChecker | One Ok device, one UnknownAppleMouse device → returns `UnknownAppleMouse` | Worst-state wins: `UnknownAppleMouse > NotBound > Ok` |
+| T1-03 | DriverHealthChecker | One Ok device, one NotBound device → returns `NotBound` | Correct priority ordering |
+| T1-04 | DriverHealthChecker | Two Ok devices (same PID) → returns `Ok` | Dual-device same PID handled |
+| T1-05 | MouseBatteryReader | `ValidateBattery` with buf[1]=0 → returns -1 | Zero battery value rejected |
+| T1-06 | MouseBatteryReader | `ValidateBattery` with buf[1]=101 → returns -1 | Out-of-range value rejected |
+| T1-07 | MouseBatteryReader | `ValidateBattery` with buf[1]=75 → returns 75 | Valid value passed through |
+
+**Note**: T1-01 requires code fix before this tier can pass — current `CheckDriverHealth()` returns `Ok`
+on zero devices (default initialization bug from adversarial review).
+
+---
+
+## Tier 2 — Section Tests (Component Isolation)
+
+**Scope**: Each system component verified independently before integration.
+**When**: After driver install, before running the app.
+**Owner**: Developer (Lesley running on Windows).
+**Environment**: ENV-A (incremental) first, then ENV-B (clean-slate).
+
+| Test ID | Component | Test Case | Command | Pass Criteria |
+|---------|-----------|-----------|---------|---------------|
+| T2-01 | Driver install | applewirelessmouse package installed | `pnputil /enum-drivers \| Select-String applewireless` | OEM slot visible with correct provider |
+| T2-02 | Driver binding | LowerFilters set on BTHENUM device | `Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Enum\BTHENUM\...\9&..." \| Select LowerFilters` | Value = `applewirelessmouse` |
+| T2-03 | HID enumeration | COL01 and COL02 both Status OK | `Get-PnpDevice \| Where-Object { $_.InstanceId -match "0323" -and $_.Status -eq "OK" }` | Count = 2 |
+| T2-04 | Scheduled task | `MagicMouseTray-StartupRepair` registered | `Get-ScheduledTask -TaskName MagicMouseTray-StartupRepair` | Task exists, trigger = AtStartup, delay = PT30S, principal = SYSTEM |
+| T2-05 | Cert trust | MagicMouseFix in TrustedPublisher | `Get-ChildItem Cert:\LocalMachine\TrustedPublisher \| Where Subject -match MagicMouseFix` | Certificate present |
+| T2-06 | Test signing | Test signing mode active | `bcdedit /enum {current} \| Select-String testsigning` | `testsigning Yes` |
+| T2-07 | Log directory | Log dir created with correct ACL | `icacls C:\ProgramData\MagicMouseTray` | SYSTEM: Full, Administrators: Full, Users: no write |
+
+**T2-07 is a new requirement** from the adversarial review (TOCTOU symlink mitigation) — sign-and-install.ps1
+needs to create and lock the log directory before startup-repair.ps1 first runs.
+
+---
+
+## Tier 3 — Integration Tests (App + HID Stack)
+
+**Scope**: MagicMouseTray binary running, reading from live Windows HID devices.
+**When**: After T2 passes.
+**Environment**: ENV-A (no reboot needed), mouse already paired and COL02 present.
+
+| Test ID | Test Case | Expected debug.log Output | Pass Criteria |
+|---------|-----------|--------------------------|---------------|
+| T3-01 | App reads battery on COL02 | `OK path=...col02... battery=NN%` | Battery value 1–100, logged within 10s of app start |
+| T3-02 | Tray tooltip shows battery | Hover tray icon | `Magic Mouse — NN%` (not "disconnected") |
+| T3-03 | HidP_GetCaps threshold correct | `InputReportByteLength=X` in log | X ≥ 3 (confirms threshold is correct); **ADD THIS LOG LINE BEFORE TESTING** |
+| T3-04 | COL01 not producing READ_FAILED spam | Scan debug.log for READ_FAILED | Zero READ_FAILED entries after first 30s of stable operation |
+| T3-05 | Mouse disconnect → reconnect | App detects disconnect, then recovery | Log shows "disconnected" then battery % resumes within 30s of BT reconnect |
+| T3-06 | DriverHealthChecker status displayed | App tray icon shows correct status | Status icon reflects `Ok` when driver bound; changes to warning if LowerFilters removed |
+| T3-07 | Scroll still works | Physical scroll test | Page scrolls normally while app is running |
+
+**Pre-condition for T3-03**: Add `Logger.Log($"HidP_GetCaps InputReportByteLength={caps.InputReportByteLength} path={devicePath}");`
+to `MouseBatteryReader.cs` before the threshold check, rebuild, and verify in debug.log.
+This is a **blocking gate** — if `InputReportByteLength < 3` for COL02, the battery reader silently
+skips the device and battery reads will never work.
+
+---
+
+## Tier 4 — End-to-End Tests (Full User Journey)
+
+**Scope**: Complete install → use → reboot cycle, from the perspective of a new user who just
+downloaded the software. Goal: zero manual steps beyond running sign-and-install.ps1 as admin.
+
+**Two scenarios:**
+
+### T4-A: Incremental (current machine state, ENV-A)
+
+| Step | Action | Pass Criteria |
+|------|--------|---------------|
+| T4-A-01 | Run `sign-and-install.ps1` as Administrator | Script completes with no errors; all 9 steps logged |
+| T4-A-02 | Verify T2 section checks all pass | T2-01 through T2-06 pass |
+| T4-A-03 | Run binary from `\\wsl.localhost\Ubuntu\tmp\mmtray-build\MagicMouseTray.exe` | App starts, tray icon appears |
+| T4-A-04 | Verify battery reading (T3-01 through T3-04) | Battery % in tray within 10s |
+| T4-A-05 | Reboot | System reboots normally |
+| T4-A-06 | After reboot: check startup-repair.log | Log at `C:\ProgramData\MagicMouseTray\startup-repair.log` shows `REPAIRED: COL02 present` or `COL02 present — no repair needed` |
+| T4-A-07 | After reboot: verify COL02 present | `Get-PnpDevice` shows 2 HID devices for PID 0323 |
+| T4-A-08 | After reboot: app starts and reads battery | Battery % visible in tray within 30s of desktop load |
+| T4-A-09 | Verify scroll works post-reboot | Physical scroll test |
+
+### T4-B: Clean-Slate (new user install, ENV-B) — MM-V3 (PID 0323)
+
+| Step | Action | Pass Criteria |
+|------|--------|---------------|
+| T4-B-00 | Run teardown procedure | All driver, cert, task, LowerFilters removed. Reboot. |
+| T4-B-01 | Confirm baseline: battery reads fail | App (if started now) shows "disconnected" — confirms clean slate |
+| T4-B-02 | Pair Magic Mouse | Mouse pairs via Bluetooth Settings. Scroll works. Battery NOT visible yet (expected). |
+| T4-B-03 | Run `sign-and-install.ps1` as Administrator | All 9 steps complete without error |
+| T4-B-04 | **Do NOT reboot yet** — verify driver installed | `pnputil /enum-drivers` shows applewirelessmouse |
+| T4-B-05 | Re-pair Magic Mouse (required after driver install) | Remove mouse from BT, re-pair. Scroll resumes. |
+| T4-B-06 | Run binary | Battery % appears in tray |
+| T4-B-07 | Reboot | System reboots normally |
+| T4-B-08 | Verify startup-repair ran | Log shows COL02 repaired or already present |
+| T4-B-09 | Verify battery reads after reboot | Battery % in tray without manual intervention |
+| T4-B-10 | Verify scroll after reboot | Physical scroll test |
+
+### T4-C: Clean-Slate — MM-V1 (PID 030d)
+
+Same as T4-B but with Magic Mouse v1. Substitute PID 030d in all verification steps.
+
+| Step | Action | Pass Criteria |
+|------|--------|---------------|
+| T4-C-01 through T4-C-10 | Repeat T4-B steps with MM-V1 | All steps pass; battery reads via COL02 for PID 030d |
+
+**Note**: MM-V1 uses a different HID descriptor than MM-V3. Confirm startup-repair.ps1 detects
+the correct BTHENUM parent for PID 030d and that `MouseBatteryReader` matches the correct
+KnownMice entry.
+
+---
+
+## Tier 7 — Failover / Resilience Tests
+
+**Scope**: System recovers correctly from failure states without manual intervention.
+
+| Test ID | Scenario | Steps | Pass Criteria |
+|---------|----------|-------|---------------|
+| T7-01 | BT disconnect mid-session | Physically turn mouse off. Wait 60s. Turn on. | App detects disconnect (log), resumes battery reads within 30s of reconnect |
+| T7-02 | COL02 missing after cold reboot | Reboot with driver active | startup-repair.log shows REPAIRED; COL02 present before app reads battery |
+| T7-03 | Rapid reboot (< 10s uptime) | Force quick reboot | startup-repair.ps1 30s delay gives BT stack time; battery reads correctly |
+| T7-04 | App crash and restart | Kill MagicMouseTray.exe; restart | App restarts, reads battery correctly without needing driver re-install |
+| T7-05 | startup-repair.log rotation | Grow log to > 512KB (pad with writes), reboot | Log rotated to `.1.log`; no CRITICAL error; new log created |
+
+---
+
+## Tier 8 — Upgrade Tests
+
+**Scope**: Existing installation upgrades to new version without data loss or re-configuration.
+
+| Test ID | Scenario | Steps | Pass Criteria |
+|---------|----------|-------|---------------|
+| T8-01 | v1.0 → v1.1 binary upgrade | Replace exe only; no re-run of sign-and-install | Battery reads work; scheduled task unchanged; driver unchanged |
+| T8-02 | Re-run sign-and-install on existing install | Run script when driver + task already present | Script detects existing task (skips), detects existing driver slot (removes + reinstalls), completes cleanly |
+| T8-03 | Sign-and-install idempotency | Run script twice back-to-back | Second run produces same result as first; no duplicate tasks, no orphaned driver slots |
+
+---
+
+## Tier 9 — Security Tests
+
+Mitigations from adversarial peer review (2026-04-22).
+
+| Test ID | Control | Verification | Pass Criteria |
+|---------|---------|-------------|---------------|
+| T9-01 | Scheduled task path is protected directory | `icacls` on script path | Script lives in a directory where standard users cannot write (`C:\Program Files\...` or locked `C:\ProgramData\MagicMouseTray\`) |
+| T9-02 | MagicMouseFix cert private key non-exportable | `Get-ChildItem Cert:\LocalMachine\My \| Where Subject -match MagicMouseFix` after sign | Certificate not present in `My` store (deleted after signing), OR marked non-exportable |
+| T9-03 | Log directory ACL locked | `icacls C:\ProgramData\MagicMouseTray` | Standard users have no write access; prevents TOCTOU symlink attack |
+| T9-04 | Test signing disabled after install confirmed | After T4-B reboot confirms battery works: `bcdedit /set testsigning off` + reboot | Watermark gone; driver still loads; battery reads continue |
+| T9-05 | Driver file integrity | Hash `AppleWirelessMouse.sys` before and after install | SHA256 unchanged; no substitution during install |
+
+**T9-01 and T9-03 require code changes to sign-and-install.ps1** before this tier can pass:
+1. Change `$repairScript = Join-Path $PSScriptRoot "startup-repair.ps1"` to copy script to a
+   fixed protected path (e.g., `C:\Program Files\MagicMouseTray\`) and register the task pointing there.
+2. After creating `C:\ProgramData\MagicMouseTray\`, run `icacls` to remove user write access.
+
+---
+
+## Test Execution Matrix
+
+| Tier | T1 Unit | T2 Section | T3 Integration | T4 E2E | T7 Failover | T8 Upgrade | T9 Security |
+|------|---------|-----------|----------------|--------|-------------|-----------|-------------|
+| Executable without hardware | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Requires Lesley + Windows machine | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| MM-V3 (0323) | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| MM-V1 (030d) | ✅ | ✅ | ✅ | ✅ T4-C | ⬜ v1.1 | ⬜ v1.1 | ⬜ v1.1 |
+| Must pass before v1.1.0 release | ✅ | ✅ | ✅ | T4-A + T4-B | T7-01 T7-02 T7-03 | T8-02 T8-03 | T9-01 T9-03 T9-04 |
+
+---
+
+## Blockers That Must Be Fixed Before Testing
+
+These are code issues found in the adversarial peer review that will cause test failures if not fixed first:
+
+| ID | Severity | File | Issue | Fix Required |
+|----|----------|------|-------|-------------|
+| BLK-01 | **High** | `MouseBatteryReader.cs` | `InputReportByteLength < 3` threshold unverified — if COL02 reports exactly 2 bytes, battery reads silently fail | Add log line for byte length; verify empirically in T3-03 |
+| BLK-02 | **Medium** | `DriverHealthChecker.cs` | Zero devices → returns `Ok` (false negative) | Initialize default to `NotInstalled` |
+| BLK-03 | **Medium** | `sign-and-install.ps1` | Scheduled task points to `$PSScriptRoot` — LPE if run from writable dir | Copy script to `C:\Program Files\MagicMouseTray\` before registering task |
+| BLK-04 | **Medium** | `sign-and-install.ps1` | `C:\ProgramData\MagicMouseTray\` not created/locked at install time | Create dir and lock ACL in Step 9 before task registration |
+
+BLK-01 is the highest priority — it directly determines whether battery reads work at all.
+
+---
+
+## Issue Log
+
+Issues discovered during testing are tracked as GitHub Issues on `ReviveBusiness/magic-mouse-tray`.
+Tag with `test-finding` and reference this plan's test ID (e.g., `T3-03 FAIL — InputReportByteLength=2`).
+
+---
+
+*Test Plan v1.0 — Built per BCP-STD-015 9-Tier Testing Framework*
+*Created 2026-04-22 by RILEY / Lesley Murfin*

--- a/diagnose-driver.ps1
+++ b/diagnose-driver.ps1
@@ -1,0 +1,140 @@
+#Requires -RunAsAdministrator
+<#
+.SYNOPSIS
+    Apple Wireless Mouse driver diagnostic script.
+    Run from PowerShell as Administrator.
+#>
+
+$driverName = "applewirelessmouse"
+$sysFile    = "C:\Windows\System32\drivers\$driverName.sys"
+$logFile    = "$env:USERPROFILE\Desktop\apple-mouse-diag.txt"
+
+function Write-Log {
+    param([string]$text)
+    $line = "[$(Get-Date -Format 'HH:mm:ss')] $text"
+    Write-Host $line
+    Add-Content -Path $logFile -Value $line
+}
+
+function Write-Section {
+    param([string]$title)
+    $bar = "=" * 60
+    Write-Log ""
+    Write-Log $bar
+    Write-Log "  $title"
+    Write-Log $bar
+}
+
+# Start fresh log
+"" | Set-Content $logFile
+Write-Log "Apple Wireless Mouse Driver Diagnostic"
+Write-Log "Date: $(Get-Date)"
+
+# ── 1. Driver .sys file ──────────────────────────────────────
+Write-Section "1. Driver .sys file"
+if (Test-Path $sysFile) {
+    $file = Get-Item $sysFile
+    Write-Log "FOUND: $sysFile"
+    Write-Log "  Size:     $($file.Length) bytes"
+    Write-Log "  Modified: $($file.LastWriteTime)"
+
+    # Authenticode signature (built-in, no Sysinternals needed)
+    $sig = Get-AuthenticodeSignature $sysFile
+    Write-Log "  Signature status: $($sig.Status)"
+    Write-Log "  Signer:           $($sig.SignerCertificate.Subject)"
+} else {
+    Write-Log "NOT FOUND: $sysFile  <-- driver binary is missing"
+}
+
+# ── 2. Service config ────────────────────────────────────────
+Write-Section "2. Service config (sc qc)"
+$scOutput = & sc.exe qc $driverName 2>&1
+$scOutput | ForEach-Object { Write-Log "  $_" }
+
+Write-Section "2b. Service state (sc query)"
+$scQuery = & sc.exe query $driverName 2>&1
+$scQuery | ForEach-Object { Write-Log "  $_" }
+
+# ── 3. Autorunsc (Unicode-safe via Select-String) ────────────
+Write-Section "3. Autoruns — registered driver entries"
+$autorunsPath = @(
+    "$env:USERPROFILE\Downloads\autorunsc.exe",
+    "C:\Tools\autorunsc.exe",
+    "C:\Sysinternals\autorunsc.exe",
+    (Get-Command autorunsc.exe -ErrorAction SilentlyContinue)?.Source
+) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+
+if ($autorunsPath) {
+    Write-Log "Using: $autorunsPath"
+    # -nobanner suppresses header noise; pipe to Select-String handles Unicode
+    & $autorunsPath -accepteula -nobanner -a d 2>&1 |
+        Select-String -Pattern "apple" -CaseSensitive:$false |
+        ForEach-Object { Write-Log "  $_" }
+
+    Write-Log ""
+    Write-Log "--- Full driver list (all entries) ---"
+    & $autorunsPath -accepteula -nobanner -a d 2>&1 |
+        ForEach-Object { Write-Log "  $_" }
+} else {
+    Write-Log "autorunsc.exe not found in common paths. Skipping."
+    Write-Log "Download from: https://learn.microsoft.com/sysinternals/downloads/autoruns"
+}
+
+# ── 4. Sigcheck (if available) ───────────────────────────────
+Write-Section "4. Sigcheck — deep signature verification"
+$sigcheckPath = @(
+    "$env:USERPROFILE\Downloads\sigcheck.exe",
+    "C:\Tools\sigcheck.exe",
+    "C:\Sysinternals\sigcheck.exe",
+    (Get-Command sigcheck.exe -ErrorAction SilentlyContinue)?.Source
+) | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+
+if ($sigcheckPath -and (Test-Path $sysFile)) {
+    & $sigcheckPath -accepteula -i -a $sysFile 2>&1 |
+        ForEach-Object { Write-Log "  $_" }
+} elseif (-not $sigcheckPath) {
+    Write-Log "sigcheck.exe not found. Skipping."
+} else {
+    Write-Log "Driver .sys not present — skipping sigcheck."
+}
+
+# ── 5. pnputil device info ───────────────────────────────────
+Write-Section "5. PnP devices — Apple HID/BT entries"
+& pnputil /enum-devices 2>&1 |
+    Select-String -Pattern "apple|00001124-0000-1000-8000-00805f9b34fb" -CaseSensitive:$false |
+    ForEach-Object { Write-Log "  $_" }
+
+Write-Section "5b. INF package info (oem0.inf)"
+& pnputil /enum-drivers 2>&1 |
+    Select-String -Pattern "apple|oem0\.inf" -CaseSensitive:$false |
+    ForEach-Object { Write-Log "  $_" }
+
+# ── 6. Windows Event Log errors ──────────────────────────────
+Write-Section "6. System event log — driver/service errors (last 48h)"
+$since = (Get-Date).AddHours(-48)
+Get-WinEvent -LogName System -ErrorAction SilentlyContinue |
+    Where-Object {
+        $_.TimeCreated -ge $since -and
+        $_.Id -in @(7000, 7001, 7009, 7011, 7022, 7023, 7026, 7034, 7043) -and
+        ($_.Message -match "apple|wirelessmouse|hid" -or $_.ProviderName -match "apple")
+    } |
+    Sort-Object TimeCreated |
+    ForEach-Object {
+        Write-Log "  [$($_.TimeCreated)] ID=$($_.Id) — $($_.Message -replace '\s+',' ')"
+    }
+
+# ── 7. Registry LowerFilters check ───────────────────────────
+Write-Section "7. Registry — LowerFilters entry"
+$regPath = "HKLM:\SYSTEM\CurrentControlSet\Control\Class\{745a17a0-74d3-11d0-b6fe-00a0c90f57da}\0005"
+try {
+    $lf = (Get-ItemProperty $regPath -ErrorAction Stop).LowerFilters
+    Write-Log "  LowerFilters: $($lf -join ', ')"
+} catch {
+    Write-Log "  Could not read registry key: $_"
+}
+
+# ── Done ─────────────────────────────────────────────────────
+Write-Section "DONE"
+Write-Log "Full log saved to: $logFile"
+Write-Host ""
+Write-Host "Log written to: $logFile" -ForegroundColor Cyan

--- a/docs/mm3-pre-validation-baseline-2026-04-26.md
+++ b/docs/mm3-pre-validation-baseline-2026-04-26.md
@@ -66,6 +66,18 @@ HidD_GetInputReport(col02, buf[3], 0x90)
 
 Confirms `MouseBatteryReader.cs` layout: `buf[2]` = battery %. ✅
 
+## applewirelessmouse.sys Baseline
+
+| Field | Value |
+|-------|-------|
+| Path | `C:\Windows\System32\drivers\applewirelessmouse.sys` |
+| FileVersion | 6.1.7700.0 |
+| ProductVersion | 6.1.0.0 |
+| SHA-256 | `08F33D7E3ECE2C73950A9706F1C4C9057894EAEAF1C4FB355F261F3C2333378F` |
+
+This is the Apple BootCamp HID lower filter driver. Version 6.1.7700.0 is the Windows 7-era
+BootCamp build. The KMDF function driver (M12) will replace this driver's role entirely.
+
 ## Raw Descriptor Capture — Not Obtained
 
 `IOCTL_HID_GET_REPORT_DESCRIPTOR` (0x000B0083) returns err=1 (ERROR_INVALID_FUNCTION) when

--- a/docs/mm3-pre-validation-baseline-2026-04-26.md
+++ b/docs/mm3-pre-validation-baseline-2026-04-26.md
@@ -1,0 +1,101 @@
+# MM3 Pre-Validation Baseline — 2026-04-26
+
+Captured before KMDF driver development begins (M12). All data collected on the live Windows 11
+machine with Magic Mouse 3 (PID 0323) paired and COL01+COL02 both present.
+
+## Device Identity
+
+| Field | Value |
+|-------|-------|
+| BTHENUM instance ID | `BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&0001004C_PID&0323\9&73B8B28&0&D0C050CC8C4D_C00000000` |
+| Pairing session | `9&73B8B28&0` |
+| BT MAC address | `D0C050CC8C4D` (permanent) |
+| PID | 0323 (Magic Mouse 3 / 2024 USB-C model) |
+| VID | 004C (Apple, Bluetooth class) |
+
+## Device Stack (Baseline — Filter Absent)
+
+```
+Get-PnpDeviceProperty -InstanceId $id -KeyName 'DEVPKEY_Device_Stack'
+
+\Driver\HidBth
+\Driver\BthEnum
+```
+
+`applewirelessmouse` is NOT present. Clean stack: BthEnum (bus) → HidBth (function driver only).
+This is the state where battery works and scroll does not.
+
+## HID Devices (Healthy State)
+
+```
+Get-PnpDevice | Where-Object { $_.InstanceId -match '0323' -and $_.Status -eq 'OK' }
+```
+
+Expected 4 devices: 2× BTHENUM + COL01 + COL02, all Status=OK.
+
+### COL01 — Pointer / Scroll
+
+| Field | Value |
+|-------|-------|
+| Path | `\\?\hid#{00001124-0000-1000-8000-00805f9b34fb}_vid&0001004c_pid&0323&col01#a&31e5d054&9&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}` |
+| UsagePage | 0x0001 (Generic Desktop) |
+| Usage | 0x0002 (Mouse) |
+| InputReportByteLength | 8 |
+| Access | mouhid holds exclusive read — CreateFile(GENERIC_READ) → ReadFile err=5 (ACCESS_DENIED) |
+| Zero-access | Works for HidD_GetPreparsedData / HidP_GetCaps; ReadFile still fails |
+
+### COL02 — Battery / Vendor
+
+| Field | Value |
+|-------|-------|
+| Path | `\\?\hid#{00001124-0000-1000-8000-00805f9b34fb}_vid&0001004c_pid&0323&col02#a&31e5d054&9&0001#{4d1e55b2-f16f-11cf-88cb-001111000030}` |
+| UsagePage | 0xFF00 (Vendor-defined) |
+| Usage | 0x0014 |
+| InputReportByteLength | 3 |
+| Access | Zero-access CreateFile works; HidD_GetInputReport works |
+
+## Battery Report Confirmation
+
+```
+HidD_GetInputReport(col02, buf[3], 0x90)
+→  90 04 31
+   buf[0] = 0x90  (Report ID)
+   buf[1] = 0x04  (flags)
+   buf[2] = 0x31  = 49%  ← battery percentage
+```
+
+Confirms `MouseBatteryReader.cs` layout: `buf[2]` = battery %. ✅
+
+## Raw Descriptor Capture — Not Obtained
+
+`IOCTL_HID_GET_REPORT_DESCRIPTOR` (0x000B0083) returns err=1 (ERROR_INVALID_FUNCTION) when
+sent to COL01 or COL02. This IOCTL is only handled by the HID class FDO (parent device), which
+does not expose an accessible `GUID_DEVINTERFACE_HID` path for multi-collection BT devices.
+
+**Not needed for KMDF driver design.** The KMDF driver defines a custom HID descriptor; it does
+not copy the device's descriptor. Linux `drivers/hid/hid-magicmouse.c` fully documents the raw
+report format (Report ID 0x12: multi-touch, Report ID 0x90: battery).
+
+## Probe Scripts (saved to C:\Temp\ on Windows machine)
+
+| Script | Purpose | Result |
+|--------|---------|--------|
+| `capture-hid-descriptor.ps1` | Enumerate HID devices, attempt raw descriptor capture | COL01/COL02 found; IOCTL err=1 |
+| `TouchpadProbe.ps1` | Read raw input reports from COL01/COL02 | COL02 battery 49% ✅; COL01 err=5 (mouhid exclusive) |
+
+## Key Findings for KMDF Driver Design
+
+1. **COL01 is exclusively owned by mouhid** — any user-space raw HID read path fails. KMDF
+   function driver must intercept at kernel level, before mouhid, to access raw touch reports.
+
+2. **COL02 InputReportLen=3** — battery report is 3 bytes: Report ID (0x90) + 2 data bytes.
+   `buf[2]` = battery %. MagicMouseTray reads this correctly.
+
+3. **Device stack is clean** — no applewirelessmouse filter. KMDF driver will bind to the same
+   BTHENUM hardware ID (`BTHENUM\{00001124-...}_VID&0001004c_PID&0323`) as function driver,
+   replacing HidBth.
+
+4. **Custom HID descriptor plan:**
+   - TLC 1: Generic Desktop Mouse (0x0001/0x0002) — pointer + scroll axes
+   - TLC 2: Vendor (0xFF00) — Report ID 0x90, battery percentage in byte 2
+   - No stripping needed — driver owns the full descriptor from init.

--- a/driver/Driver.c
+++ b/driver/Driver.c
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+#include "Driver.h"
+#include "HidDescriptor.h"
+#include "InputHandler.h"
+
+NTSTATUS
+DriverEntry(
+    _In_ PDRIVER_OBJECT  DriverObject,
+    _In_ PUNICODE_STRING RegistryPath)
+{
+    WDF_DRIVER_CONFIG config;
+    WDF_DRIVER_CONFIG_INIT(&config, EvtDeviceAdd);
+    return WdfDriverCreate(DriverObject, RegistryPath,
+                           WDF_NO_OBJECT_ATTRIBUTES, &config, WDF_NO_HANDLE);
+}
+
+NTSTATUS
+EvtDeviceAdd(
+    _In_    WDFDRIVER       Driver,
+    _Inout_ PWDFDEVICE_INIT DeviceInit)
+{
+    UNREFERENCED_PARAMETER(Driver);
+
+    // Mark as filter — WDF will not claim exclusive I/O ownership
+    WdfFdoInitSetFilter(DeviceInit);
+
+    WDF_OBJECT_ATTRIBUTES deviceAttributes;
+    WDF_OBJECT_ATTRIBUTES_INIT_CONTEXT_TYPE(&deviceAttributes, DEVICE_CONTEXT);
+
+    WDFDEVICE device;
+    NTSTATUS status = WdfDeviceCreate(&DeviceInit, &deviceAttributes, &device);
+    if (!NT_SUCCESS(status)) {
+        return status;
+    }
+
+    // Internal device control queue handles HID IOCTLs (IRP_MJ_INTERNAL_DEVICE_CONTROL)
+    WDF_IO_QUEUE_CONFIG queueConfig;
+    WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&queueConfig, WdfIoQueueDispatchParallel);
+    queueConfig.EvtIoInternalDeviceControl = EvtIoInternalDeviceControl;
+
+    WDFQUEUE queue;
+    status = WdfIoQueueCreate(device, &queueConfig, WDF_NO_OBJECT_ATTRIBUTES, &queue);
+    return status;
+}
+
+VOID
+EvtIoInternalDeviceControl(
+    _In_ WDFQUEUE   Queue,
+    _In_ WDFREQUEST Request,
+    _In_ size_t     OutputBufferLength,
+    _In_ size_t     InputBufferLength,
+    _In_ ULONG      IoControlCode)
+{
+    UNREFERENCED_PARAMETER(InputBufferLength);
+
+    WDFDEVICE device = WdfIoQueueGetDevice(Queue);
+
+    switch (IoControlCode) {
+
+    case IOCTL_HID_GET_REPORT_DESCRIPTOR:
+        // Complete with our custom descriptor immediately — do not forward to BthEnum.
+        // HidBth receives our descriptor and creates COL01 (scroll) + COL02 (battery).
+        HidDescriptor_Handle(Request, OutputBufferLength);
+        return;
+
+    case IOCTL_HID_READ_REPORT:
+        // Forward to BthEnum (blocks until BT data arrives); translate 0x12 on completion.
+        InputHandler_ForwardWithCompletion(device, Request);
+        return;
+
+    default:
+        break;
+    }
+
+    // Pass all other IOCTLs straight through
+    WdfRequestFormatRequestUsingCurrentType(Request);
+    WDF_REQUEST_SEND_OPTIONS opts;
+    WDF_REQUEST_SEND_OPTIONS_INIT(&opts, WDF_REQUEST_SEND_OPTION_SEND_AND_FORGET);
+    if (!WdfRequestSend(Request, WdfDeviceGetIoTarget(device), &opts)) {
+        WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+    }
+}

--- a/driver/Driver.h
+++ b/driver/Driver.h
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: MIT
+// Magic Mouse 2024 KMDF Lower Filter Driver
+// Replaces applewirelessmouse.sys: returns a custom HID descriptor that preserves
+// both the scroll collection (COL01) and battery collection (COL02) on every
+// enumeration, eliminating the descriptor-strip conflict.
+//
+// Stack position (between BthEnum and HidBth):
+//   HidClass → HidBth → [MagicMouseDriver (this)] → BthEnum
+//
+// Two interception points:
+//   IOCTL_HID_GET_REPORT_DESCRIPTOR: complete immediately with custom descriptor
+//   IOCTL_HID_READ_REPORT:           forward + translate Report 0x12 on completion
+
+#pragma once
+
+#include <ntddk.h>
+#include <wdf.h>
+
+// HID IOCTL codes (from WDK hidport.h / FILE_DEVICE_KEYBOARD=0x0B, METHOD_NEITHER=3)
+// Verified: IOCTL_HID_GET_REPORT_DESCRIPTOR = 0x000B0083 (confirmed by baseline test 2026-04-26)
+#ifndef IOCTL_HID_GET_REPORT_DESCRIPTOR
+#define IOCTL_HID_GET_REPORT_DESCRIPTOR  0x000B0083UL
+#endif
+#ifndef IOCTL_HID_READ_REPORT
+#define IOCTL_HID_READ_REPORT            0x000B000FUL  // verify at first build
+#endif
+
+// Report IDs
+#define MM_REPORT_ID_TOUCH    0x12   // Raw multi-touch report from BT device
+#define MM_REPORT_ID_MOUSE    0x01   // Standard mouse report ID in our descriptor (TLC1)
+#define MM_REPORT_ID_BATTERY  0x90   // Battery report — pass through unchanged (TLC2)
+
+// TLC1 output report layout (what we emit from InputHandler):
+//   [0] = 0x01  Report ID
+//   [1] = buttons bitmask (bits 0-2: L/R/Middle, bits 3-7: padding)
+//   [2] = X delta  (INT8, -127..127, relative)
+//   [3] = Y delta  (INT8, -127..127, relative)
+//   [4] = Wheel vertical  (INT8, scroll up/down)
+//   [5] = Wheel horizontal (INT8, AC Pan, scroll left/right)
+#define MM_MOUSE_REPORT_LEN   6
+
+// Device context (reserved for per-device state if needed)
+typedef struct _DEVICE_CONTEXT {
+    ULONG Reserved;
+} DEVICE_CONTEXT, *PDEVICE_CONTEXT;
+
+WDF_DECLARE_CONTEXT_TYPE_WITH_NAME(DEVICE_CONTEXT, GetDeviceContext)
+
+// Function declarations
+DRIVER_INITIALIZE DriverEntry;
+EVT_WDF_DRIVER_DEVICE_ADD EvtDeviceAdd;
+EVT_WDF_IO_QUEUE_IO_INTERNAL_DEVICE_CONTROL EvtIoInternalDeviceControl;

--- a/driver/HidDescriptor.c
+++ b/driver/HidDescriptor.c
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+//
+// Custom HID report descriptor for Apple Magic Mouse 2024 (PID 0x0323).
+//
+// Replaces the descriptor provided by the raw BT device to ensure both
+// collections are always present regardless of filter state:
+//
+//   TLC1 (Report ID 0x01) — Generic Desktop Mouse
+//     Pointer + 3 buttons + X/Y relative + vertical wheel + horizontal scroll (AC Pan)
+//     InputReportByteLength = 6  ([0x01, buttons, X, Y, WheelV, WheelH])
+//
+//   TLC2 (Report ID 0x90) — Vendor-Defined Battery
+//     Matches raw BT device battery report exactly:
+//     InputReportByteLength = 3  ([0x90, flags, battery_%])
+//     MagicMouseTray reads buf[2] = battery% via HidD_GetInputReport on COL02.
+//
+// Design notes:
+//   - Both TLCs declare explicit Report IDs (required when any TLC uses one).
+//   - TLC1 format is compatible with mouhid.sys (standard Windows mouse driver).
+//   - TLC2 is pass-through: Report 0x90 from BT device is forwarded unchanged.
+//   - InputHandler translates raw Report 0x12 (multi-touch) → Report 0x01.
+
+#include "HidDescriptor.h"
+
+const UCHAR g_HidDescriptor[] = {
+    // ----------------------------------------------------------------
+    // TLC1: Generic Desktop Mouse (Usage Page 0x01, Usage 0x02)
+    // ----------------------------------------------------------------
+    0x05, 0x01,        // Usage Page (Generic Desktop)
+    0x09, 0x02,        // Usage (Mouse)
+    0xA1, 0x01,        // Collection (Application)
+    0x85, 0x01,        //   Report ID (1)
+
+    0x09, 0x01,        //   Usage (Pointer)
+    0xA1, 0x00,        //   Collection (Physical)
+
+    // 3 buttons — 3 × 1-bit fields + 5-bit padding = 1 byte
+    0x05, 0x09,        //     Usage Page (Button)
+    0x19, 0x01,        //     Usage Minimum (Button 1 — left)
+    0x29, 0x03,        //     Usage Maximum (Button 3 — middle)
+    0x15, 0x00,        //     Logical Minimum (0)
+    0x25, 0x01,        //     Logical Maximum (1)
+    0x75, 0x01,        //     Report Size (1)
+    0x95, 0x03,        //     Report Count (3)
+    0x81, 0x02,        //     Input (Data, Variable, Absolute)
+    0x75, 0x05,        //     Report Size (5) — padding
+    0x95, 0x01,        //     Report Count (1)
+    0x81, 0x03,        //     Input (Constant)
+
+    // X and Y — 2 × INT8 relative axes
+    0x05, 0x01,        //     Usage Page (Generic Desktop)
+    0x09, 0x30,        //     Usage (X)
+    0x09, 0x31,        //     Usage (Y)
+    0x15, 0x81,        //     Logical Minimum (-127)
+    0x25, 0x7F,        //     Logical Maximum (127)
+    0x75, 0x08,        //     Report Size (8)
+    0x95, 0x02,        //     Report Count (2)
+    0x81, 0x06,        //     Input (Data, Variable, Relative)
+
+    // Vertical scroll wheel — INT8 relative
+    0x09, 0x38,        //     Usage (Wheel)
+    0x15, 0x81,        //     Logical Minimum (-127)
+    0x25, 0x7F,        //     Logical Maximum (127)
+    0x75, 0x08,        //     Report Size (8)
+    0x95, 0x01,        //     Report Count (1)
+    0x81, 0x06,        //     Input (Data, Variable, Relative)
+
+    // Horizontal scroll — INT8 relative (Consumer page, AC Pan usage 0x0238)
+    0x05, 0x0C,        //     Usage Page (Consumer Devices)
+    0x0A, 0x38, 0x02,  //     Usage (0x0238 AC Pan) — 2-byte extended usage
+    0x15, 0x81,        //     Logical Minimum (-127)
+    0x25, 0x7F,        //     Logical Maximum (127)
+    0x75, 0x08,        //     Report Size (8)
+    0x95, 0x01,        //     Report Count (1)
+    0x81, 0x06,        //     Input (Data, Variable, Relative)
+
+    0xC0,              //   End Collection (Physical)
+    0xC0,              // End Collection (Application)
+
+    // ----------------------------------------------------------------
+    // TLC2: Vendor-Defined Battery (Usage Page 0xFF00, Usage 0x14)
+    // Report ID 0x90 — matches raw BT device battery report exactly.
+    // MagicMouseTray reads buf[2] = battery% via HidD_GetInputReport(COL02).
+    // ----------------------------------------------------------------
+    0x06, 0x00, 0xFF,  // Usage Page (Vendor-Defined 0xFF00)
+    0x09, 0x14,        // Usage (0x14)
+    0xA1, 0x01,        // Collection (Application)
+    0x85, 0x90,        //   Report ID (0x90)
+    0x09, 0x01,        //   Usage (0x01) — flags byte
+    0x09, 0x02,        //   Usage (0x02) — battery% byte
+    0x15, 0x00,        //   Logical Minimum (0)
+    0x26, 0xFF, 0x00,  //   Logical Maximum (255)
+    0x75, 0x08,        //   Report Size (8)
+    0x95, 0x02,        //   Report Count (2)
+    0x81, 0x02,        //   Input (Data, Variable, Absolute)
+    0xC0,              // End Collection
+};
+
+const ULONG g_HidDescriptorSize = sizeof(g_HidDescriptor);
+
+VOID
+HidDescriptor_Handle(
+    _In_ WDFREQUEST Request,
+    _In_ size_t     OutputBufferLength)
+{
+    // IOCTL_HID_GET_REPORT_DESCRIPTOR uses METHOD_NEITHER.
+    // Output buffer is in Irp->UserBuffer; length is from the IRP stack location.
+    PIRP irp = WdfRequestWdmGetIrp(Request);
+    PVOID outBuffer = irp->UserBuffer;
+
+    if (outBuffer == NULL) {
+        WdfRequestComplete(Request, STATUS_INVALID_PARAMETER);
+        return;
+    }
+
+    if (OutputBufferLength < g_HidDescriptorSize) {
+        // Caller passed insufficient buffer — tell it how much is needed
+        irp->IoStatus.Information = g_HidDescriptorSize;
+        WdfRequestComplete(Request, STATUS_BUFFER_TOO_SMALL);
+        return;
+    }
+
+    RtlCopyMemory(outBuffer, g_HidDescriptor, g_HidDescriptorSize);
+    irp->IoStatus.Information = g_HidDescriptorSize;
+    WdfRequestComplete(Request, STATUS_SUCCESS);
+}

--- a/driver/HidDescriptor.h
+++ b/driver/HidDescriptor.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+#include "Driver.h"
+
+// Size of the custom HID report descriptor (TLC1 + TLC2)
+extern const UCHAR  g_HidDescriptor[];
+extern const ULONG  g_HidDescriptorSize;
+
+VOID HidDescriptor_Handle(_In_ WDFREQUEST Request, _In_ size_t OutputBufferLength);

--- a/driver/InputHandler.c
+++ b/driver/InputHandler.c
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+//
+// InputHandler — translates raw Apple Magic Mouse BT HID reports.
+//
+// Raw BT device sends two report types:
+//   Report 0x12 — multi-touch: 14-byte header + N × 9-byte touch records
+//   Report 0x90 — battery:     [0x90, flags, battery%]
+//
+// We translate 0x12 → Report 0x01 (standard mouse format matching TLC1 descriptor).
+// Report 0x90 passes through unchanged (TLC2 descriptor matches exactly).
+//
+// TODO: Fill in TranslateTouch() once TouchpadProbe.ps1 output is captured.
+//   Run: scripts\TouchpadProbe.ps1 (elevated, on Windows, mouse connected)
+//   Move finger while it runs — capture Report 0x12 raw hex to docs\
+//   Then port Linux hid-magicmouse.c touch parsing to TranslateTouch().
+//
+// Reference: drivers/hid/hid-magicmouse.c in the Linux kernel
+//   MOUSE2_REPORT_ID = 0x12
+//   Each touch record: x(int16), y(int16), touch_state(u8), size(u8), pressure(u8), ...
+//   Scroll: accumulate Y delta across 1-finger moves; emit on threshold.
+
+#include "InputHandler.h"
+
+// Minimum report length to attempt 0x12 parsing (9-byte header minimum)
+#define MM_TOUCH_REPORT_MIN_LEN   9
+
+// Bytes per touch record in Report 0x12 (from Linux hid-magicmouse.c MOUSE2 format)
+// TODO: verify exact byte layout against TouchpadProbe.ps1 output
+#define MM_TOUCH_RECORD_BYTES     9
+
+// Header bytes before first touch record in Report 0x12
+#define MM_TOUCH_HEADER_BYTES     9
+
+// Signed byte clamp to INT8 range
+static INT8 ClampToInt8(INT32 val) {
+    if (val > 127)  return 127;
+    if (val < -127) return -127;
+    return (INT8)val;
+}
+
+// TODO: Implement using actual Report 0x12 byte layout from TouchpadProbe output.
+// Signature kept minimal — extend as needed for multi-finger gestures.
+static VOID
+TranslateTouch(
+    _In_reads_bytes_(reportLen) PUCHAR reportBuf,
+    _In_  ULONG  reportLen,
+    _Out_ PUCHAR outBuf6)  // 6-byte output: [0x01, buttons, X, Y, WheelV, WheelH]
+{
+    UNREFERENCED_PARAMETER(reportLen);
+
+    // Zero the output report
+    RtlZeroMemory(outBuf6, MM_MOUSE_REPORT_LEN);
+    outBuf6[0] = MM_REPORT_ID_MOUSE;
+
+    // TODO: Parse reportBuf per Linux hid-magicmouse.c MOUSE2_REPORT_ID handling.
+    //
+    // Reference layout (verify with TouchpadProbe.ps1):
+    //   reportBuf[0] = 0x12 (Report ID)
+    //   reportBuf[1] = buttons bitmask (bit 0 = left click)
+    //   reportBuf[2] = ? (possibly click force / number of touches)
+    //   reportBuf[3..8] = rest of header
+    //   reportBuf[9 + i*9 .. 9 + i*9 + 8] = touch record i:
+    //     [0..1] = X (INT16 little-endian, unit: 100ths of mm)
+    //     [2..3] = Y (INT16 little-endian, unit: 100ths of mm)
+    //     [4]    = tracking ID + touch flags
+    //     [5]    = touch size
+    //     [6..8] = other data
+    //
+    // Basic single-finger implementation:
+    //   nTouches = (reportLen - MM_TOUCH_HEADER_BYTES) / MM_TOUCH_RECORD_BYTES;
+    //   if (nTouches == 1) {
+    //       INT16 rawX = (INT16)(reportBuf[10] << 8 | reportBuf[9]);
+    //       INT16 rawY = (INT16)(reportBuf[12] << 8 | reportBuf[11]);
+    //       outBuf6[2] = ClampToInt8(rawX / SCALE);  // X pointer
+    //       outBuf6[3] = ClampToInt8(rawY / SCALE);  // Y pointer
+    //   } else if (nTouches == 2) {
+    //       // Two-finger scroll: accumulate Y → WheelV, X → WheelH
+    //   }
+    //
+    // Pass through button state from report header byte 1:
+    outBuf6[1] = (reportBuf[1] & 0x01);  // left button — assume bit 0
+}
+
+VOID
+InputHandler_ForwardWithCompletion(
+    _In_ WDFDEVICE  Device,
+    _In_ WDFREQUEST Request)
+{
+    WdfRequestFormatRequestUsingCurrentType(Request);
+    WdfRequestSetCompletionRoutine(Request, InputHandler_OnReadComplete, Device);
+
+    if (!WdfRequestSend(Request, WdfDeviceGetIoTarget(Device), WDF_NO_SEND_OPTIONS)) {
+        WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+    }
+}
+
+VOID
+InputHandler_OnReadComplete(
+    _In_ WDFREQUEST                     Request,
+    _In_ WDFIOTARGET                    Target,
+    _In_ PWDF_REQUEST_COMPLETION_PARAMS Params,
+    _In_ WDFCONTEXT                     Context)
+{
+    UNREFERENCED_PARAMETER(Target);
+    UNREFERENCED_PARAMETER(Context);
+
+    NTSTATUS status = Params->IoStatus.Status;
+    if (!NT_SUCCESS(status)) {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    ULONG reportLen = (ULONG)Params->IoStatus.Information;
+    if (reportLen < 1) {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    // Report buffer is in Irp->UserBuffer for METHOD_NEITHER IOCTL_HID_READ_REPORT
+    PIRP irp = WdfRequestWdmGetIrp(Request);
+    PUCHAR data = (PUCHAR)irp->UserBuffer;
+    if (data == NULL) {
+        WdfRequestComplete(Request, STATUS_INVALID_PARAMETER);
+        return;
+    }
+
+    UCHAR reportId = data[0];
+
+    if (reportId == MM_REPORT_ID_TOUCH && reportLen >= MM_TOUCH_REPORT_MIN_LEN) {
+        // Translate raw multi-touch → standard mouse report in place
+        UCHAR translated[MM_MOUSE_REPORT_LEN];
+        TranslateTouch(data, reportLen, translated);
+        RtlCopyMemory(data, translated, MM_MOUSE_REPORT_LEN);
+        Params->IoStatus.Information = MM_MOUSE_REPORT_LEN;
+        irp->IoStatus.Information    = MM_MOUSE_REPORT_LEN;
+    }
+    // Report 0x90 (battery) and any others pass through unchanged
+
+    WdfRequestComplete(Request, status);
+}

--- a/driver/InputHandler.h
+++ b/driver/InputHandler.h
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+#pragma once
+#include "Driver.h"
+
+// Forward IOCTL_HID_READ_REPORT to BthEnum with a completion routine.
+// The completion routine translates Report 0x12 (raw multi-touch) → Report 0x01
+// (standard mouse: X/Y + vertical/horizontal scroll). Report 0x90 passes through.
+VOID InputHandler_ForwardWithCompletion(_In_ WDFDEVICE Device, _In_ WDFREQUEST Request);
+
+// Completion routine — called when BthEnum delivers a raw BT HID report.
+EVT_WDF_REQUEST_COMPLETION_ROUTINE InputHandler_OnReadComplete;

--- a/driver/MagicMouseDriver.inf
+++ b/driver/MagicMouseDriver.inf
@@ -1,0 +1,69 @@
+; MagicMouseDriver.inf
+; SPDX-License-Identifier: MIT
+;
+; Installs MagicMouseDriver.sys as a lower filter on the Apple Magic Mouse 2024
+; BTHENUM device. The driver provides a custom HID descriptor that preserves both
+; the scroll collection (COL01) and battery collection (COL02) on every enumeration.
+;
+; Hardware ID: BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&0001004C_PID&0323
+; (Magic Mouse 2024, Bluetooth HID, confirmed from baseline 2026-04-26)
+;
+; Install:
+;   pnputil /add-driver MagicMouseDriver.inf /install
+;   (requires test signing enabled: bcdedit /set testsigning on + reboot)
+;
+; Uninstall:
+;   pnputil /delete-driver oem<N>.inf /uninstall /force
+
+[Version]
+Signature   = "$Windows NT$"
+Class       = Bluetooth
+ClassGuid   = {e0cbf06c-cd8b-4647-bb8a-263b43f0f974}
+Provider    = %ManufacturerName%
+DriverVer   = 04/27/2026,1.0.0.0
+CatalogFile = MagicMouseDriver.cat
+PnpLockdown = 1
+
+[Manufacturer]
+%ManufacturerName% = Standard, NTamd64
+
+[Standard.NTamd64]
+%DeviceDesc% = Install, BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&0001004C_PID&0323
+
+; ---- Installation ----
+
+[Install]
+CopyFiles = DriverFiles
+
+[Install.HW]
+AddReg = AddReg_LowerFilter
+
+[AddReg_LowerFilter]
+; Add MagicMouseDriver as lower filter on the BTHENUM HID device.
+; 0x00010008 = FLG_ADDREG_TYPE_MULTI_SZ | FLG_ADDREG_APPEND
+HKR,,"LowerFilters",0x00010008,"MagicMouseDriver"
+
+[Install.Services]
+AddService = MagicMouseDriver,, ServiceInstall
+
+[ServiceInstall]
+DisplayName   = %ServiceDesc%
+ServiceType   = 1               ; SERVICE_KERNEL_DRIVER
+StartType     = 3               ; SERVICE_DEMAND_START (PnP loads on device stack construction)
+ErrorControl  = 1               ; SERVICE_ERROR_NORMAL
+ServiceBinary = %12%\MagicMouseDriver.sys
+
+; ---- Files ----
+
+[DestinationDirs]
+DriverFiles = 12                ; %windir%\system32\drivers\
+
+[DriverFiles]
+MagicMouseDriver.sys
+
+; ---- Strings ----
+
+[Strings]
+ManufacturerName = "Magic Mouse Driver"
+DeviceDesc       = "Apple Magic Mouse 2024 HID Lower Filter"
+ServiceDesc      = "Magic Mouse Driver (scroll + battery coexistence)"

--- a/driver/MagicMouseDriver.vcxproj
+++ b/driver/MagicMouseDriver.vcxproj
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  MagicMouseDriver.vcxproj — KMDF Kernel-Mode Driver Project
+  Build with EWDK (Enterprise WDK) standalone environment:
+
+    1. Mount EWDK ISO (no install needed)
+    2. Run: <ISO>\LaunchBuildEnv.cmd
+    3. In the EWDK shell: cd <this directory>
+    4. Build: msbuild MagicMouseDriver.vcxproj /p:Configuration=Debug /p:Platform=x64
+
+  If this .vcxproj does not work with your EWDK version, clone mac-precision-touchpad
+  (https://github.com/roblabla/MacTrackpad) and adapt its project files:
+    - Change TargetName to MagicMouseDriver
+    - Replace source files with Driver.c, HidDescriptor.c, InputHandler.c
+    - Update the INF reference to MagicMouseDriver.inf
+
+  Requires test signing for development:
+    bcdedit /set testsigning on  (run elevated, then reboot once)
+-->
+<Project DefaultTargets="Build" ToolsVersion="15.0"
+         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}</ProjectGuid>
+    <TargetName>MagicMouseDriver</TargetName>
+    <TargetExt>.sys</TargetExt>
+    <!-- KMDF version — update to match EWDK version (1.33 = Windows 11 22H2) -->
+    <DriverType>KMDF</DriverType>
+    <KmdfVersionMajor>1</KmdfVersionMajor>
+    <KmdfVersionMinor>33</KmdfVersionMinor>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Driver</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <TargetVersion>Windows10</TargetVersion>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <EnableInf2cat>false</EnableInf2cat>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Driver</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <TargetVersion>Windows10</TargetVersion>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+    <EnableInf2cat>false</EnableInf2cat>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <SubSystem>Native</SubSystem>
+      <Driver>WDM</Driver>
+      <AdditionalDependencies>wdmguid.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <ClCompile Include="Driver.c" />
+    <ClCompile Include="HidDescriptor.c" />
+    <ClCompile Include="InputHandler.c" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ClInclude Include="Driver.h" />
+    <ClInclude Include="HidDescriptor.h" />
+    <ClInclude Include="InputHandler.h" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Inf Include="MagicMouseDriver.inf" />
+  </ItemGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(WDKContentRoot)\build\WindowsDriver.targets"
+          Condition="Exists('$(WDKContentRoot)\build\WindowsDriver.targets')" />
+
+</Project>

--- a/scripts/TouchpadProbe.ps1
+++ b/scripts/TouchpadProbe.ps1
@@ -1,0 +1,200 @@
+# TouchpadProbe.ps1
+# Reads raw HID input reports from Magic Mouse 3 COL01 (touch) and COL02 (battery).
+# Run elevated. Move your finger on the mouse surface while it runs.
+# Press Ctrl+C to stop.
+# Output: C:\Temp\TouchpadProbe_reports.txt
+
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+using System.Threading;
+public class TouchProbe {
+    [DllImport("hid.dll", SetLastError=true)]
+    public static extern bool HidD_GetInputReport(IntPtr h, byte[] buf, int len);
+    [DllImport("hid.dll", SetLastError=true)]
+    public static extern bool HidD_GetPreparsedData(IntPtr h, out IntPtr p);
+    [DllImport("hid.dll", SetLastError=true)]
+    public static extern bool HidD_FreePreparsedData(IntPtr p);
+    [DllImport("hid.dll", SetLastError=true)]
+    public static extern int HidP_GetCaps(IntPtr p, ref HIDP_CAPS c);
+    [DllImport("setupapi.dll", CharSet=CharSet.Auto, SetLastError=true)]
+    public static extern IntPtr SetupDiGetClassDevs(ref Guid g, string e, IntPtr hw, uint f);
+    [DllImport("setupapi.dll", SetLastError=true)]
+    public static extern bool SetupDiEnumDeviceInterfaces(IntPtr s, IntPtr d, ref Guid g, uint i, ref SPDI data);
+    [DllImport("setupapi.dll", CharSet=CharSet.Auto, SetLastError=true)]
+    public static extern bool SetupDiGetDeviceInterfaceDetail(IntPtr s, ref SPDI d, IntPtr det, uint sz, ref uint req, IntPtr inf);
+    [DllImport("setupapi.dll", SetLastError=true)]
+    public static extern bool SetupDiDestroyDeviceInfoList(IntPtr s);
+    [DllImport("kernel32.dll", CharSet=CharSet.Auto, SetLastError=true)]
+    public static extern IntPtr CreateFile(string n, uint a, uint sh, IntPtr sec, uint cd, uint fl, IntPtr t);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern bool ReadFile(IntPtr h, byte[] buf, uint sz, ref uint read, IntPtr ov);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern bool CloseHandle(IntPtr h);
+    [StructLayout(LayoutKind.Sequential)]
+    public struct SPDI { public uint cbSize; public Guid Guid; public uint Flags; public UIntPtr Reserved; }
+    [StructLayout(LayoutKind.Sequential)]
+    public struct HIDP_CAPS {
+        public ushort Usage, UsagePage, InputReportByteLength, OutputReportByteLength, FeatureReportByteLength;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst=17)] public ushort[] Reserved;
+        public ushort NumberLinkCollectionNodes;
+        public ushort NumberInputButtonCaps, NumberInputValueCaps, NumberInputDataIndices;
+        public ushort NumberOutputButtonCaps, NumberOutputValueCaps, NumberOutputDataIndices;
+        public ushort NumberFeatureButtonCaps, NumberFeatureValueCaps, NumberFeatureDataIndices;
+    }
+}
+"@
+
+function Get-MM3DevicePath {
+    param([string]$ColSuffix)
+    $hidGuid = [Guid]"{4d1e55b2-f16f-11cf-88cb-001111000030}"
+    $devs = [TouchProbe]::SetupDiGetClassDevs([ref]$hidGuid, $null, [IntPtr]::Zero, 0x12)
+    $iface = New-Object TouchProbe+SPDI
+    $iface.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($iface)
+    $result = $null; $i = 0
+    while ([TouchProbe]::SetupDiEnumDeviceInterfaces($devs, [IntPtr]::Zero, [ref]$hidGuid, $i, [ref]$iface)) {
+        $req = [uint32]0
+        [TouchProbe]::SetupDiGetDeviceInterfaceDetail($devs, [ref]$iface, [IntPtr]::Zero, 0, [ref]$req, [IntPtr]::Zero) | Out-Null
+        if ($req -gt 0) {
+            $ptr = [Runtime.InteropServices.Marshal]::AllocHGlobal([int]$req)
+            $detCbSize = if ([IntPtr]::Size -eq 8) { 8 } else { 6 }
+            [Runtime.InteropServices.Marshal]::WriteInt32($ptr, $detCbSize)
+            if ([TouchProbe]::SetupDiGetDeviceInterfaceDetail($devs, [ref]$iface, $ptr, $req, [ref]$req, [IntPtr]::Zero)) {
+                $path = [Runtime.InteropServices.Marshal]::PtrToStringAuto([IntPtr]($ptr.ToInt64() + 4))
+                if ($path -match '0323' -and $path -match $ColSuffix) { $result = $path }
+            }
+            [Runtime.InteropServices.Marshal]::FreeHGlobal($ptr)
+        }
+        $i++
+    }
+    [TouchProbe]::SetupDiDestroyDeviceInfoList($devs) | Out-Null
+    return $result
+}
+
+$logPath  = "C:\Temp\TouchpadProbe_reports.txt"
+$log      = [System.Collections.Generic.List[string]]::new()
+$INVALID  = [IntPtr](-1)
+$SHARE_RW = [uint32]3
+$OPEN_EX  = [uint32]3
+
+# --- Locate devices ---
+$col01Path = Get-MM3DevicePath 'col01'
+$col02Path = Get-MM3DevicePath 'col02'
+Write-Host "COL01: $col01Path"
+Write-Host "COL02: $col02Path"
+
+# --- Open COL02 (battery) with zero-access + HidD_GetInputReport ---
+$hCol02 = $null
+if ($col02Path) {
+    $h = [TouchProbe]::CreateFile($col02Path, 0, $SHARE_RW, [IntPtr]::Zero, $OPEN_EX, 0, [IntPtr]::Zero)
+    if ($h -ne $INVALID) {
+        $pp = [IntPtr]::Zero; $caps = New-Object TouchProbe+HIDP_CAPS
+        [TouchProbe]::HidD_GetPreparsedData($h, [ref]$pp) | Out-Null
+        [TouchProbe]::HidP_GetCaps($pp, [ref]$caps) | Out-Null
+        [TouchProbe]::HidD_FreePreparsedData($pp) | Out-Null
+        $buf = [byte[]]::new($caps.InputReportByteLength)
+        $buf[0] = 0x90
+        if ([TouchProbe]::HidD_GetInputReport($h, $buf, $buf.Length)) {
+            $hex = ($buf | ForEach-Object { $_.ToString('X2') }) -join ' '
+            Write-Host "COL02 battery report: $hex"
+            Write-Host "  Battery = $($buf[2])%"
+            $log.Add("COL02 battery: $hex  (battery=$($buf[2])%)")
+        } else {
+            Write-Host "COL02 GetInputReport failed err=$([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+        }
+        [TouchProbe]::CloseHandle($h) | Out-Null
+    }
+}
+
+# --- Open COL01 (touch) --- try GENERIC_READ first, then zero-access ---
+$hCol01       = $INVALID
+$col01Access  = 'none'
+$GENERIC_READ = [uint32]0x80000000
+
+if ($col01Path) {
+    # GENERIC_READ allows ReadFile (blocking); mouhid may share the device
+    $h = [TouchProbe]::CreateFile($col01Path, $GENERIC_READ, $SHARE_RW, [IntPtr]::Zero, $OPEN_EX, 0, [IntPtr]::Zero)
+    if ($h -ne $INVALID) {
+        $hCol01 = $h; $col01Access = 'GENERIC_READ'
+        Write-Host "COL01 opened with GENERIC_READ — ReadFile loop starting"
+        Write-Host "Move your finger on the mouse surface. Ctrl+C to stop."
+    } else {
+        $err = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        Write-Host "COL01 GENERIC_READ failed err=$err — trying zero-access + HidD_GetInputReport"
+        $h = [TouchProbe]::CreateFile($col01Path, 0, $SHARE_RW, [IntPtr]::Zero, $OPEN_EX, 0, [IntPtr]::Zero)
+        if ($h -ne $INVALID) {
+            $hCol01 = $h; $col01Access = 'zero-access'
+        } else {
+            Write-Host "COL01 zero-access also failed err=$([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+        }
+    }
+}
+
+if ($hCol01 -eq $INVALID) {
+    Write-Host "COL01 not accessible — cannot read touch reports. Moving on."
+} else {
+    $pp = [IntPtr]::Zero; $caps = New-Object TouchProbe+HIDP_CAPS
+    [TouchProbe]::HidD_GetPreparsedData($hCol01, [ref]$pp) | Out-Null
+    [TouchProbe]::HidP_GetCaps($pp, [ref]$caps) | Out-Null
+    [TouchProbe]::HidD_FreePreparsedData($pp) | Out-Null
+    $reportLen = [Math]::Max([int]$caps.InputReportByteLength, 64)
+    Write-Host "COL01 InputReportByteLength=$($caps.InputReportByteLength)  reading with bufSize=$reportLen"
+
+    $seen = @{}  # deduplicate identical consecutive reports
+    $count = 0
+
+    try {
+        if ($col01Access -eq 'GENERIC_READ') {
+            # Blocking ReadFile loop — each call returns one raw HID input report
+            $buf  = [byte[]]::new($reportLen)
+            $read = [uint32]0
+            while ($true) {
+                $buf  = [byte[]]::new($reportLen)
+                $read = [uint32]0
+                $ok = [TouchProbe]::ReadFile($hCol01, $buf, [uint32]$reportLen, [ref]$read, [IntPtr]::Zero)
+                if ($ok -and $read -gt 0) {
+                    $trimmed = $buf[0..($read-1)]
+                    $hex = ($trimmed | ForEach-Object { $_.ToString('X2') }) -join ' '
+                    $rid = '0x' + $trimmed[0].ToString('X2')
+                    if ($hex -ne $seen['last']) {
+                        $seen['last'] = $hex
+                        $count++
+                        $line = "[$count] reportId=$rid  bytes=$read  $hex"
+                        Write-Host $line
+                        $log.Add($line)
+                    }
+                } else {
+                    $err = [Runtime.InteropServices.Marshal]::GetLastWin32Error()
+                    Write-Host "ReadFile failed err=$err"; break
+                }
+            }
+        } else {
+            # Zero-access: poll HidD_GetInputReport for known report IDs
+            Write-Host "Polling Report IDs 0x01, 0x12, 0x90 via HidD_GetInputReport (move finger now)..."
+            $reportIds = @(0x01, 0x12, 0x02, 0x03)
+            for ($poll = 0; $poll -lt 100; $poll++) {
+                foreach ($rid in $reportIds) {
+                    $buf = [byte[]]::new($reportLen); $buf[0] = $rid
+                    if ([TouchProbe]::HidD_GetInputReport($hCol01, $buf, $buf.Length)) {
+                        $hex = ($buf[0..15] | ForEach-Object { $_.ToString('X2') }) -join ' '
+                        if ($hex -ne $seen[$rid]) {
+                            $seen[$rid] = $hex
+                            $count++
+                            $line = "[$count] reportId=0x$($rid.ToString('X2'))  $hex ..."
+                            Write-Host $line
+                            $log.Add($line)
+                        }
+                    }
+                }
+                Start-Sleep -Milliseconds 50
+            }
+        }
+    } finally {
+        [TouchProbe]::CloseHandle($hCol01) | Out-Null
+    }
+}
+
+Write-Host ""
+Write-Host "Captured $($log.Count) unique report(s). Saving to $logPath"
+$log | Set-Content $logPath
+Write-Host "Done."

--- a/scripts/capture-hid-descriptor.ps1
+++ b/scripts/capture-hid-descriptor.ps1
@@ -1,0 +1,107 @@
+# capture-hid-descriptor.ps1
+# Captures HID report descriptors from Magic Mouse 3 (PID 0323) devices.
+# Run elevated (Admin PowerShell). If "type already exists" error appears, open a NEW PowerShell window and re-run.
+# Output: C:\Temp\mm3_desc_col01.bin, mm3_desc_col02.bin
+
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public class HidCapV2 {
+    [DllImport("hid.dll", SetLastError=true)]
+    public static extern bool HidD_GetPreparsedData(IntPtr h, out IntPtr p);
+    [DllImport("hid.dll", SetLastError=true)]
+    public static extern bool HidD_FreePreparsedData(IntPtr p);
+    [DllImport("hid.dll", SetLastError=true)]
+    public static extern int HidP_GetCaps(IntPtr p, ref HIDP_CAPS c);
+    [DllImport("setupapi.dll", CharSet=CharSet.Auto, SetLastError=true)]
+    public static extern IntPtr SetupDiGetClassDevs(ref Guid g, string e, IntPtr hw, uint f);
+    [DllImport("setupapi.dll", SetLastError=true)]
+    public static extern bool SetupDiEnumDeviceInterfaces(IntPtr s, IntPtr d, ref Guid g, uint i, ref SPDI data);
+    [DllImport("setupapi.dll", CharSet=CharSet.Auto, SetLastError=true)]
+    public static extern bool SetupDiGetDeviceInterfaceDetail(IntPtr s, ref SPDI d, IntPtr det, uint sz, ref uint req, IntPtr inf);
+    [DllImport("setupapi.dll", SetLastError=true)]
+    public static extern bool SetupDiDestroyDeviceInfoList(IntPtr s);
+    [DllImport("kernel32.dll", CharSet=CharSet.Auto, SetLastError=true)]
+    public static extern IntPtr CreateFile(string n, uint a, uint sh, IntPtr sec, uint cd, uint f, IntPtr t);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern bool CloseHandle(IntPtr h);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern bool DeviceIoControl(IntPtr dev, uint code,
+        IntPtr inBuf, uint inSz, byte[] outBuf, uint outSz, ref uint ret, IntPtr ov);
+    [StructLayout(LayoutKind.Sequential)]
+    public struct SPDI { public uint cbSize; public Guid Guid; public uint Flags; public UIntPtr Reserved; }
+    [StructLayout(LayoutKind.Sequential)]
+    public struct HIDP_CAPS {
+        public ushort Usage, UsagePage, InputReportByteLength, OutputReportByteLength, FeatureReportByteLength;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst=17)] public ushort[] Reserved;
+        public ushort NumberLinkCollectionNodes;
+        public ushort NumberInputButtonCaps, NumberInputValueCaps, NumberInputDataIndices;
+        public ushort NumberOutputButtonCaps, NumberOutputValueCaps, NumberOutputDataIndices;
+        public ushort NumberFeatureButtonCaps, NumberFeatureValueCaps, NumberFeatureDataIndices;
+    }
+}
+"@
+
+# IOCTL_HID_GET_REPORT_DESCRIPTOR = CTL_CODE(FILE_DEVICE_KEYBOARD=0xB, 0x20, METHOD_NEITHER=3, FILE_ANY_ACCESS=0)
+$IOCTL_DESC    = [uint32]0x000B0083
+$hidGuid       = [Guid]"{4d1e55b2-f16f-11cf-88cb-001111000030}"
+$INVALID       = [IntPtr](-1)
+$OPEN_EXISTING = [uint32]3
+$SHARE_RW      = [uint32]3
+
+$devs = [HidCapV2]::SetupDiGetClassDevs([ref]$hidGuid, $null, [IntPtr]::Zero, 0x12)
+if ($devs -eq $INVALID) { Write-Host "FATAL: SetupDiGetClassDevs err=$([Runtime.InteropServices.Marshal]::GetLastWin32Error())"; exit 1 }
+
+$iface        = New-Object HidCapV2+SPDI
+$iface.cbSize = [Runtime.InteropServices.Marshal]::SizeOf($iface)
+$saved = 0; $i = 0
+
+while ([HidCapV2]::SetupDiEnumDeviceInterfaces($devs, [IntPtr]::Zero, [ref]$hidGuid, $i, [ref]$iface)) {
+
+    $req = [uint32]0
+    [HidCapV2]::SetupDiGetDeviceInterfaceDetail($devs, [ref]$iface, [IntPtr]::Zero, 0, [ref]$req, [IntPtr]::Zero) | Out-Null
+    if ($req -eq 0) { $i++; continue }
+
+    $ptr       = [Runtime.InteropServices.Marshal]::AllocHGlobal([int]$req)
+    $detCbSize = if ([IntPtr]::Size -eq 8) { 8 } else { 6 }
+    [Runtime.InteropServices.Marshal]::WriteInt32($ptr, $detCbSize)
+    $ok = [HidCapV2]::SetupDiGetDeviceInterfaceDetail($devs, [ref]$iface, $ptr, $req, [ref]$req, [IntPtr]::Zero)
+    $path = if ($ok) { [Runtime.InteropServices.Marshal]::PtrToStringAuto([IntPtr]($ptr.ToInt64() + 4)) } else { '' }
+    [Runtime.InteropServices.Marshal]::FreeHGlobal($ptr)
+
+    if ($path -notmatch '0323') { $i++; continue }
+
+    $suffix = if ($path -match 'col01') { 'col01' } elseif ($path -match 'col02') { 'col02' } else { "idx$i" }
+    Write-Host "`nMM3 $suffix : $path"
+
+    $h = [HidCapV2]::CreateFile($path, 0, $SHARE_RW, [IntPtr]::Zero, $OPEN_EXISTING, 0, [IntPtr]::Zero)
+    if ($h -eq $INVALID) { Write-Host "  OPEN_FAIL err=$([Runtime.InteropServices.Marshal]::GetLastWin32Error())"; $i++; continue }
+
+    $pp = [IntPtr]::Zero; $caps = New-Object HidCapV2+HIDP_CAPS
+    if ([HidCapV2]::HidD_GetPreparsedData($h, [ref]$pp)) {
+        [HidCapV2]::HidP_GetCaps($pp, [ref]$caps) | Out-Null
+        [HidCapV2]::HidD_FreePreparsedData($pp) | Out-Null
+        Write-Host "  UsagePage=0x$($caps.UsagePage.ToString('X4'))  Usage=0x$($caps.Usage.ToString('X4'))  InputReportLen=$($caps.InputReportByteLength)"
+    }
+
+    $descSaved = $false
+    foreach ($sz in @(512, 1024, 2048, 4096)) {
+        $buf = [byte[]]::new($sz); $ret = [uint32]0
+        if ([HidCapV2]::DeviceIoControl($h, $IOCTL_DESC, [IntPtr]::Zero, 0, $buf, [uint32]$sz, [ref]$ret, [IntPtr]::Zero) -and $ret -gt 0) {
+            $out = "C:\Temp\mm3_desc_$suffix.bin"
+            [IO.File]::WriteAllBytes($out, $buf[0..($ret-1)])
+            Write-Host "  SAVED $out ($ret bytes)"
+            Write-Host "  Hex: $(($buf[0..([Math]::Min(31,$ret-1))] | ForEach-Object { $_.ToString('X2') }) -join ' ')"
+            $saved++; $descSaved = $true; break
+        }
+    }
+    if (-not $descSaved) {
+        Write-Host "  DESC_FAIL err=$([Runtime.InteropServices.Marshal]::GetLastWin32Error())"
+    }
+
+    [HidCapV2]::CloseHandle($h) | Out-Null
+    $i++
+}
+
+[HidCapV2]::SetupDiDestroyDeviceInfoList($devs) | Out-Null
+Write-Host "`nDone. $saved descriptor(s) saved."

--- a/scripts/capture-state.ps1
+++ b/scripts/capture-state.ps1
@@ -1,0 +1,182 @@
+# capture-state.ps1 — Snapshot Magic Mouse device state for reboot comparison
+# Run before a reboot, then again after, then compare.
+#
+# Usage:
+#   .\capture-state.ps1 -Label "pre-reboot"         -> saves state-pre-reboot.json
+#   .\capture-state.ps1 -Label "post-reboot-1"      -> saves state-post-reboot-1.json
+#   .\capture-state.ps1 -Compare .\state-pre-reboot.json .\state-post-reboot-1.json
+#
+# Saved to current directory unless -OutputDir is specified.
+# Run elevated (some queries need admin for sc.exe and registry reads).
+
+param(
+    [string]$Label = "",
+    [switch]$Compare,
+    [string]$FileA = "",
+    [string]$FileB = "",
+    [string]$OutputDir = "."
+)
+
+Set-StrictMode -Version 2
+
+# ---- Compare mode ----
+if ($Compare) {
+    if (-not $FileA -or -not $FileB) {
+        # Try positional args if Compare was used with positional params
+        $args2 = $args
+        Write-Host "Usage: capture-state.ps1 -Compare <fileA.json> <fileB.json>" -ForegroundColor Yellow
+        exit 1
+    }
+
+    $a = Get-Content $FileA -Raw | ConvertFrom-Json
+    $b = Get-Content $FileB -Raw | ConvertFrom-Json
+
+    Write-Host ""
+    Write-Host "=== STATE COMPARISON ===" -ForegroundColor Cyan
+    Write-Host "  A: $($a.label)  [$($a.timestamp)]"
+    Write-Host "  B: $($b.label)  [$($b.timestamp)]"
+    Write-Host ""
+
+    function Diff-Field {
+        param($Name, $ValA, $ValB, [switch]$GoodIfTrue, [switch]$GoodIfEqual)
+        $changed = ($ValA -ne $ValB) -and ($null -ne $ValA) -and ($null -ne $ValB)
+        if ($changed) {
+            $color = "Yellow"
+            if ($GoodIfTrue  -and $ValB) { $color = "Green" }
+            if ($GoodIfTrue  -and !$ValB) { $color = "Red" }
+            if ($GoodIfEqual) { $color = "Yellow" }
+            Write-Host "  CHANGED  $Name" -ForegroundColor $color
+            Write-Host "           A: $ValA"
+            Write-Host "           B: $ValB"
+        } else {
+            Write-Host "  same     $Name = $ValA"
+        }
+    }
+
+    Diff-Field "col01Present"           $a.col01Present          $b.col01Present          -GoodIfTrue
+    Diff-Field "col02Present"           $a.col02Present          $b.col02Present          -GoodIfTrue
+    Diff-Field "filterInStack"          $a.filterInStack         $b.filterInStack
+    Diff-Field "lowerFiltersEnumKey"    ($a.lowerFiltersEnumKey  -join ',') ($b.lowerFiltersEnumKey  -join ',') -GoodIfEqual
+    Diff-Field "lowerFiltersDriverKey"  ($a.lowerFiltersDriverKey -join ',') ($b.lowerFiltersDriverKey -join ',') -GoodIfEqual
+    Diff-Field "serviceState"           $a.serviceState          $b.serviceState
+    Diff-Field "hidDeviceCount"         $a.hidDeviceCount        $b.hidDeviceCount        -GoodIfTrue
+
+    Write-Host ""
+    Write-Host "=== STARTUP-REPAIR LOG (B only — last 10 lines) ===" -ForegroundColor Cyan
+    if ($b.startupRepairLog) {
+        $b.startupRepairLog | Select-Object -Last 10 | ForEach-Object { Write-Host "  $_" }
+    } else {
+        Write-Host "  (no log data in B)"
+    }
+    Write-Host ""
+    exit 0
+}
+
+# ---- Capture mode ----
+if (-not $Label) {
+    $Label = "capture-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
+    Write-Host "No -Label specified, using: $Label" -ForegroundColor Yellow
+}
+
+$mmPid = "0323"
+$state = [ordered]@{
+    label              = $Label
+    timestamp          = (Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+    col01Present       = $false
+    col02Present       = $false
+    filterInStack      = $false
+    hidDeviceCount     = 0
+    hidDevices         = @()
+    bthenumInstanceId  = ""
+    lowerFiltersEnumKey    = @()
+    lowerFiltersDriverKey  = @()
+    serviceState       = ""
+    startupRepairLog   = @()
+}
+
+# Find BTHENUM parent
+$btDev = Get-PnpDevice -ErrorAction SilentlyContinue |
+    Where-Object { $_.InstanceId -match 'BTHENUM' -and
+                   $_.InstanceId -match '00001124' -and
+                   $_.InstanceId -match "_PID&$mmPid" -and
+                   $_.Status -eq 'OK' } |
+    Select-Object -First 1
+
+if ($btDev) {
+    $state.bthenumInstanceId = $btDev.InstanceId
+
+    # Driver stack
+    try {
+        $stackProp = Get-PnpDeviceProperty -InstanceId $btDev.InstanceId `
+            -KeyName 'DEVPKEY_Device_Stack' -ErrorAction SilentlyContinue
+        if ($stackProp -and $stackProp.Data) {
+            $stackStr = $stackProp.Data -join ' '
+            $state.filterInStack = $stackStr -imatch 'applewirelessmouse'
+        }
+    } catch {}
+
+    # LowerFilters — Enum key
+    $btRegPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\" + $btDev.InstanceId
+    try {
+        $lf = (Get-ItemProperty -Path $btRegPath -Name LowerFilters -ErrorAction SilentlyContinue).LowerFilters
+        if ($lf) { $state.lowerFiltersEnumKey = @($lf) }
+    } catch {}
+
+    # LowerFilters — driver instance key
+    try {
+        $driverKey = (Get-ItemProperty -Path $btRegPath -Name Driver -ErrorAction SilentlyContinue).Driver
+        if ($driverKey) {
+            $driverInstPath = "HKLM:\SYSTEM\CurrentControlSet\Control\Class\$driverKey"
+            $lf2 = (Get-ItemProperty -Path $driverInstPath -Name LowerFilters -ErrorAction SilentlyContinue).LowerFilters
+            if ($lf2) { $state.lowerFiltersDriverKey = @($lf2) }
+        }
+    } catch {}
+}
+
+# HID devices with this PID
+$hidDevices = Get-PnpDevice -ErrorAction SilentlyContinue |
+    Where-Object { $_.InstanceId -match $mmPid -and $_.Status -eq 'OK' }
+$hidList = @($hidDevices)
+$state.hidDeviceCount = $hidList.Count
+$state.hidDevices     = $hidList | ForEach-Object { @{ instanceId = $_.InstanceId; status = $_.Status } }
+$state.col01Present   = ($hidList | Where-Object { $_.InstanceId -match 'COL01' }).Count -gt 0
+$state.col02Present   = ($hidList | Where-Object { $_.InstanceId -match 'COL02' }).Count -gt 0
+
+# Service state
+try {
+    $scOut = & sc.exe query applewirelessmouse 2>&1
+    $state.serviceState = ($scOut | Where-Object { $_ -match 'STATE' } | Select-Object -First 1).Trim()
+} catch {}
+
+# startup-repair.log
+$logFile = "C:\ProgramData\MagicMouseTray\startup-repair.log"
+if (Test-Path $logFile) {
+    $state.startupRepairLog = @(Get-Content $logFile -Tail 20)
+}
+
+# Save JSON
+$outFile = Join-Path $OutputDir "state-$Label.json"
+$state | ConvertTo-Json -Depth 5 | Set-Content $outFile -Encoding UTF8
+
+# Print summary
+Write-Host ""
+Write-Host "=== STATE CAPTURED: $Label ===" -ForegroundColor Cyan
+Write-Host "  Timestamp:      $($state.timestamp)"
+Write-Host "  COL01 (scroll): $($state.col01Present)" -ForegroundColor $(if ($state.col01Present) {"Green"} else {"Red"})
+Write-Host "  COL02 (battery):$($state.col02Present)" -ForegroundColor $(if ($state.col02Present) {"Green"} else {"Red"})
+Write-Host "  Filter in stack:$($state.filterInStack)"
+Write-Host "  LowerFilters(Enum):   $($state.lowerFiltersEnumKey -join ', ')"
+Write-Host "  LowerFilters(Driver): $($state.lowerFiltersDriverKey -join ', ')"
+Write-Host "  Service state:  $($state.serviceState)"
+Write-Host "  HID device count: $($state.hidDeviceCount)"
+if ($state.startupRepairLog.Count -gt 0) {
+    Write-Host "  Last log entry: $($state.startupRepairLog | Select-Object -Last 1)"
+}
+Write-Host ""
+Write-Host "Saved: $outFile" -ForegroundColor Green
+Write-Host ""
+Write-Host "Workflow:" -ForegroundColor Yellow
+Write-Host "  1. Run this NOW (before reboot):  capture-state.ps1 -Label pre-reboot"
+Write-Host "  2. Reboot"
+Write-Host "  3. Run after boot:                capture-state.ps1 -Label post-reboot-1"
+Write-Host "  4. Compare:                       capture-state.ps1 -Compare .\state-pre-reboot.json .\state-post-reboot-1.json"

--- a/scripts/test-filter-stack.ps1
+++ b/scripts/test-filter-stack.ps1
@@ -1,0 +1,173 @@
+#Requires -RunAsAdministrator
+# test-filter-stack.ps1
+# Tests whether applewirelessmouse loads into the BTHENUM device stack
+# and whether COL02 (battery) survives with the filter active.
+# If COL02 is stripped, runs &6& recovery automatically.
+#
+# Usage:
+#   .\test-filter-stack.ps1           # live run
+#   .\test-filter-stack.ps1 -DryRun   # read-only preview, no changes
+
+param(
+    [switch]$DryRun
+)
+
+if ($DryRun) {
+    Write-Host "*** DRY RUN — no changes will be made ***" -ForegroundColor Magenta
+    Write-Host ""
+}
+
+$bthenumId  = 'BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&0001004C_PID&0323\9&73B8B28&0&D0C050CC8C4D_C00000000'
+$bthenumKey = "HKLM:\SYSTEM\CurrentControlSet\Enum\$bthenumId"
+
+function Get-MouseDevices {
+    Get-PnpDevice | Where-Object { $_.InstanceId -match '0323' -and $_.Status -eq 'OK' } |
+        Select-Object Status, InstanceId
+}
+
+function Has-COL02 {
+    $null -ne (Get-PnpDevice | Where-Object {
+        $_.InstanceId -match '0323' -and
+        $_.InstanceId -match 'COL02' -and
+        $_.Status -eq 'OK'
+    })
+}
+
+# ─────────────────────────────────────────────────────────────
+# PHASE 0 — Baseline
+# ─────────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "=== PHASE 0: BASELINE ===" -ForegroundColor Cyan
+Write-Host "Devices before test:"
+Get-MouseDevices | Format-Table -AutoSize
+$col02Before = Has-COL02
+Write-Host "COL02 present: $col02Before"
+Write-Host ""
+
+if (-not $col02Before) {
+    Write-Host "WARNING: COL02 already missing before test. Aborting." -ForegroundColor Yellow
+    exit 1
+}
+
+# ─────────────────────────────────────────────────────────────
+# PHASE 1 — Cycle BTHENUM with filter in LowerFilters
+# Forces fresh device stack construction — PnP reads Enum key
+# LowerFilters and loads applewirelessmouse during AddDevice.
+# ─────────────────────────────────────────────────────────────
+Write-Host "=== PHASE 1: CYCLE BTHENUM (filter active) ===" -ForegroundColor Cyan
+Write-Host "Disabling BTHENUM device..."
+if ($DryRun) { Write-Host "  [DRY RUN] pnputil /disable-device $bthenumId" -ForegroundColor Magenta }
+else { pnputil /disable-device "$bthenumId"; Start-Sleep -Seconds 2 }
+Write-Host "Enabling BTHENUM device..."
+if ($DryRun) { Write-Host "  [DRY RUN] pnputil /enable-device $bthenumId" -ForegroundColor Magenta }
+else { pnputil /enable-device "$bthenumId"; Start-Sleep -Seconds 10 }
+
+# ─────────────────────────────────────────────────────────────
+# PHASE 2 — Check results
+# ─────────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "=== PHASE 2: RESULTS ===" -ForegroundColor Cyan
+
+Write-Host "Device stack after cycle:"
+(Get-PnpDeviceProperty -InstanceId $bthenumId -KeyName DEVPKEY_Device_Stack).Data
+
+Write-Host ""
+Write-Host "Devices after cycle:"
+Get-MouseDevices | Format-Table -AutoSize
+
+$col02After = Has-COL02
+if ($DryRun) {
+    Write-Host "  [DRY RUN] Would check DEVPKEY_Device_Stack for \Driver\applewirelessmouse" -ForegroundColor Magenta
+    Write-Host "  [DRY RUN] Would check COL02 presence"  -ForegroundColor Magenta
+    Write-Host ""
+    Write-Host "Current (unchanged) device stack:"
+    (Get-PnpDeviceProperty -InstanceId $bthenumId -KeyName DEVPKEY_Device_Stack).Data
+    Write-Host "Current devices:"
+    Get-MouseDevices | Format-Table -AutoSize
+    Write-Host "Dry run complete. No changes made." -ForegroundColor Magenta
+    exit 0
+}
+$filterInStack = (Get-PnpDeviceProperty -InstanceId $bthenumId -KeyName DEVPKEY_Device_Stack).Data -contains '\Driver\applewirelessmouse'
+
+Write-Host "Filter in stack: $filterInStack"
+Write-Host "COL02 present:   $col02After"
+Write-Host ""
+
+# ─────────────────────────────────────────────────────────────
+# PHASE 3 — Outcome
+# ─────────────────────────────────────────────────────────────
+Write-Host "=== PHASE 3: OUTCOME ===" -ForegroundColor Cyan
+
+if ($filterInStack -and $col02After) {
+    Write-Host "SUCCESS: Filter in stack AND COL02 present." -ForegroundColor Green
+    Write-Host "Scroll and battery should both work."
+    Write-Host "Reboot to confirm both survive across a reboot."
+    exit 0
+}
+
+if ($filterInStack -and -not $col02After) {
+    Write-Host "PARTIAL: Filter loaded (scroll works) but COL02 was stripped (battery broken)." -ForegroundColor Yellow
+    Write-Host "Driver still modifies descriptor. Running &6& recovery to restore COL02..."
+    Write-Host ""
+}
+
+if (-not $filterInStack) {
+    Write-Host "FAIL: Filter did not load into device stack." -ForegroundColor Red
+    Write-Host "sc query result:"
+    sc query applewirelessmouse
+    exit 1
+}
+
+# ─────────────────────────────────────────────────────────────
+# PHASE 4 — &6& Recovery (only runs if COL02 was stripped)
+# ─────────────────────────────────────────────────────────────
+Write-Host "=== PHASE 4: &6& RECOVERY ===" -ForegroundColor Cyan
+
+Write-Host "Step 4.1 — Removing LowerFilters from Enum key (registry only)..."
+if ($DryRun) { Write-Host "  [DRY RUN] Remove-ItemProperty $bthenumKey LowerFilters" -ForegroundColor Magenta }
+else { Remove-ItemProperty -Path $bthenumKey -Name LowerFilters -ErrorAction SilentlyContinue }
+
+Write-Host "Step 4.2 — Cycling BTHENUM without filter (creates COL01+COL02)..."
+if ($DryRun) {
+    Write-Host "  [DRY RUN] pnputil /disable-device $bthenumId" -ForegroundColor Magenta
+    Write-Host "  [DRY RUN] pnputil /enable-device $bthenumId" -ForegroundColor Magenta
+} else {
+    pnputil /disable-device "$bthenumId"
+    Start-Sleep -Seconds 2
+    pnputil /enable-device "$bthenumId"
+}
+
+Write-Host "Step 4.3 — Waiting for COL02 to appear (up to 30s)..."
+$waited = 0
+while (-not (Has-COL02) -and $waited -lt 30) {
+    Start-Sleep -Seconds 3
+    $waited += 3
+}
+
+if (Has-COL02) {
+    Write-Host "COL02 restored." -ForegroundColor Green
+} else {
+    Write-Host "ERROR: COL02 did not appear after 30s. Manual intervention required." -ForegroundColor Red
+    exit 1
+}
+
+Write-Host "Step 4.4 — Restoring LowerFilters to Enum key (no device restart)..."
+if ($DryRun) { Write-Host "  [DRY RUN] Set-ItemProperty $bthenumKey LowerFilters = applewirelessmouse" -ForegroundColor Magenta }
+else { Set-ItemProperty -Path $bthenumKey -Name LowerFilters -Value @('applewirelessmouse') -Type MultiString }
+
+Write-Host "Step 4.5 — Restoring LowerFilters to driver instance key..."
+$driverKey = (Get-ItemProperty $bthenumKey).Driver
+if ($DryRun) { Write-Host "  [DRY RUN] Set-ItemProperty HKLM:\...\Control\Class\$driverKey LowerFilters = applewirelessmouse" -ForegroundColor Magenta }
+else {
+    Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Class\$driverKey" `
+        -Name LowerFilters -Value @('applewirelessmouse') -Type MultiString
+}
+
+Write-Host ""
+Write-Host "=== RECOVERY COMPLETE ===" -ForegroundColor Cyan
+Write-Host "Final device state:"
+Get-MouseDevices | Format-Table -AutoSize
+Write-Host ""
+Write-Host "COL02 restored. Battery works. Scroll still broken (driver strips descriptor)." -ForegroundColor Yellow
+Write-Host "Do NOT reboot or run pnputil again — just close this window."
+Write-Host "Next step: KMDF function driver."

--- a/startup-repair.ps1
+++ b/startup-repair.ps1
@@ -1,14 +1,20 @@
-# startup-repair.ps1 — MagicMouseTray COL02 Battery Collection Repair
+# startup-repair.ps1 - MagicMouseTray COL02 Battery Collection Repair
 # SPDX-License-Identifier: MIT
 #
 # Runs at startup via Windows Scheduled Task (SYSTEM account, 30s delay).
-# Detects whether COL02 (battery HID collection) is missing — this happens every
-# reboot when applewirelessmouse is in LowerFilters, because the filter modifies
-# the HID descriptor during fresh BTHENUM enumeration and strips the battery
-# collection. If missing, cycles the BTHENUM parent to restore COL01+COL02.
+# Detects whether COL02 (battery HID collection) is missing. COL02 persists
+# through normal reboots; it only goes missing after a fresh device re-enumeration
+# (unpair/re-pair, or a previous buggy startup-repair run that called /restart-device).
+# If missing, cycles BTHENUM without the filter to create COL01+COL02, then restores
+# the filter to both registry locations (Enum key + driver instance key).
+#
+# CRITICAL: Do NOT call pnputil /restart-device after restoring LowerFilters.
+# /restart-device triggers descriptor re-processing with the filter active, which
+# strips COL02 again. The filter loads correctly at the next reboot via the driver
+# instance key — no forced restart is needed.
 #
 # Usage (manual): powershell -ExecutionPolicy Bypass -File startup-repair.ps1
-# Usage (scheduled task): registered by install-driver.ps1 — runs automatically.
+# Usage (scheduled task): registered by install-driver.ps1 - runs automatically.
 
 param(
     [string]$LogFile = "C:\ProgramData\MagicMouseTray\startup-repair.log",
@@ -22,6 +28,12 @@ function Write-Log {
     param([string]$Msg)
     $line = "[$(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')] $Msg"
     Add-Content -Path $LogFile -Value $line -Encoding UTF8
+}
+
+# PS5-compatible pnputil output helper - Out-String -NoNewline is PS6+ only
+function Get-PnpOutput {
+    param([string[]]$Lines)
+    return ($Lines | Select-Object -Last 2 | Out-String).TrimEnd()
 }
 
 # ---- bootstrap ----
@@ -44,33 +56,36 @@ $knownPids = @("0323", "030d", "0269", "0310")
 
 $anyRepaired = $false
 
-foreach ($pid in $knownPids) {
-    # Find BTHENUM parent device for this Magic Mouse pairing
+foreach ($mmPid in $knownPids) {
+    # Find BTHENUM parent device for this Magic Mouse pairing.
+    # Must match HID service UUID {00001124} - not PnP Info {00001200} or other profiles.
     $btDevice = Get-PnpDevice -ErrorAction SilentlyContinue |
         Where-Object { $_.InstanceId -match "BTHENUM" -and
-                       $_.InstanceId -match "_PID&$pid" -and
+                       $_.InstanceId -match "00001124" -and
+                       $_.InstanceId -match "_PID&$mmPid" -and
                        $_.Status -eq 'OK' } |
         Select-Object -First 1
 
     if (-not $btDevice) {
-        continue  # PID not paired — normal, skip silently
+        continue  # PID not paired - normal, skip silently
     }
 
-    Write-Log "PID 0x$($pid.ToUpper()): BTHENUM = $($btDevice.InstanceId)"
+    Write-Log "PID 0x$($mmPid.ToUpper()): BTHENUM = $($btDevice.InstanceId)"
 
     # COL02 exists when there are 2+ HID-class child devices with this PID and Status OK.
     # One collapsed device (filter stripped COL02) = Count 1. Healthy = Count 2+.
     $hidDevices = Get-PnpDevice -ErrorAction SilentlyContinue |
         Where-Object { $_.Class -eq 'HIDClass' -and
-                       $_.InstanceId -match $pid -and
+                       $_.InstanceId -match $mmPid -and
                        $_.Status -eq 'OK' }
 
-    if ($hidDevices.Count -ge 2) {
-        Write-Log "PID 0x$($pid.ToUpper()): COL02 present ($($hidDevices.Count) HID device(s)) — no repair needed"
+    $hidCount = @($hidDevices).Count   # @() wraps $null -> 0 in PS5
+    if ($hidCount -ge 2) {
+        Write-Log "PID 0x$($mmPid.ToUpper()): COL02 present ($hidCount HID device(s)) - no repair needed"
         continue
     }
 
-    Write-Log "PID 0x$($pid.ToUpper()): COL02 missing ($($hidDevices.Count) HID device(s)) — starting repair"
+    Write-Log "PID 0x$($mmPid.ToUpper()): COL02 missing ($hidCount HID device(s)) - starting repair"
 
     $btRegPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\" + $btDevice.InstanceId
 
@@ -82,13 +97,13 @@ foreach ($pid in $knownPids) {
     # Read current LowerFilters (need to restore after cycling)
     $lowerFilters = (Get-ItemProperty -Path $btRegPath -Name LowerFilters -ErrorAction SilentlyContinue).LowerFilters
     if (-not ($lowerFilters -contains 'applewirelessmouse')) {
-        Write-Log "PID 0x$($pid.ToUpper()): applewirelessmouse not in LowerFilters — no filter conflict, skipping"
+        Write-Log "PID 0x$($mmPid.ToUpper()): applewirelessmouse not in LowerFilters - no filter conflict, skipping"
         continue
     }
 
     Write-Log "LowerFilters = $($lowerFilters -join ', ')"
 
-    # Repair: remove filter → cycle BTHENUM → restore filter
+    # Repair: remove filter -> cycle BTHENUM -> restore filter
     # Cycling BTHENUM forces a fresh HID descriptor negotiation without the filter,
     # creating COL01 (scroll) and COL02 (battery) as separate child devices.
     # Re-adding the filter afterward adds scroll support to COL01 without collapsing COL02.
@@ -98,36 +113,61 @@ foreach ($pid in $knownPids) {
 
         Write-Log "Step 2: disabling BTHENUM device..."
         $out = pnputil /disable-device "$($btDevice.InstanceId)" 2>&1
-        Write-Log "  $($out | Select-Object -Last 2 | Out-String -NoNewline)"
+        Write-Log "  $(Get-PnpOutput $out)"
 
         Start-Sleep -Milliseconds 500
 
         Write-Log "Step 3: enabling BTHENUM device..."
         $out = pnputil /enable-device "$($btDevice.InstanceId)" 2>&1
-        Write-Log "  $($out | Select-Object -Last 2 | Out-String -NoNewline)"
+        Write-Log "  $(Get-PnpOutput $out)"
 
         Start-Sleep -Seconds $SettleSeconds
 
-        Write-Log "Step 4: restoring LowerFilters..."
+        # Step 4a: restore LowerFilters to the Enum key (instance-level)
+        Write-Log "Step 4a: restoring LowerFilters to Enum key (no device restart)..."
         Set-ItemProperty -Path $btRegPath -Name LowerFilters -Value $lowerFilters -Type MultiString -ErrorAction Stop
 
-        # Verify
+        # Step 4b: also write to the driver instance key — PnP reads from here during
+        # device stack construction at boot. Without this, the filter gets error 1077
+        # (SERVICE_NEVER_STARTED) because PnP never finds LowerFilters in the canonical location.
+        $driverKey = (Get-ItemProperty -Path $btRegPath -Name Driver -ErrorAction SilentlyContinue).Driver
+        if ($driverKey) {
+            $driverInstPath = "HKLM:\SYSTEM\CurrentControlSet\Control\Class\$driverKey"
+            if (Test-Path $driverInstPath) {
+                Set-ItemProperty -Path $driverInstPath -Name LowerFilters -Value $lowerFilters -Type MultiString -ErrorAction SilentlyContinue
+                Write-Log "Step 4b: driver instance key updated ($driverInstPath)"
+            } else {
+                Write-Log "Step 4b: WARNING - driver instance key not found: $driverInstPath"
+            }
+        } else {
+            Write-Log "Step 4b: WARNING - Driver value not found in $btRegPath"
+        }
+
+        # No Step 5. Do NOT call pnputil /restart-device here — it triggers HID descriptor
+        # re-processing with the filter active, which strips COL02 again. The filter will
+        # load into the stack at the next reboot via the driver instance key set above.
+
+        # Verify COL02 is present (should be — we just cycled without filter)
         Start-Sleep -Seconds 1
         $hidAfter = Get-PnpDevice -ErrorAction SilentlyContinue |
             Where-Object { $_.Class -eq 'HIDClass' -and
-                           $_.InstanceId -match $pid -and
+                           $_.InstanceId -match $mmPid -and
                            $_.Status -eq 'OK' }
+        $hidAfterCount = @($hidAfter).Count
 
-        if ($hidAfter.Count -ge 2) {
-            Write-Log "REPAIRED: COL02 present ($($hidAfter.Count) HID device(s)) — battery reading restored"
+        if ($hidAfterCount -ge 2) {
+            Write-Log "REPAIRED: COL02 present ($hidAfterCount HID device(s)). Battery restored. Scroll loads at next reboot."
             $anyRepaired = $true
         } else {
-            Write-Log "WARNING: repair attempted — COL02 still not visible ($($hidAfter.Count) HID device(s))"
+            Write-Log "WARNING: repair attempted - COL02 still not visible ($hidAfterCount HID device(s))"
         }
 
     } catch {
         Write-Log "ERROR during repair: $($_.Exception.Message)"
-        # Attempt to restore LowerFilters on error
+        # Re-enable device in case we failed after Step 2 (disable) but before Step 3 (enable)
+        $reEnableOut = pnputil /enable-device "$($btDevice.InstanceId)" 2>&1
+        Write-Log "  recovery re-enable: $(Get-PnpOutput $reEnableOut)"
+        # Restore LowerFilters
         try {
             Set-ItemProperty -Path $btRegPath -Name LowerFilters -Value $lowerFilters -Type MultiString
             Write-Log "LowerFilters restored after error"


### PR DESCRIPTION
## Summary
- KMDF-PLAN.md: Apple INF analysis added — confirms error 1077 root cause structurally, documents function driver INF design (SPSVCINST_ASSOCSERVICE, no HidBth, same hardware IDs), rules out .sys modification
- PSN-0001: Session 6 entry added, next-step brief updated to PRD #184 M12 driver dev tasks, sessions_logged → 6

## Test plan
- [ ] KMDF-PLAN.md contains Apple INF Analysis section
- [ ] PSN-0001 sessions_logged = 6, session 6 row present
- [ ] No changes to main branch (all work in worktree)
