### PR TITLE
feat(M14): RID=0x27 raw byte capture via registry ring buffer

### DIFF
--- a/driver/Driver.c
+++ b/driver/Driver.c
@@ -95,6 +95,7 @@ EvtDeviceAdd(_In_ WDFDRIVER Driver, _Inout_ PWDFDEVICE_INIT DeviceInit)
     WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&qCfg, WdfIoQueueDispatchParallel);
     qCfg.EvtIoDeviceControl         = EvtIoDeviceControl;
     qCfg.EvtIoInternalDeviceControl = EvtIoInternalDeviceControl;
+    qCfg.EvtIoRead                  = EvtIoRead;   // M14: intercept READ completions for RID=0x27 logging
     qCfg.EvtIoDefault               = EvtIoDefault;
     WDFQUEUE queue;
     return WdfIoQueueCreate(device, &qCfg, WDF_NO_OBJECT_ATTRIBUTES, &queue);
@@ -215,6 +216,117 @@ EvtIoDefault(_In_ WDFQUEUE Queue, _In_ WDFREQUEST Request)
 }
 
 // --------------------------------------------------------------------------
+// EvtIoRead — M14: intercept IRP_MJ_READ completions
+//
+// Forwards the READ request with OnHidReadComplete so we can inspect the
+// returned buffer. HidBth fills the buffer with a HID input report on
+// completion; byte[0] is the Report ID.
+// --------------------------------------------------------------------------
+
+VOID
+EvtIoRead(_In_ WDFQUEUE Queue, _In_ WDFREQUEST Request, _In_ size_t Length)
+{
+    UNREFERENCED_PARAMETER(Length);
+
+    WDFDEVICE   device = WdfIoQueueGetDevice(Queue);
+    PDEVICE_CONTEXT ctx = GetDeviceContext(device);
+    WDFIOTARGET target = WdfDeviceGetIoTarget(device);
+
+    WdfSpinLockAcquire(ctx->Lock);
+    ctx->HidReadCount++;
+    WdfSpinLockRelease(ctx->Lock);
+
+    WdfRequestFormatRequestUsingCurrentType(Request);
+    WdfRequestSetCompletionRoutine(Request, OnHidReadComplete, ctx);
+    if (!WdfRequestSend(Request, target, WDF_NO_SEND_OPTIONS))
+    {
+        WdfRequestComplete(Request, WdfRequestGetStatus(Request));
+    }
+}
+
+// --------------------------------------------------------------------------
+// OnHidReadComplete — M14: log RID=0x27 raw bytes via DbgPrint
+//
+// Log policy: log every report for the first 20 RID=0x27 completions,
+// then every 64th thereafter (shows it's still running without flooding).
+// Counters flushed to registry by DiagWorkItem so PowerShell can verify.
+// --------------------------------------------------------------------------
+
+VOID
+OnHidReadComplete(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target,
+                  _In_ PWDF_REQUEST_COMPLETION_PARAMS Params, _In_ WDFCONTEXT Context)
+{
+    UNREFERENCED_PARAMETER(Target);
+
+    PDEVICE_CONTEXT ctx    = (PDEVICE_CONTEXT)Context;
+    NTSTATUS        status = Params->IoStatus.Status;
+
+    if (!NT_SUCCESS(status) || ctx == NULL)
+    {
+        WdfRequestComplete(Request, status);
+        return;
+    }
+
+    PVOID  buf    = NULL;
+    size_t bufLen = 0;
+    NTSTATUS rs = WdfRequestRetrieveOutputBuffer(Request, 1, &buf, &bufLen);
+    if (NT_SUCCESS(rs) && buf != NULL)
+    {
+        size_t bytesRead = Params->IoStatus.Information;
+        PUCHAR p = (PUCHAR)buf;
+
+        if (bytesRead > 0 && p[0] == 0x27)
+        {
+            WdfSpinLockAcquire(ctx->Lock);
+            ULONG cnt = ++ctx->Rid27Count;
+
+            // Ring buffer: store up to RID27_BYTES_PER_SLOT bytes of this report.
+            ULONG slot = ctx->Rid27RingNext % RID27_RING_SLOTS;
+            ctx->Rid27RingNext++;
+            ULONG copyLen = (ULONG)((bytesRead < RID27_BYTES_PER_SLOT)
+                                    ? bytesRead : RID27_BYTES_PER_SLOT);
+            RtlCopyMemory(ctx->Rid27Ring[slot], p, copyLen);
+            if (copyLen < RID27_BYTES_PER_SLOT)
+                RtlZeroMemory(ctx->Rid27Ring[slot] + copyLen,
+                              RID27_BYTES_PER_SLOT - copyLen);
+
+            WdfSpinLockRelease(ctx->Lock);
+
+            // Log first 20 reports, then every 64th.
+            BOOLEAN doLog = (cnt <= 20) || ((cnt & 63) == 0);
+            if (doLog)
+            {
+                WdfSpinLockAcquire(ctx->Lock);
+                ctx->Rid27LoggedCount++;
+                WdfSpinLockRelease(ctx->Lock);
+
+                // Safe zero-extend for bytes beyond actual report length.
+#define B(i) ((ULONG)((bytesRead > (i)) ? p[(i)] : 0))
+                DbgPrint("M14[RID27.%lu] len=%lu "
+                         "b[0..15]:  %02X %02X %02X %02X %02X %02X %02X %02X "
+                         "%02X %02X %02X %02X %02X %02X %02X %02X\n",
+                         cnt, (ULONG)bytesRead,
+                         B(0),B(1),B(2),B(3),B(4),B(5),B(6),B(7),
+                         B(8),B(9),B(10),B(11),B(12),B(13),B(14),B(15));
+                DbgPrint("M14[RID27.%lu] b[16..31]: %02X %02X %02X %02X %02X %02X %02X %02X "
+                         "%02X %02X %02X %02X %02X %02X %02X %02X\n",
+                         cnt,
+                         B(16),B(17),B(18),B(19),B(20),B(21),B(22),B(23),
+                         B(24),B(25),B(26),B(27),B(28),B(29),B(30),B(31));
+                DbgPrint("M14[RID27.%lu] b[32..47]: %02X %02X %02X %02X %02X %02X %02X %02X "
+                         "%02X %02X %02X %02X %02X %02X %02X %02X\n",
+                         cnt,
+                         B(32),B(33),B(34),B(35),B(36),B(37),B(38),B(39),
+                         B(40),B(41),B(42),B(43),B(44),B(45),B(46),B(47));
+#undef B
+            }
+        }
+    }
+
+    WdfRequestComplete(Request, status);
+}
+
+// --------------------------------------------------------------------------
 // OnSdpQueryComplete — completion routine for IOCTL 0x410210
 //
 // Retrieves the SDP attribute response buffer, calls SdpRewrite_Process to
