### PR TITLE
feat(m13): binary patch applewirelessmouse.sys — descriptor 0xA850 + PATCH-APPLE-SYS route

### DIFF
--- a/docs/M13-V3-BINARY-PATCH-APPLE-SYS-2026-04-29.md
+++ b/docs/M13-V3-BINARY-PATCH-APPLE-SYS-2026-04-29.md
@@ -1,0 +1,117 @@
+# M13 Binary Patch: applewirelessmouse.sys — Session 2026-04-29
+
+## TL;DR
+
+Patched `applewirelessmouse.sys` at offset `0xA850` (116-byte embedded HID descriptor) to add
+Vendor Battery TLC (RID=0x90) alongside the existing Mouse TLC (RID=0x02). Signed with
+MagicMouseFix cert. Staged to `C:\Windows\System32\drivers\applewirelessmouse.sys.new` with
+`PendingFileRenameOperations` queued. **Reboot required to apply.**
+
+---
+
+## Background
+
+Track 1 (confirmed 2026-04-29): Battery reads at cold boot via Apple stock filter. COL02
+(RID=0x90) appears after reboot when BTHPORT cache is populated with Descriptor A. `applewireless
+mouse.sys` intercepts IOCTL `0x410210` (SDP attribute 0x0206 — HIDDescriptorList) and injects a
+single-TLC Mouse-only descriptor, stripping COL02/battery.
+
+**Goal**: Instead of replacing the Apple driver with M13 KMDF driver, patch the descriptor
+embedded in `applewirelessmouse.sys` at offset `0xA850` to include both TLCs.
+
+---
+
+## Descriptor Layout at 0xA850
+
+Original: 116 bytes — Mouse TLC (RID=0x02) + phantom Feature 0x47 + RID=0x27 input.
+
+Patched: 116 bytes (same size, no length field changes needed):
+- **TLC1** (81 bytes): Mouse RID=0x02 — 5 buttons + X/Y + AC Pan + Wheel
+- **TLC2** (35 bytes): Vendor Battery RID=0x90 (flags + battery%) + dummy Feature RID=0x91 (10-byte padding)
+
+Key offsets within the 116-byte block:
+| Offset | Value | Meaning |
+|--------|-------|---------|
+| +7     | 0x02  | RID for TLC1 (Mouse) |
+| +80    | 0xC0  | End Collection (end of TLC1) |
+| +81    | 0x06  | Start of TLC2 (UsagePage vendor) |
+| +89    | 0x90  | RID for TLC2 (Battery) |
+
+---
+
+## Signing Behavior
+
+Original `applewirelessmouse.sys`: **78424 bytes** (includes Apple's ~12KB PE authenticode cert).
+
+After `signtool sign` with MagicMouseFix cert: **66288 bytes**. Signtool replaces the entire
+certificate table. Apple's large cert is removed; our smaller self-signed cert is added. This is
+expected — the cert is a PE overlay, not part of any section. The data section containing offset
+`0xA850` is unaffected.
+
+Verified: `data[0xA850+7] == 0x02`, `data[0xA850+89] == 0x90` in the signed binary.
+
+---
+
+## Installation Method: PendingFileRenameOperations
+
+The SYS file is locked by the kernel driver while Windows is running. Even disabling the BTHENUM
+device does not unload the module from kernel memory. Solution: queue a boot-time rename.
+
+**Staged file**: `C:\Windows\System32\drivers\applewirelessmouse.sys.new`
+**Registry entry**: `HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\PendingFileRenameOperations`
+```
+\??\C:\Windows\System32\drivers\applewirelessmouse.sys.new  →  \??\C:\Windows\System32\drivers\applewirelessmouse.sys
+```
+
+SMSS.exe processes this before any drivers load on the next boot.
+
+---
+
+## PATCH-APPLE-SYS Task Runner Route
+
+Added to `mm-task-runner.ps1`:
+
+```
+PATCH-APPLE-SYS|<nonce>|<patched-sys-path>
+```
+
+1. Finds BTHENUM HID device instance ID (regex `{00001124...}...004c...0323`)
+2. Copies patched sys to `applewirelessmouse.sys.new` in System32\drivers
+3. Queues `PendingFileRenameOperations` for atomic boot-time replace
+4. Returns 0 on success; log at `C:\mm-dev-queue\patch-apple-<nonce>.log`
+
+Also used: existing `SIGN-FILE|<nonce>|<file-path>|<thumbprint>` route (uses `/sm /sha1` against
+`LocalMachine\My`).
+
+---
+
+## Current State (2026-04-29)
+
+| Item | State |
+|------|-------|
+| Backup (original) | `D:\Backups\AppleWirelessMouse-RECOVERY\AppleWirelessMouse.sys` — 78424 bytes |
+| Patched + signed | `D:\Backups\AppleWirelessMouse-RECOVERY\AppleWirelessMouse-patched.sys` — 66288 bytes |
+| Staged | `C:\Windows\System32\drivers\applewirelessmouse.sys.new` — 66288 bytes ✅ |
+| PendingFileRenameOperations | Queued ✅ |
+| **Action required** | **Reboot Windows** |
+
+---
+
+## Post-Reboot Verification
+
+After reboot, run `mm-accept-test.sh` (or `mm-accept-test.ps1`). Key checks:
+
+1. `applewirelessmouse.sys` file size = 66288 bytes (confirms rename applied)
+2. COL02 device shows as Started in Device Manager
+3. `HidD_GetInputReport(0x90)` returns 0-100% battery
+4. Scroll (AC Pan + Wheel) working on COL01
+
+---
+
+## Rollback
+
+If the patched driver causes issues:
+1. Boot into Safe Mode
+2. Replace `C:\Windows\System32\drivers\applewirelessmouse.sys` with
+   `D:\Backups\AppleWirelessMouse-RECOVERY\AppleWirelessMouse.sys`
+3. Or use the `ROLLBACK-M12` task runner route (reinstalls from Apple INF backup)

--- a/scripts/mm-task-runner.ps1
+++ b/scripts/mm-task-runner.ps1
@@ -262,6 +262,55 @@ try {
         }
         Log "UNINSTALL-DRIVER exited $rc; log at $unLog"
     }
