### PR TITLE
fix(startup-repair): update repair logic for WDF filter

### DIFF
--- a/startup-repair.ps1
+++ b/startup-repair.ps1
@@ -1,27 +1,29 @@
-# startup-repair.ps1 - MagicMouseTray COL02 Battery Collection Repair
+# startup-repair.ps1 - MagicMouseTray WDF Filter Repair
 # SPDX-License-Identifier: MIT
 #
 # Runs at startup via Windows Scheduled Task (SYSTEM account, 30s delay).
-# Detects whether COL02 (battery HID collection) is missing. COL02 persists
-# through normal reboots; it only goes missing after a fresh device re-enumeration
-# (unpair/re-pair, or a previous buggy startup-repair run that called /restart-device).
-# If missing, cycles BTHENUM without the filter to create COL01+COL02, then restores
-# the filter to both registry locations (Enum key + driver instance key).
+# Detects whether the WDF filter has enumerated all 3 HID collections (COL01,
+# COL02, COL03). If any are missing the repair triggers pnputil /restart-device
+# on the BTHENUM parent WITH the filter in place, which forces a fresh SDP
+# negotiation. The WDF filter intercepts the SDP IOCTL and injects the fixed
+# 135-byte descriptor, producing:
+#   COL01 -> Generic Desktop Mouse (mouhid, cursor + scroll)
+#   COL02 -> Vendor 0xFF00/0x14 (HIDClass, battery via RID=0x90)
+#   COL03 -> Vendor 0xFF00/0x27 (HIDClass, raw touch data)
 #
-# CRITICAL: Do NOT call pnputil /restart-device after restoring LowerFilters.
-# /restart-device triggers descriptor re-processing with the filter active, which
-# strips COL02 again. The filter loads correctly at the next reboot via the driver
-# instance key — no forced restart is needed.
+# CRITICAL: DO call pnputil /restart-device WITH the filter registered. The WDF
+# filter produces the correct 3-TLC descriptor on SDP renegotiation -- unlike the
+# old applewirelessmouse.sys which would strip COL02 when the filter was active
+# during descriptor re-processing. Old cycle-without-filter repair is WRONG here.
 #
 # Usage (manual): powershell -ExecutionPolicy Bypass -File startup-repair.ps1
 # Usage (scheduled task): registered by install-driver.ps1 - runs automatically.
 
 param(
     [string]$LogFile = "C:\ProgramData\MagicMouseTray\startup-repair.log",
-    [int]$SettleSeconds = 2    # wait after re-enable before checking result
+    [int]$SettleSeconds = 12   # wait after restart-device before checking result
 )
 