@@ -305,6 +417,9 @@ OnSdpQueryComplete(_In_ WDFREQUEST Request, _In_ WDFIOTARGET Target,
 //   LastSdpBufSize       REG_DWORD  — size of last SDP buffer
 //   LastPatchStatusHex   REG_DWORD  — NTSTATUS of last patch attempt
 //   LastSdpBytes         REG_BINARY — first 64 bytes of last SDP buffer
+//   HidReadCount         REG_DWORD  — M14: total IRP_MJ_READ completions
+//   Rid27Count           REG_DWORD  — M14: completions where buf[0]==0x27
+//   Rid27LoggedCount     REG_DWORD  — M14: RID=0x27 reports sent to DbgPrint
 // --------------------------------------------------------------------------
 
 VOID M13_DiagTimerFunc(_In_ WDFTIMER Timer)
@@ -323,14 +438,22 @@ VOID M13_DiagWorkItemFunc(_In_ WDFWORKITEM WorkItem)
 
     // Snapshot under lock, then write registry at PASSIVE_LEVEL unlocked.
     ULONG ictlCount, scanHits, patchOk, lastSize, lastStatus;
+    ULONG hidReads, rid27Count, rid27Logged, rid27SlotsFilled;
     UCHAR lastBytes[64];
+    UCHAR rid27Snapshot[RID27_RING_SLOTS * RID27_BYTES_PER_SLOT];
     WdfSpinLockAcquire(ctx->Lock);
-    ictlCount  = ctx->IoctlInterceptCount;
-    scanHits   = ctx->SdpScanHits;
-    patchOk    = ctx->SdpPatchSuccess;
-    lastSize   = ctx->LastSdpBufSize;
-    lastStatus = ctx->LastPatchStatus;
+    ictlCount     = ctx->IoctlInterceptCount;
+    scanHits      = ctx->SdpScanHits;
+    patchOk       = ctx->SdpPatchSuccess;
+    lastSize      = ctx->LastSdpBufSize;
+    lastStatus    = ctx->LastPatchStatus;
+    hidReads      = ctx->HidReadCount;
+    rid27Count    = ctx->Rid27Count;
+    rid27Logged   = ctx->Rid27LoggedCount;
+    rid27SlotsFilled = (rid27Count < RID27_RING_SLOTS) ? rid27Count : RID27_RING_SLOTS;
     RtlCopyMemory(lastBytes, ctx->LastSdpBytes, 64);
+    RtlCopyMemory(rid27Snapshot, ctx->Rid27Ring,
+                  RID27_RING_SLOTS * RID27_BYTES_PER_SLOT);
     WdfSpinLockRelease(ctx->Lock);
 
     UNICODE_STRING keyPath;
@@ -355,11 +478,22 @@ VOID M13_DiagWorkItemFunc(_In_ WDFWORKITEM WorkItem)
     SET_DWORD(L"SdpPatchSuccess",     patchOk);
     SET_DWORD(L"LastSdpBufSize",      lastSize);
     SET_DWORD(L"LastPatchStatusHex",  lastStatus);
+    SET_DWORD(L"HidReadCount",        hidReads);
+    SET_DWORD(L"Rid27Count",          rid27Count);
+    SET_DWORD(L"Rid27LoggedCount",    rid27Logged);
+    SET_DWORD(L"Rid27SlotsFilled",    rid27SlotsFilled);
 
 #undef SET_DWORD
 
     RtlInitUnicodeString(&n, L"LastSdpBytes");
     ZwSetValueKey(key, &n, 0, REG_BINARY, lastBytes, 64);
+
+    // Flush RID=0x27 ring buffer so PowerShell can read raw bytes directly
+    // from registry (no DebugView required).
+    // Each slot is RID27_BYTES_PER_SLOT bytes; only rid27SlotsFilled slots valid.
+    RtlInitUnicodeString(&n, L"Rid27RingBuf");
+    ZwSetValueKey(key, &n, 0, REG_BINARY, rid27Snapshot,
+                  RID27_RING_SLOTS * RID27_BYTES_PER_SLOT);
 
     ZwClose(key);
 }