+    # CLEAR-BT-SDP-CACHE: delete CachedServices/DynamicCachedServices for a BT MAC.
+    # Format: CLEAR-BT-SDP-CACHE|<nonce>|<MAC-12-hex-no-colons>
+    elseif ($phase -eq 'CLEAR-BT-SDP-CACHE') {
+        $mac = if ($parts.Count -gt 2) { $parts[2].Trim() } else { '' }
+        $cbLog = Join-Path $QueueDir "bthcache-$nonce.log"
+        if (-not $mac) {
+            "ERROR: MAC required" | Set-Content $cbLog -Encoding ASCII
+            $rc = 2
+        } else {
+            try {
+                $base = "HKLM:\SYSTEM\CurrentControlSet\Services\BTHPORT\Parameters\Devices\$mac"
+                "=== clearing $base CachedServices + DynamicCachedServices ===" | Set-Content $cbLog -Encoding ASCII
+                foreach ($sub in 'CachedServices','DynamicCachedServices') {
+                    $p = "$base\$sub"
+                    if (Test-Path $p) {
+                        Remove-Item -Path $p -Recurse -Force -ErrorAction Stop
+                        "removed $p" | Add-Content $cbLog -Encoding ASCII
+                    } else {
+                        "$p not present" | Add-Content $cbLog -Encoding ASCII
+                    }
+                }
+                $rc = 0
+            } catch {
+                "Exception: $_" | Add-Content $cbLog -Encoding ASCII
+                $rc = 99
+            }
+        }
+        Log "CLEAR-BT-SDP-CACHE exited $rc; log at $cbLog"
+    }
+    # RESTART-DEVICE: pnputil /restart-device <instanceId> (requires SYSTEM/admin)
+    elseif ($phase -eq 'RESTART-DEVICE') {
+        $iid = if ($parts.Count -gt 2) { $parts[2..($parts.Count-1)] -join '|' } else { '' }
+        $rdLog = Join-Path $QueueDir "restart-$nonce.log"
+        if (-not $iid) {
+            "ERROR: instance ID required" | Set-Content $rdLog -Encoding ASCII
+            $rc = 2
+        } else {
+            try {
+                "=== pnputil /restart-device $iid ===" | Set-Content $rdLog -Encoding ASCII
+                & pnputil /restart-device $iid 2>&1 | Add-Content $rdLog -Encoding ASCII
+                $rc = $LASTEXITCODE
+                if ($null -eq $rc) { $rc = 0 }
+            } catch {
+                "Exception: $_" | Add-Content $rdLog -Encoding ASCII
+                $rc = 99
+            }
+        }
+        Log "RESTART-DEVICE exited $rc; log at $rdLog"
+    }
     # SIGN-FILE: signtool sign /sm /sha1 ... /fd sha256 /tr ... /td sha256 <file>
     # Format: SIGN-FILE|<nonce>|<file-path>|<thumbprint>
     elseif ($phase -eq 'SIGN-FILE') {
@@ -284,6 +333,68 @@ try {
             }
         }
         Log "SIGN-FILE exited $rc; log at $sfLog"