-# Maximum log size before rotation (bytes)
 $MaxLogBytes = 512KB
 
 function Write-Log {
@@ -30,35 +32,25 @@ function Write-Log {
     Add-Content -Path $LogFile -Value $line -Encoding UTF8
 }
 
-# PS5-compatible pnputil output helper - Out-String -NoNewline is PS6+ only
-function Get-PnpOutput {
-    param([string[]]$Lines)
-    return ($Lines | Select-Object -Last 2 | Out-String).TrimEnd()
-}
-
 # ---- bootstrap ----
 $logDir = Split-Path $LogFile -Parent
 if (-not (Test-Path $logDir)) {
     New-Item -ItemType Directory -Path $logDir -Force | Out-Null
 }
 
-# Rotate log if over limit
 if ((Test-Path $LogFile) -and (Get-Item $LogFile).Length -gt $MaxLogBytes) {
     $archive = [System.IO.Path]::ChangeExtension($LogFile, "1.log")
     Move-Item $LogFile $archive -Force
 }
 
-Write-Log "startup-repair: begin"
+Write-Log "startup-repair: begin (WDF filter mode)"
 
-# Apple Magic Mouse PIDs covered by AppleWirelessMouse.inf
-# (matches DriverHealthChecker.cs KnownPids list)
 $knownPids = @("0323", "030d", "0269", "0310")
-
+$paramsTemplate = "HKLM:\SYSTEM\CurrentControlSet\Services\applewirelessmouse\Parameters"
 $anyRepaired = $false
 
 foreach ($mmPid in $knownPids) {
-    # Find BTHENUM parent device for this Magic Mouse pairing.
-    # Must match HID service UUID {00001124} - not PnP Info {00001200} or other profiles.
+    # Find BTHENUM parent device (HID service UUID {00001124} only)
     $btDevice = Get-PnpDevice -ErrorAction SilentlyContinue |
         Where-Object { $_.InstanceId -match "BTHENUM" -and
                        $_.InstanceId -match "00001124" -and
@@ -72,20 +64,21 @@ foreach ($mmPid in $knownPids) {
 
     Write-Log "PID 0x$($mmPid.ToUpper()): BTHENUM = $($btDevice.InstanceId)"
 
-    # COL02 exists when there are 2+ HID-class child devices with this PID and Status OK.
-    # One collapsed device (filter stripped COL02) = Count 1. Healthy = Count 2+.
-    $hidDevices = Get-PnpDevice -ErrorAction SilentlyContinue |
+    # Count HIDClass child devices. COL01 is claimed by mouhid (Mouse class) so
+    # it does NOT appear in HIDClass. Healthy state: BTHENUM parent + COL02 + COL03
+    # = 3 HIDClass devices. Less than 3 means SDP patch did not produce all TLCs.
+    $hidDevices = @(Get-PnpDevice -ErrorAction SilentlyContinue |
         Where-Object { $_.Class -eq 'HIDClass' -and
                        $_.InstanceId -match $mmPid -and
-                       $_.Status -eq 'OK' }
+                       $_.Status -eq 'OK' })
 
-    $hidCount = @($hidDevices).Count   # @() wraps $null -> 0 in PS5
-    if ($hidCount -ge 2) {
-        Write-Log "PID 0x$($mmPid.ToUpper()): COL02 present ($hidCount HID device(s)) - no repair needed"
+    $hidCount = $hidDevices.Count
+    if ($hidCount -ge 3) {
+        Write-Log "PID 0x$($mmPid.ToUpper()): HID OK ($hidCount) - no repair needed"
         continue
     }
 
-    Write-Log "PID 0x$($mmPid.ToUpper()): COL02 missing ($hidCount HID device(s)) - starting repair"
+    Write-Log "PID 0x$($mmPid.ToUpper()): HID count=$hidCount (need 3) - starting WDF repair"
 
     $btRegPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\" + $btDevice.InstanceId
 
@@ -94,86 +87,86 @@ foreach ($mmPid in $knownPids) {
         continue
     }
 
-    # Read current LowerFilters (need to restore after cycling)
-    $lowerFilters = (Get-ItemProperty -Path $btRegPath -Name LowerFilters -ErrorAction SilentlyContinue).LowerFilters
-    if (-not ($lowerFilters -contains 'applewirelessmouse')) {
-        Write-Log "PID 0x$($mmPid.ToUpper()): applewirelessmouse not in LowerFilters - no filter conflict, skipping"
+    # Step 1: Verify WDF binary is present
+    $wdfBin = "C:\Windows\System32\drivers\applewirelessmouse.sys"
+    $wdfItem = Get-Item $wdfBin -ErrorAction SilentlyContinue
+    if (-not $wdfItem) {
+        Write-Log "CRITICAL: $wdfBin missing - cannot repair without WDF binary"
         continue
     }
+    Write-Log "Step 1: WDF binary present ($($wdfItem.Length) bytes)"
 
-    Write-Log "LowerFilters = $($lowerFilters -join ', ')"
+    # Step 2: Verify/set EnableInjection=1
+    $paramsKey = $paramsTemplate
+    if (-not (Test-Path $paramsKey)) {
+        New-Item -Path $paramsKey -Force | Out-Null
+    }
+    $ei = (Get-ItemProperty $paramsKey -Name "EnableInjection" -ErrorAction SilentlyContinue).EnableInjection
+    if ($ei -ne 1) {
+        Write-Log "Step 2: EnableInjection=$ei -- setting to 1"
+        Set-ItemProperty -Path $paramsKey -Name "EnableInjection" -Value 1 -Type DWord
+    } else {
+        Write-Log "Step 2: EnableInjection=1 (OK)"
+    }
 
-    # Repair: remove filter -> cycle BTHENUM -> restore filter
-    # Cycling BTHENUM forces a fresh HID descriptor negotiation without the filter,
-    # creating COL01 (scroll) and COL02 (battery) as separate child devices.
-    # Re-adding the filter afterward adds scroll support to COL01 without collapsing COL02.
+    # Step 3: Verify/set LowerFilters on Enum key
+    $lfEnum = (Get-ItemProperty -Path $btRegPath -Name LowerFilters -ErrorAction SilentlyContinue).LowerFilters
+    if (-not ($lfEnum -contains 'applewirelessmouse')) {
+        Write-Log "Step 3: Enum LowerFilters missing applewirelessmouse -- setting"
+        Set-ItemProperty -Path $btRegPath -Name LowerFilters -Value @("applewirelessmouse") -Type MultiString -ErrorAction SilentlyContinue
+    } else {
+        Write-Log "Step 3: Enum LowerFilters OK ($($lfEnum -join ', '))"
+    }
+
+    # Step 3b: Verify/set LowerFilters on driver instance (Class) key
+    $driverKey = (Get-ItemProperty -Path $btRegPath -Name Driver -ErrorAction SilentlyContinue).Driver
+    if ($driverKey) {
+        $driverInstPath = "HKLM:\SYSTEM\CurrentControlSet\Control\Class\$driverKey"
+        if (Test-Path $driverInstPath) {
+            $lfClass = (Get-ItemProperty $driverInstPath -Name LowerFilters -ErrorAction SilentlyContinue).LowerFilters
+            if (-not ($lfClass -contains 'applewirelessmouse')) {
+                Write-Log "Step 3b: Class key LowerFilters missing -- setting"
+                Set-ItemProperty -Path $driverInstPath -Name LowerFilters -Value @("applewirelessmouse") -Type MultiString -ErrorAction SilentlyContinue
+            } else {
+                Write-Log "Step 3b: Class key LowerFilters OK"
+            }
+        }
+    }
+
+    # Step 4: Restart BTHENUM device WITH WDF filter in place.
+    # The filter intercepts IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE and replaces
+    # the HIDDescriptorList with our 135-byte 3-TLC descriptor. This produces the
+    # correct 3 HID child PDOs without needing to remove the filter first.
     try {
-        Write-Log "Step 1: removing LowerFilters..."
-        Remove-ItemProperty -Path $btRegPath -Name LowerFilters -ErrorAction Stop
+        Write-Log "Step 4: pnputil /restart-device $($btDevice.InstanceId)"
+        $out = pnputil /restart-device "$($btDevice.InstanceId)" 2>&1
+        $lastLine = ($out | Select-Object -Last 2 | Out-String).TrimEnd()
+        Write-Log "  pnp: $lastLine"
 
-        Write-Log "Step 2: disabling BTHENUM device..."
-        $out = pnputil /disable-device "$($btDevice.InstanceId)" 2>&1
-        Write-Log "  $(Get-PnpOutput $out)"
-
-        Start-Sleep -Milliseconds 500
-
-        Write-Log "Step 3: enabling BTHENUM device..."
-        $out = pnputil /enable-device "$($btDevice.InstanceId)" 2>&1
-        Write-Log "  $(Get-PnpOutput $out)"
-
+        Write-Log "Step 4: waiting $SettleSeconds seconds for SDP negotiation..."
         Start-Sleep -Seconds $SettleSeconds
 
-        # Step 4a: restore LowerFilters to the Enum key (instance-level)
-        Write-Log "Step 4a: restoring LowerFilters to Enum key (no device restart)..."
-        Set-ItemProperty -Path $btRegPath -Name LowerFilters -Value $lowerFilters -Type MultiString -ErrorAction Stop
-
-        # Step 4b: also write to the driver instance key — PnP reads from here during
-        # device stack construction at boot. Without this, the filter gets error 1077
-        # (SERVICE_NEVER_STARTED) because PnP never finds LowerFilters in the canonical location.
-        $driverKey = (Get-ItemProperty -Path $btRegPath -Name Driver -ErrorAction SilentlyContinue).Driver
-        if ($driverKey) {
-            $driverInstPath = "HKLM:\SYSTEM\CurrentControlSet\Control\Class\$driverKey"
-            if (Test-Path $driverInstPath) {
-                Set-ItemProperty -Path $driverInstPath -Name LowerFilters -Value $lowerFilters -Type MultiString -ErrorAction SilentlyContinue
-                Write-Log "Step 4b: driver instance key updated ($driverInstPath)"
-            } else {
-                Write-Log "Step 4b: WARNING - driver instance key not found: $driverInstPath"
-            }
-        } else {
-            Write-Log "Step 4b: WARNING - Driver value not found in $btRegPath"
-        }
-
-        # No Step 5. Do NOT call pnputil /restart-device here — it triggers HID descriptor
-        # re-processing with the filter active, which strips COL02 again. The filter will
-        # load into the stack at the next reboot via the driver instance key set above.
-
-        # Verify COL02 is present (should be — we just cycled without filter)
-        Start-Sleep -Seconds 1
-        $hidAfter = Get-PnpDevice -ErrorAction SilentlyContinue |
+        # Step 5: Verify result
+        $hidAfter = @(Get-PnpDevice -ErrorAction SilentlyContinue |
             Where-Object { $_.Class -eq 'HIDClass' -and
                            $_.InstanceId -match $mmPid -and
-                           $_.Status -eq 'OK' }
-        $hidAfterCount = @($hidAfter).Count
+                           $_.Status -eq 'OK' })
+        $hidAfterCount = $hidAfter.Count
 
-        if ($hidAfterCount -ge 2) {
-            Write-Log "REPAIRED: COL02 present ($hidAfterCount HID device(s)). Battery restored. Scroll loads at next reboot."
+        if ($hidAfterCount -ge 3) {
+            Write-Log "REPAIRED: HID OK=$hidAfterCount (COL01 mouhid + COL02 battery + COL03 touch)"
             $anyRepaired = $true
         } else {
-            Write-Log "WARNING: repair attempted - COL02 still not visible ($hidAfterCount HID device(s))"
+            Write-Log "WARNING: repair attempted - HID count=$hidAfterCount (need 3)"
+            $hidAfter | ForEach-Object { Write-Log "  found: $($_.InstanceId)" }
+            Write-Log "  Possible causes:"
+            Write-Log "    - applewirelessmouse.sys unsigned or wrong binary (run install-wdf-permanent.ps1)"
+            Write-Log "    - CN=MagicMouseFix cert not in LocalMachine\\TrustedPublisher"
+            Write-Log "    - testsigning BCD not active (bcdedit /set testsigning on)"
         }
 
     } catch {
-        Write-Log "ERROR during repair: $($_.Exception.Message)"
-        # Re-enable device in case we failed after Step 2 (disable) but before Step 3 (enable)
-        $reEnableOut = pnputil /enable-device "$($btDevice.InstanceId)" 2>&1
-        Write-Log "  recovery re-enable: $(Get-PnpOutput $reEnableOut)"
-        # Restore LowerFilters
-        try {
-            Set-ItemProperty -Path $btRegPath -Name LowerFilters -Value $lowerFilters -Type MultiString
-            Write-Log "LowerFilters restored after error"
-        } catch {
-            Write-Log "CRITICAL: could not restore LowerFilters: $($_.Exception.Message)"
-        }
+        Write-Log "ERROR during restart-device: $($_.Exception.Message)"
     }
 }
 


### PR DESCRIPTION
## Summary

- Replaces the V4-era cycle-without-filter repair with WDF-filter-aware repair
- Updates HID collection health threshold from 2 to 3
- Calls `pnputil /restart-device` WITH filter active (correct for our WDF filter)

## What changed and why

**Old repair (wrong for WDF filter)**:
1. Remove LowerFilters from Enum key
2. Cycle BTHENUM (disable/enable) — creates COL01+COL02 without filter
3. Restore LowerFilters (no restart)

This was necessary because `applewirelessmouse.sys` would strip COL02 when active during SDP renegotiation. Wrong for our WDF filter.

**New repair (WDF-aware)**:
1. Verify `EnableInjection=1` in registry (set if missing)
2. Verify LowerFilters on both Enum + Class keys (set if missing)
3. `pnputil /restart-device` WITH filter on stack
4. Filter intercepts `IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE` → injects 135-byte 3-TLC descriptor
5. Result: COL01 (mouhid) + COL02 (battery) + COL03 (touch) — HID OK=3

**Health threshold**: 3 (was 2). HIDClass count: BTHENUM parent + COL02 + COL03. COL01 is in Mouse class (mouhid) so it doesn't count here, but its presence is implicit.

## Test plan

- [ ] Reboot with WDF filter installed
- [ ] If mouse doesn't auto-repair: `startup-repair.log` shows `HID count < 3 -- starting WDF repair`
- [ ] After repair: `REPAIRED: HID OK=3`
- [ ] Verify battery readable via `test-battery-col02.ps1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)