--- a/driver/Driver.h
+++ b/driver/Driver.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 //
-// M13 — Magic Mouse 2024 KMDF lower filter, SDP descriptor injection.
+// M14 — RID=0x27 raw byte capture layer (on top of M13 SDP injection).
 //
 // Stack position (lower filter between BTHENUM and HidBth):
 //   HidClass → HidBth → [M13 (this)] → BTHENUM
@@ -52,6 +52,19 @@ typedef struct _DEVICE_CONTEXT
     ULONG   LastPatchStatus;       // NTSTATUS of most recent PatchSdpHidDescriptor
     UCHAR   LastSdpBytes[64];      // first 64 raw bytes of most recent SDP buffer
 
+    // M14: HID READ intercept counters + ring buffer (flushed to registry by DiagWorkItem)
+    ULONG   HidReadCount;          // total IRP_MJ_READ completions seen
+    ULONG   Rid27Count;            // completions where buf[0] == 0x27
+    ULONG   Rid27LoggedCount;      // how many RID=0x27 reports were DbgPrinted
+
+    // Ring buffer: last 8 RID=0x27 raw reports (48 bytes each).
+    // Work item flushes as Rid27RingBuf REG_BINARY (8×48=384 bytes).
+    // PowerShell reads without needing DebugView.
+#define RID27_RING_SLOTS 8
+#define RID27_BYTES_PER_SLOT 48
+    UCHAR   Rid27Ring[RID27_RING_SLOTS][RID27_BYTES_PER_SLOT];
+    ULONG   Rid27RingNext;         // next write slot (0..7, wraps mod 8)
+
     WDFTIMER    DiagTimer;         // 1 Hz periodic
     WDFWORKITEM DiagWorkItem;      // PASSIVE_LEVEL flush to registry
 