+    }
+    # PATCH-APPLE-SYS: stop service, copy patched .sys to System32\drivers, restart device.
+    # Format: PATCH-APPLE-SYS|<nonce>|<patched-sys-path>
+    elseif ($phase -eq 'PATCH-APPLE-SYS') {
+        $src   = if ($parts.Count -gt 2) { $parts[2].Trim() } else { '' }
+        $dest  = 'C:\Windows\System32\drivers\applewirelessmouse.sys'
+        $btId  = 'BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&0001004C_PID&0323'
+        $paLog = Join-Path $QueueDir "patch-apple-$nonce.log"
+
+        if (-not $src -or -not (Test-Path $src)) {
+            "ERROR: patched sys not found: $src" | Set-Content $paLog -Encoding ASCII
+            $rc = 2
+        } else {
+            try {
+                "=== PATCH-APPLE-SYS $src -> $dest ===" | Set-Content $paLog -Encoding ASCII
+
+                # Find the BTHENUM 00001124 (HID) device instance ID for the Magic Mouse
+                $devEnum = & pnputil /enum-devices 2>&1 | Out-String
+                $rxId = [regex]'(?i)Instance ID:\s+(BTHENUM\\{00001124[^\r\n]*004c[^\r\n]*0323[^\r\n]*)'
+                $mId = $rxId.Match($devEnum)
+                $devId = if ($mId.Success) { $mId.Groups[1].Value.Trim() } else { '' }
+                "Device instance: '$devId'" | Add-Content $paLog -Encoding ASCII
+
+                # Re-enable device if it was previously disabled (in case a prior attempt disabled it)
+                if ($devId) {
+                    "Re-enabling device (precautionary)..." | Add-Content $paLog -Encoding ASCII
+                    & pnputil /enable-device "$devId" 2>&1 | Add-Content $paLog -Encoding ASCII
+                }
+
+                # Stage patched sys under a temp name in System32\drivers (no file lock on .new)
+                $staged = $dest + '.new'
+                "Staging to $staged ..." | Add-Content $paLog -Encoding ASCII
+                Copy-Item -Path $src -Destination $staged -Force -ErrorAction Stop
+                "Stage copy: OK" | Add-Content $paLog -Encoding ASCII
+
+                # Queue PendingFileRenameOperations: on next boot, rename .new -> .sys (atomic replace)
+                # Format: REG_MULTI_SZ, pairs of [src, dest] (NtMoveFile semantics at boot)
+                # Pair 1: delete/rename original -> to nothing is not needed; MoveFileEx replaces
+                # Use [System.IO.Path] NT prefix: \??\<path>
+                $ntNew  = '\??\' + $staged
+                $ntDest = '\??\' + $dest
+                $regKey = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager'
+                $existing = (Get-ItemProperty $regKey -Name PendingFileRenameOperations -ErrorAction SilentlyContinue).PendingFileRenameOperations
+                $newEntry = @($ntNew, $ntDest)
+                if ($existing) {
+                    # Remove any previous entry for this file to avoid duplicates
+                    $cleaned = $existing | Where-Object { $_ -notlike "*applewirelessmouse*" }
+                    $merged = [string[]]($cleaned + $newEntry)
+                } else {
+                    $merged = [string[]]$newEntry
+                }
+                Set-ItemProperty -Path $regKey -Name PendingFileRenameOperations -Value $merged -Type MultiString
+                "PendingFileRenameOperations queued: $ntNew -> $ntDest" | Add-Content $paLog -Encoding ASCII
+                "REBOOT REQUIRED to apply patch." | Add-Content $paLog -Encoding ASCII
+                $rc = 0
+            } catch {
+                "Exception: $_" | Add-Content $paLog -Encoding ASCII
+                Log "Exception in PATCH-APPLE-SYS: $_"
+                $rc = 99
+            }
+        }
+        Log "PATCH-APPLE-SYS exited $rc; log at $paLog"
     }
     # Special phase prefix "SNAPSHOT:Stack" routes to mm-bt-stack-snapshot.ps1
     elseif ($phase -like 'SNAPSHOT:*') {


### PR DESCRIPTION
## Summary
- Patches embedded 116-byte HID descriptor at offset `0xA850` in `applewirelessmouse.sys` to include Mouse TLC (RID=0x02) + Vendor Battery TLC (RID=0x90)
- Adds `PATCH-APPLE-SYS` route to `mm-task-runner.ps1`: stages patched sys, queues `PendingFileRenameOperations` for atomic boot-time replace
- Session doc: `docs/M13-V3-BINARY-PATCH-APPLE-SYS-2026-04-29.md`

## State
Patched + signed binary staged at `C:\Windows\System32\drivers\applewirelessmouse.sys.new`. Reboot required to apply. Post-reboot: run `mm-accept-test.sh` — expect COL02 Started + `HidD_GetInputReport(0x90)` returning battery%.

## Rollback
Boot Safe Mode → restore from `D:\Backups\AppleWirelessMouse-RECOVERY\AppleWirelessMouse.sys`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