@@ -68,6 +81,8 @@ EVT_WDF_DRIVER_DEVICE_ADD               EvtDeviceAdd;
 EVT_WDF_IO_QUEUE_IO_INTERNAL_DEVICE_CONTROL EvtIoInternalDeviceControl;
 EVT_WDF_IO_QUEUE_IO_DEVICE_CONTROL      EvtIoDeviceControl;
 EVT_WDF_IO_QUEUE_IO_DEFAULT             EvtIoDefault;
+EVT_WDF_IO_QUEUE_IO_READ                EvtIoRead;
 EVT_WDF_REQUEST_COMPLETION_ROUTINE      OnSdpQueryComplete;
+EVT_WDF_REQUEST_COMPLETION_ROUTINE      OnHidReadComplete;
 EVT_WDF_TIMER                           M13_DiagTimerFunc;
 EVT_WDF_WORKITEM                        M13_DiagWorkItemFunc;

--- a/scripts/mm-dev.ps1
+++ b/scripts/mm-dev.ps1
@@ -98,8 +98,9 @@ function Resolve-DeviceId {
     return $null
 }
 
-# Derive driver source root from script location (scripts\ -> repo root)
-$DriverRoot = Split-Path -Parent $PSScriptRoot
+# Derive driver source root from script location (scripts\ -> repo root).
+# Guard against $PSScriptRoot being null when called from a scheduled task context.
+$DriverRoot = if ($PSScriptRoot) { Split-Path -Parent $PSScriptRoot } else { 'D:\mm3-driver' }
 $BuildOut   = Join-Path $DriverRoot 'x64\Debug'
 $VcxProj    = Join-Path $DriverRoot 'MagicMouseDriver.vcxproj'
 
@@ -211,16 +212,41 @@ function Build-Driver {
     # NOT LaunchBuildEnv.cmd: that wraps SetupBuildEnv in `cmd /k` which spawns
     # an interactive shell that never exits, hanging the entire pipeline.
     $ewdkSetup = Join-Path $EwdkRoot 'BuildEnv\SetupBuildEnv.cmd'
+
+    # If not found at $EwdkRoot, scan all ready drives (handles ISO mounted to any letter).
     if (-not (Test-Path $ewdkSetup)) {
-        Write-Log "EWDK SetupBuildEnv.cmd not found at $ewdkSetup" 'ERROR'
+        Write-Log "EWDK not at $ewdkSetup - scanning drives..." 'WARN'
+        foreach ($drv in [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.IsReady }) {
+            $candidate = Join-Path $drv.RootDirectory.FullName 'BuildEnv\SetupBuildEnv.cmd'
+            if (Test-Path $candidate) {
+                $ewdkSetup = $candidate
+                Write-Log "Found EWDK at $ewdkSetup" 'OK'
+                break
+            }
+        }
+    }
+
+    if (-not (Test-Path $ewdkSetup)) {
+        Write-Log "EWDK SetupBuildEnv.cmd not found on any drive. Mount the ISO first." 'ERROR'
         return $false
     }
 
-    Write-Log "Running EWDK msbuild (Rebuild) via SetupBuildEnv..."
-    # 'call' is critical: ensures cmd.exe returns from SetupBuildEnv.cmd before
-    # executing msbuild. Without 'call', batch chaining behaves unpredictably.
-    $buildCmd = "call `"$ewdkSetup`" >NUL && msbuild `"$VcxProj`" /p:Configuration=Debug /p:Platform=x64 /t:Rebuild /nologo /v:minimal /p:SignFiles=false /p:EnableCodeSigning=false"
-    $output = cmd /c $buildCmd 2>&1
+    Write-Log "Running EWDK msbuild (Rebuild) via temp batch file..."
+    # Write a temp .bat to avoid PowerShell→cmd double-quote mangling.
+    # cmd /c with embedded quotes produces '""' is not recognized errors.
+    $tempBat = [System.IO.Path]::GetTempFileName() -replace '\.tmp$','.bat'
+    @"
+@echo off
+call "$ewdkSetup" >NUL 2>&1
+if errorlevel 1 (
+    echo [BUILD] EWDK SetupBuildEnv.cmd failed >&2
+    exit /b 1
+)
+msbuild "$VcxProj" /p:Configuration=Debug /p:Platform=x64 /t:Rebuild /nologo /v:minimal /p:SignFiles=false /p:EnableCodeSigning=false
+"@ | Out-File -FilePath $tempBat -Encoding ASCII
+    Write-Log "Batch file: $tempBat"
+    $output = cmd /c $tempBat 2>&1
+    Remove-Item $tempBat -Force -ErrorAction SilentlyContinue
     $output | ForEach-Object { Add-Content -Path $SessionLog -Value $_ -Encoding UTF8 }
 
     $sys     = Join-Path $BuildOut 'MagicMouseDriver.sys'
@@ -617,43 +643,69 @@ function Restore-LowerFilters {
 # ---------------------------------------------------------------------------
 # DEBUG CAPTURE
 # ---------------------------------------------------------------------------
-function Start-DebugCapture {
-    Write-Section "CAPTURE - $(Get-Date -Format 'HH:mm:ss')"
+function Read-Rid27Captures {
+    # M14: read RID=0x27 ring buffer from registry (no DebugView required).
+    # The driver's 1Hz DiagWorkItem writes:
+    #   Diag\HidReadCount   DWORD   total IRP_MJ_READ completions
+    #   Diag\Rid27Count     DWORD   how many had buf[0]==0x27
+    #   Diag\Rid27SlotsFilled DWORD  slots written (capped at 8)
+    #   Diag\Rid27RingBuf   REG_BINARY  8 x 48 bytes of raw reports
+    Write-Section "CAPTURE (RID=0x27 ring buffer) - $(Get-Date -Format 'HH:mm:ss')"
 
-    # Ensure kernel debug filter is set (force-replace if existing key is wrong type)
-    $regKey = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Debug Print Filter'
-    if (-not (Test-Path $regKey)) { New-Item -Path $regKey -Force | Out-Null }
-    try {
-        Remove-ItemProperty -Path $regKey -Name 'DEFAULT' -ErrorAction SilentlyContinue
-    } catch { }
-    New-ItemProperty -Path $regKey -Name 'DEFAULT' -PropertyType DWord -Value 8 -Force | Out-Null
-    Write-Log "Debug print filter set (DEFAULT=8 DWord)" 'OK'
-
-    # Kill existing DebugView
-    Get-Process -Name Dbgview -ErrorAction SilentlyContinue | Stop-Process -Force
-    Start-Sleep -Milliseconds 500
-
-    # Clear old log
-    if (Test-Path $DebugLog) { Remove-Item $DebugLog -Force }
-    Write-Log "Old debug log cleared." 'OK'
-
-    # Start DebugView
-    if (-not (Test-Path $DbgViewExe)) {
-        Write-Log "DebugView not found at $DbgViewExe - download Sysinternals Suite" 'ERROR'
+    $diagKey = 'HKLM:\SYSTEM\CurrentControlSet\Services\MagicMouseDriver\Diag'
+    if (-not (Test-Path $diagKey)) {
+        Write-Log "Diag registry key not found - driver not loaded or not M14 build" 'ERROR'
         return $false
     }
 
-    Start-Process $DbgViewExe -ArgumentList "/accepteula /t /k /l `"$DebugLog`"" -WindowStyle Minimized
-    Start-Sleep -Milliseconds 800
+    $props        = Get-ItemProperty $diagKey -ErrorAction SilentlyContinue
+    $hidReads     = $props.HidReadCount
+    $rid27Count   = $props.Rid27Count
+    $slotsFilled  = $props.Rid27SlotsFilled
+    $ringBuf      = $props.Rid27RingBuf   # byte[] or $null
 
-    $proc = Get-Process -Name Dbgview -ErrorAction SilentlyContinue
-    if ($proc) {
-        Write-Log "DebugView started (PID $($proc.Id)) -> logging to $DebugLog" 'OK'
-        return $true
-    } else {
-        Write-Log "DebugView did not start" 'ERROR'
+    Write-Log "HidReadCount=$hidReads  Rid27Count=$rid27Count  SlotsFilled=$slotsFilled" 'OK'
+
+    if (-not $slotsFilled -or $slotsFilled -eq 0) {
+        Write-Log "No RID=0x27 captures yet - touch the mouse surface and re-run Capture" 'WARN'
         return $false
     }
+
+    if (-not $ringBuf -or $ringBuf.Length -eq 0) {
+        Write-Log "Rid27RingBuf key empty despite SlotsFilled=$slotsFilled" 'WARN'
+        return $false
+    }
+
+    # Dump each filled slot
+    $nSlots = [Math]::Min($slotsFilled, 8)
+    Write-Log "--- RID=0x27 ring buffer: $nSlots slot(s) ---"
+    for ($i = 0; $i -lt $nSlots; $i++) {
+        $offset = $i * 48
+        $slot   = $ringBuf[$offset..($offset + 47)]
+        $hex    = ($slot | ForEach-Object { '{0:X2}' -f $_ }) -join ' '
+        Write-Log "Slot[$i]: $hex"
+
+        # Layout analysis (Linux hid-magicmouse.c reference)
+        $rid     = $slot[0]
+        $flags   = $slot[1]
+        $ts      = [uint16]($slot[2] + ($slot[3] -shl 8))
+        $nFinger = $slot[4]
+        Write-Log "  RID=0x{0:X2}  flags=0x{1:X2}  ts={2}  nFingers={3}" -f $rid,$flags,$ts,$nFinger
+        # Bytes 5..end: per-finger data (7 bytes each in hid-magicmouse v2/v3)
+        if ($nFinger -gt 0) {
+            for ($f = 0; $f -lt $nFinger; $f++) {
+                $foff = 5 + ($f * 9)
+                if ($foff + 8 -ge 48) { break }
+                $absX = [int16]($slot[$foff] + ($slot[$foff+1] -shl 8))
+                $absY = [int16]($slot[$foff+2] + ($slot[$foff+3] -shl 8))
+                Write-Log ("  Finger[$f]: x={0} y={1} raw=[{2}]" -f $absX, $absY,
+                    (($slot[$foff..($foff+8)]) | ForEach-Object { '{0:X2}' -f $_ }) -join ' ')
+            }
+        }
+    }
+
+    Write-Log "Capture complete." 'OK'
+    return $true
 }
 
 # ---------------------------------------------------------------------------
@@ -693,7 +745,7 @@ switch ($Phase) {
     'Verify'   { if (-not (Verify-Install)) { $exitCode = 1 } }
     'Rollback' { if (-not (Rollback-Driver)){ $exitCode = 1 } }
     'Restore'  { if (-not (Restore-LowerFilters)) { $exitCode = 1 } }
-    'Capture'  { if (-not (Start-DebugCapture)) { $exitCode = 1 } }
+    'Capture'  { if (-not (Read-Rid27Captures)) { $exitCode = 1 } }
     'Log'      { Show-SessionLog }
     'Debug'    { Show-DebugLog }
     'Full' {
@@ -704,7 +756,8 @@ switch ($Phase) {
         if ($ok) { $ok = Verify-Install }
         Get-DriverState
         if ($ok) {
-            Write-Log "Full cycle complete - run Capture phase to start DebugView, then test." 'OK'
+            Read-Rid27Captures | Out-Null
+            Write-Log "Full cycle complete - touch mouse surface then run Capture to read ring buffer." 'OK'
         } else {
             Write-Log "Full cycle FAILED - check session log: $SessionLog" 'ERROR'
             $exitCode = 1

--- a/scripts/mm-task-runner.ps1
+++ b/scripts/mm-task-runner.ps1
@@ -80,47 +80,80 @@ try {
 
     $rc = 0
 
-    # BUILD route: invoke EWDK msbuild against M12.sln (or any .sln on WSL path)
-    # Request format: BUILD|<nonce>|<config>|<platform>[|<sln-path>]
+    # BUILD route: ensure EWDK ISO is mounted, then delegate to mm-dev.ps1 -Phase Build.
+    # mm-dev.ps1 uses a temp .bat to avoid PowerShell→cmd quoting bugs and writes
+    # to the session log. Task runner handles mount so mm-dev.ps1 stays simple.
     if ($phase -eq 'BUILD') {
-        $config   = if ($parts.Count -gt 2) { $parts[2].Trim() } else { 'Release' }
-        $platform = if ($parts.Count -gt 3) { $parts[3].Trim() } else { 'x64' }
-        $defaultSln = '\\wsl.localhost\Ubuntu\home\lesley\projects\Personal\magic-mouse-tray\driver\M12.sln'
-        $solution = if ($parts.Count -gt 4 -and $parts[4].Trim()) { $parts[4].Trim() } else { $defaultSln }
-        $buildLog = Join-Path $QueueDir "build-$nonce.log"
-        # Use SetupBuildEnv.cmd (one-shot env setup), NOT LaunchBuildEnv.cmd (cmd /k interactive)
-        # Senior-dev review CRIT-1: LaunchBuildEnv hangs the queue indefinitely.
-        $ewdk     = 'F:\BuildEnv\SetupBuildEnv.cmd'
-
-        Log "BUILD config=$config platform=$platform solution=$solution"
-
-        if (-not (Test-Path $ewdk)) {
-            $msg = "ERROR: EWDK SetupBuildEnv not found at $ewdk - is the ISO mounted?"
-            Log $msg
-            $msg | Set-Content $buildLog -Encoding ASCII
-            $rc = 1
-        } else {
-            $cmdLine = "call `"$ewdk`" >NUL 2>&1 && msbuild `"$solution`" /p:Configuration=$config /p:Platform=$platform /v:minimal"
-            Log "Invoking: cmd /c $cmdLine"
+        $isoPath  = 'D:\Users\Lesley\Downloads\EWDK_ge_release_svc_prod1_26100_250904-1728.iso'
+        $ewdkSetup = $null
+        foreach ($drv in [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.IsReady }) {
+            $c = Join-Path $drv.RootDirectory.FullName 'BuildEnv\SetupBuildEnv.cmd'
+            if (Test-Path $c) { $ewdkSetup = $c; break }
+        }
+        if (-not $ewdkSetup) {
+            Log "EWDK not on any drive - mounting ISO $isoPath"
             try {
-                cmd /c $cmdLine > $buildLog 2>&1
-                $rc = $LASTEXITCODE
-                if ($null -eq $rc) { $rc = 0 }
+                $disk = Mount-DiskImage -ImagePath $isoPath -PassThru -ErrorAction Stop
+                Start-Sleep -Milliseconds 1500  # let Windows assign the drive letter
+                foreach ($drv in [System.IO.DriveInfo]::GetDrives() | Where-Object { $_.IsReady }) {
+                    $c = Join-Path $drv.RootDirectory.FullName 'BuildEnv\SetupBuildEnv.cmd'
+                    if (Test-Path $c) { $ewdkSetup = $c; break }
+                }
+                if ($ewdkSetup) { Log "EWDK mounted, found at $ewdkSetup" }
+                else { Log "ERROR: mounted ISO but SetupBuildEnv.cmd not found"; $rc = 1 }
             } catch {
-                "Exception: $_" | Add-Content $buildLog -Encoding ASCII
-                Log "Exception in BUILD: $_"
-                $rc = 99
+                Log "Mount-DiskImage failed: $_"
+                $rc = 1
+            }
+        } else {
+            Log "EWDK already mounted at $ewdkSetup"
+        }
+
+        if ($rc -eq 0) {
+            $candidates = @('D:\mm3-driver\scripts\mm-dev.ps1', 'C:\mm3-pkg\scripts\mm-dev.ps1')
+            $devScript  = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+            Log "BUILD → delegating to $devScript"
+            if (-not $devScript) {
+                Log "ERROR: mm-dev.ps1 not found"
+                $rc = 127
+            } else {
+                try {
+                    & $devScript -Phase Build -NoElevate
+                    $rc = $LASTEXITCODE
+                    if ($null -eq $rc) { $rc = 0 }
+                } catch {
+                    Log "Exception in BUILD delegate: $_"
+                    $rc = 99
+                }
             }
         }
-        Log "BUILD exited $rc; log at $buildLog"
+        Log "BUILD exited $rc"
     }
-    # SIGN route: signtool sign .sys + .cat with a PFX cert
-    # Request format: SIGN|<nonce>|<sys-path>|<cat-path>|<pfx-path>|<pfx-pass-env-var>
+    # SIGN route: signtool sign .sys + .cat with a PFX cert, OR delegate to mm-dev.ps1.
+    # With no args → delegates to mm-dev.ps1 -Phase Sign (uses thumbprint cert).
+    # With args → SIGN|<nonce>|<sys-path>|<cat-path>|<pfx-path>|<pfx-pass-env-var>
     elseif ($phase -eq 'SIGN') {
         $sysPath    = if ($parts.Count -gt 2) { $parts[2].Trim() } else { '' }
         $catPath    = if ($parts.Count -gt 3) { $parts[3].Trim() } else { '' }
         $pfxPath    = if ($parts.Count -gt 4) { $parts[4].Trim() } else { '' }
         $pfxPassVar = if ($parts.Count -gt 5) { $parts[5].Trim() } else { '' }
+
+        if (-not $sysPath) {
+            # No args: delegate to mm-dev.ps1 Sign phase (thumbprint-based signing)
+            $candidates = @('D:\mm3-driver\scripts\mm-dev.ps1', 'C:\mm3-pkg\scripts\mm-dev.ps1')
+            $devScript  = $candidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+            Log "SIGN (no args) → delegating to $devScript"
+            if (-not $devScript) { Log "ERROR: mm-dev.ps1 not found"; $rc = 127 }
+            else {
+                try {
+                    & $devScript -Phase Sign -NoElevate
+                    $rc = $LASTEXITCODE
+                    if ($null -eq $rc) { $rc = 0 }
+                } catch { Log "Exception in SIGN delegate: $_"; $rc = 99 }
+            }
+            Log "SIGN exited $rc"
+        } else {
+
         $signLog    = Join-Path $QueueDir "sign-$nonce.log"
         $signtool   = 'F:\Program Files\Windows Kits\10\bin\10.0.26100.0\x64\signtool.exe'
         $tsUrl      = 'http://timestamp.digicert.com'
@@ -157,6 +190,7 @@ try {
             }
         }
         Log "SIGN exited $rc; log at $signLog"
+        }  # end else (has args)
     }
     # DV-CHECK route: configure Driver Verifier for a named driver
     # Request format: DV-CHECK|<nonce>|<driver-name>


### PR DESCRIPTION
## Summary

M14 driver milestone: RID=0x27 ring buffer capture without DebugView.

**Driver**: EvtIoRead + OnHidReadComplete intercept IRP_MJ_READ completions. Ring buffer (8x48 bytes) in DEVICE_CONTEXT, flushed to HKLM Diag key every 1s by DiagWorkItem.

**Scripts**: Read-Rid27Captures reads registry ring buffer + annotates bytes vs Linux hid-magicmouse.c. Build-Driver uses temp .bat (quoting fix). Task runner BUILD auto-mounts EWDK ISO; SIGN (no args) delegates to mm-dev.ps1 thumbprint signing.

## Status
M14 binary installed and confirmed (HidReadCount/Rid27RingBuf present in .sys). Awaiting first RID=0x27 captures from live mouse touch interaction.

## Test plan
- [ ] Touch mouse → Capture → Rid27Count > 0, hex dump in session log
- [ ] Map bytes vs Linux hid-magicmouse.c layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)