### PR TITLE
docs(M13): Session 15 empirical tests — battery patching path analysis

### DIFF
--- a/docs/INVESTIGATION-PROMPT-GHIDRA-DESCRIPTOR-TRACE.md
+++ b/docs/INVESTIGATION-PROMPT-GHIDRA-DESCRIPTOR-TRACE.md
@@ -1,0 +1,232 @@
+# Investigation Prompt — Ghidra Descriptor Source Trace for applewirelessmouse.sys
+
+**Type**: autonomous background investigation
+**Goal**: locate the actual code path through which `applewirelessmouse.sys` injects a HID Report Descriptor in response to `IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE` (`0x00410210`), so a future patch can either modify the source bytes or hook the injection routine.
+**Outcome**: a written report. NO BINARY PATCHING during this investigation.
+
+---
+
+## Prompt to give the new session
+
+```
+You are running an autonomous Ghidra-driven reverse-engineering investigation
+on Apple's applewirelessmouse.sys (Windows kernel HID lower-filter driver).
+The goal is read-only: produce a written report. DO NOT modify any binary,
+do not install anything, do not touch the live device.
+
+Hardware/OS context:
+- Magic Mouse v3 (PID 0x0323) on Windows 11 build 26100
+- Apple's stock WHQL-signed driver: 78424 bytes
+  Path: C:\Windows\System32\DriverStore\FileRepository\applewirelessmouse.inf_amd64_ac34ebceaaf7324c\applewirelessmouse.sys
+  MD5: f4ae407c228c3db6147d9e3307ed5f20
+
+Background (read these first):
+- /home/lesley/projects/Personal/magic-mouse-tray/PSN-0001-hid-battery-driver.yaml
+  (full hypothesis log H-001 .. H-018)
+- /home/lesley/projects/Personal/magic-mouse-tray/docs/SESSION-15-EMPIRICAL-TEST-RESULTS-2026-05-05.md
+  (Session 15 findings — PATH-A invalidated)
+- /home/lesley/projects/Personal/magic-mouse-tray/docs/M12-APPLEWIRELESSMOUSE-FINDINGS.md
+  (existing initial Ghidra notes, light-touch)
+- /home/lesley/projects/Personal/magic-mouse-tray/docs/M13-V3-BINARY-PATCH-APPLE-SYS-2026-04-29.md
+  (the failed patch attempt and its incorrect assumptions)
+
+CRITICAL FINDING from Session 15:
+The 116-byte HID descriptor at file offset 0xA850 has ZERO references in the
+binary code. No LEA RIP-rel, no `mov rax, imm64`, no PE relocations, no
+32-bit immediate constants point to it. It is most likely inert build-leftover
+data. Patching it does nothing.
+
+Your job: find the REAL source of the descriptor that Apple's filter injects
+in response to IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE.
+
+==================================================================
+STEP 1 — Confirm the IOCTL handler dispatch path
+==================================================================
+The IOCTL constant 0x00410210 appears at file offsets 0x80AB and 0x8F72
+(both in the .text section). At 0x80AB we have:
+    cmp esi, 0x00410210   (81 FE 10 02 41 00)
+    jz +0x57              (74 57)
+which jumps to the handler at 0x810A.
+
+The handler at 0x810A consists of a chain of indirect calls:
+    mov rax, [rip+0x58D9]
+    mov rdx, rbx
+    mov rcx, [rip+0x58D7]
+    mov rax, [rax+0x7D8]
+    call [rip+0x191A]
+    ...
+
+These are WDF dispatch helpers (WdfRequestComplete*, WdfMemoryCreate*,
+WdfRequestRetrieveOutputBuffer, etc.). Identify which WDF helper each
+indirect call resolves to, by following the [rip+offset] reference into
+the .data import table and resolving the symbol name. Use `analyzeHeadless`
+non-interactively with the Ghidra script in
+/home/lesley/projects/Personal/magic-mouse-tray/scripts/ghidra-applewirelessmouse-analysis.py
+as a starting point — extend it.
+
+==================================================================
+STEP 2 — Find what data is written to the IOCTL output buffer
+==================================================================
+The handler MUST eventually copy bytes into the IRP output buffer
+(`Irp->AssociatedIrp.SystemBuffer` or via WdfRequestRetrieveOutputBuffer).
+That copy operation is the "smoking gun" — whatever source pointer is
+passed to RtlCopyMemory / memcpy / WdfMemoryCopy* IS the descriptor source.
+
+Trace forwards from 0x810A. Look for:
+    a. Direct memcpy/RtlCopyMemory calls with a source pointer
+    b. WdfMemoryCreate* + WdfMemoryCopyFromBuffer
+    c. RtlInitUnicodeString-like patterns (less likely for binary blob)
+
+If a source pointer is identified, compute its file offset and report
+the bytes. If those bytes look like an SDP attribute response containing
+a HID descriptor sequence (UsagePage 0x05 0x01, etc.), you've found it.
+
+==================================================================
+STEP 3 — Check for dynamic descriptor construction
+==================================================================
+If no static source is found, the descriptor may be CONSTRUCTED at runtime.
+Look for:
+    - Stack-allocated buffer being filled with literal byte stores
+      (mov [rsp+N], 0x05 / mov byte ptr [rsp+M], 0x01 / etc.)
+    - Pool allocations (ExAllocatePoolWithTag) followed by population
+    - Multiple descriptor variants chosen via if/else (Mode A vs Mode B)
+
+If construction is dynamic, identify:
+    - the variant-selection criterion (registry key? device state? IOCTL
+      sub-function?)
+    - the byte sequence that constructs each variant
+    - whether one variant could be patched into the byte stores
+
+==================================================================
+STEP 4 — Map the relationship to Mode A / Mode B
+==================================================================
+PSN-0001 H-010 REVISED: HidBth's descriptor cache has two states.
+Mode A: vendor 0xFF00 TLC enumerated as separate COL02 child PDO
+        (battery readable via Input RID=0x90)
+Mode B: single Mouse TLC, COL02 stripped, phantom Feature 0x47
+        (scroll synthesized by Apple's filter, battery NOT readable)
+
+Determine: is the mode selected by Apple's filter (i.e., the filter
+chooses which descriptor to inject), or is it driven by HidBth's
+caching of device-supplied SDP responses (filter is passive)?
+
+If the filter is the source of mode selection, the variant-selection
+condition is patchable.
+
+==================================================================
+STEP 5 — Look for IOCTL 0x00410210 second occurrence
+==================================================================
+The IOCTL constant also appears at 0x8F72. That's a DIFFERENT handler
+(or fall-through). Trace it independently. It might be the other branch
+(Mode A vs Mode B) or a related IOCTL handler.
+
+==================================================================
+STEP 6 — Output report
+==================================================================
+Write findings to:
+    /home/lesley/projects/Personal/magic-mouse-tray/docs/SESSION-16-GHIDRA-DESCRIPTOR-TRACE.md
+
+Format:
+
+    # Session 16 — Ghidra Descriptor Trace Findings
+    ## BLUF
+    [1-2 sentences: did you find the descriptor source? Y/N. If Y, where.]
+
+    ## Method
+    [Tools, scripts run, time spent]
+
+    ## Findings
+    ### F1: IOCTL handler call graph
+    ### F2: Buffer-write site(s)
+    ### F3: Source pointer identification
+    ### F4: Static vs dynamic descriptor construction
+    ### F5: Mode A/B variant selection mechanism
+
+    ## Verdict
+    [One of:]
+    - PATCH-VIABLE: source bytes at file offset 0xXXXX, patch path is to
+      change those bytes + re-sign. Length-field references at 0xYYYY.
+    - PATCH-DIFFICULT: dynamic construction with N byte-store sites.
+      Patching requires modifying instructions, not data.
+    - PATCH-NOT-VIABLE: descriptor sourced from device SDP response
+      pass-through; binary patching gives no leverage.
+
+    ## Recommended Next Steps
+    [If PATCH-VIABLE: write the precise patch operations.
+     If PATCH-DIFFICULT: estimate effort and risk.
+     If PATCH-NOT-VIABLE: confirm PATH-B is the right call.]
+
+    ## Evidence
+    [Function signatures, instruction sequences, bytes-on-disk excerpts
+     supporting the verdict.]
+
+==================================================================
+RULES
+==================================================================
+- Read-only: NO writes to System32, registry, scheduled tasks, BTHPORT,
+  or any kernel-modifying state.
+- Do NOT install or replace any driver binary.
+- Do NOT modify the binary on disk; copy it to a tmp location for any
+  Ghidra analysis if needed (preserve checksums).
+- Use Ghidra in headless mode (analyzeHeadless) for repeatability.
+- If you reach a dead-end after 4 hours of focused work, stop and
+  write the report with PATCH-NOT-VIABLE verdict and rationale.
+- Do not delegate sub-questions back to the user; figure them out.
+- When in doubt, prefer reproducible scripted steps over interactive
+  Ghidra GUI sessions.
+
+==================================================================
+GUARDRAILS / SAFETY CHECKS
+==================================================================
+- After every analysis pass, verify md5 of the live driver binary still
+  matches f4ae407c228c3db6147d9e3307ed5f20. If not, abort.
+- DO NOT push commits to ai/* or main without explicit user approval.
+  Commits to a new ai/m14-ghidra-descriptor-trace branch are fine for
+  artifact preservation, but DO NOT open a PR.
+- DO NOT touch /mnt/c/mm-dev-queue/ — that's where the live driver
+  install pipeline operates.
+
+==================================================================
+EXIT CRITERIA
+==================================================================
+- Report written at the path above.
+- Verdict is one of PATCH-VIABLE / PATCH-DIFFICULT / PATCH-NOT-VIABLE.
+- Evidence section contains at minimum: 1 disassembly excerpt of the
+  IOCTL handler, 1 import-symbol resolution, 1 byte-stream sample if
+  any descriptor-shaped data is identified.
+- Notify the user via SMS (use the existing /sms or email skill if
+  available) with a 2-line summary and a link to the report file.
+```
+
+---
+
+## Optional automation
+
+If you want this to run unattended via a scheduler, add a `cron` or `at`
+entry that invokes the agent with the prompt above. The session should
+complete within 4 hours; longer than that and the agent should self-abort
+per the rules.
+
+Suggested invocation (for reference, do not run from here):
+
+```bash
+# To dispatch from another Claude Code session:
+# - Create a new background agent (general-purpose, large model preferred for RE)
+# - Pass the prompt block from above verbatim
+# - Foreground the agent only after the report file exists
+```
+
+## Estimated cost
+- Time: 2-4 hours of focused autonomous work
+- API spend: ~$5-15 in Gemini Pro / Claude Opus tokens for Ghidra script generation, decompilation review, and report writing
+- Risk: zero — investigation is read-only
+
+## Pre-check before starting (one-shot)
+
+```bash
+md5sum /mnt/c/Windows/System32/DriverStore/FileRepository/applewirelessmouse.inf_amd64_ac34ebceaaf7324c/applewirelessmouse.sys
+# Expected: f4ae407c228c3db6147d9e3307ed5f20
+```
+
+If the MD5 differs, the binary has been modified since this prompt was
+written — STOP and reconcile state before launching the investigation.

--- a/docs/PRD-PATH-B-USERLAND-RECYCLER.md
+++ b/docs/PRD-PATH-B-USERLAND-RECYCLER.md
@@ -1,0 +1,245 @@
+---
+title: "PRD-PATH-B — Phase 4-Omega Userland Recycler + Multi-Device Battery Tray"
+type: product-requirements
+parent_prd: PRD-184
+parent_psn: PSN-0001
+status: draft
+version: 0.1.0
+created: 2026-05-06
+target_release: TBD
+linked_repo: ReviveBusiness/magic-mouse-tray
+---
+
+# PRD-PATH-B — Phase 4-Omega Userland Recycler + Multi-Device Battery Tray
+
+## BLUF
+
+Deliver cursor + scroll + battery for Magic Mouse v3 (and v1/v2 + Magic Keyboard simultaneously) without modifying Apple's stock `applewirelessmouse.sys` driver. Strategy: tray app polls battery on demand by triggering a PnP recycle of the BTHENUM HID device to flip Apple's filter from Mode B (scroll, no battery) into Mode A (battery, no scroll), reads the battery, then flips back. Per H-009, recycle-to-Mode-A is empirically reliable. Acceptable trade-off: ~5 second scroll glitch per battery poll, scheduled adaptively.
+
+Multi-device support shows live battery for any combination of detected: keyboard, v1 mouse (PID 0x030D), v2 mouse (PID 0x0269), v3 mouse (PID 0x0323) — same tray icon, expanding context menu.
+
+---
+
+## Problem & Context
+
+Per PSN-0001 H-010 REVISED + H-007:
+
+- v3 hardware exposes battery only via Input RID=0x90 on a vendor TLC (UP=0xFF00 / Usage=0x14)
+- v1 mouse + Magic Keyboard expose battery via standard Feature RID=0x47 (UP=0x06 / Usage=0x20)
+- v2 mouse pattern presumed similar to v1 (Feature 0x47); confirm in M2 of this PRD
+- v3 with `applewirelessmouse` filter loaded has Mode A (battery readable, scroll broken) and Mode B (scroll synthesized, battery TLC stripped) — mutually exclusive
+- PnP recycle of the BTHENUM HID PDO can flip B→A reliably (H-009 confirmed); the inverse (A→B) is the steady state and re-establishes naturally
+
+PATH-A (binary-patch Apple driver) was invalidated 2026-05-06 — the embedded descriptor at 0xA850 has zero code references.
+
+M14 (clean-room kernel filter with in-IRP gesture translation) is out of scope per user direction.
+
+---
+
+## Goals
+
+| Goal | Acceptance Criterion |
+|---|---|
+| **G1** | v3 mouse battery readable in tray within 5 s of icon hover, with scroll auto-restored within 10 s after read completes |
+| **G2** | v1 mouse battery readable concurrently with v3 (no recycle dependency for v1) |
+| **G3** | v2 mouse battery readable concurrently with v1 + v3 (validate channel in M2) |
+| **G4** | Magic Keyboard battery readable concurrently with all mice (Feature 0x47) |
+| **G5** | Tray UI shows all detected devices simultaneously with per-device % and last-poll timestamp |
+| **G6** | Adaptive polling: more frequent when low (<20%), less frequent when high (>80%); default 15 min cadence per Magic Utilities pattern |
+| **G7** | Battery poll for v3 only fires when user is **idle for ≥30 s** to minimise scroll-glitch impact |
+| **G8** | Manual "refresh now" option in tray menu for explicit battery query |
+| **G9** | Mode A→B recovery is observed and reported in tray status; if recovery fails, alert user |
+| **G10** | Telemetry log of every recycle (timestamp, pre-state, post-state, success/fail, battery read result) |
+
+---
+
+## Non-Goals
+
+- M14 / kernel filter rewrite
+- Binary patching of `applewirelessmouse.sys`
+- AirPods / non-mouse-or-keyboard Apple devices
+- Replacing Apple's driver — keep the WHQL-signed 78424-byte stock binary intact
+
+---
+
+## Architecture
+
+### Component overview
+
+```
++---------------------------------+
+|         TrayApp (WPF)           |
+|---------------------------------|
+| - DeviceRegistry (multi-device) |
+| - PerDevicePoller (adaptive)    |
+| - V3RecycleManager (Mode A/B)   |
+| - BatteryDisplay (multi-row UI) |
++---------------+-----------------+
+                |
+                v
++---------------------------------+
+|    Per-Device Battery Reader    |
+|---------------------------------|
+| Keyboard (PID 0x0239)  -> 0x47  |  Feature read, no recycle needed
+| v1 mouse (PID 0x030D)  -> 0x47  |  Feature read, no recycle needed
+| v2 mouse (PID 0x0269)  -> 0x47* |  TBD M2 — confirm channel
+| v3 mouse (PID 0x0323)  -> 0x90  |  Input read, recycle needed for COL02
++---------------+-----------------+
+                |
+                v
++---------------------------------+
+|    PnpRecycler (v3 only)        |
+|---------------------------------|
+| - schedules recycle via         |
+|   MM-Dev-Cycle scheduled task   |
+| - waits for COL02 to enumerate  |
+| - reads battery                 |
+| - allows Mode A→B natural       |
+|   recovery (no forced action)   |
++---------------------------------+
+```
+
+### State machine for v3 polling
+
+```
+[Idle (Mode B)] --user-idle≥30s + poll-due--> [Cycling]
+[Cycling]  --recycle complete + Mode A detected--> [Reading]
+[Cycling]  --recycle complete + Mode B (still)--> [Idle (Mode B)] (skip poll, retry next interval)
+[Reading]  --battery received--> [Recovering]
+[Recovering] --Mode B observed--> [Idle (Mode B)]
+[Recovering] --60s timeout, still Mode A--> [Forced cycle to B]
+```
+
+### Multi-device tray UI
+
+```
++--------------------------------+
+|  ⌨  Magic Keyboard       82%   |
+|  🖱  Magic Mouse v1      67%   |
+|  🖱  Magic Mouse v2      54%*  |  * = polled 14 min ago
+|  🖱  Magic Mouse 2024    38%*  |  * = recycle-required device
+|--------------------------------|
+|  ⟳  Refresh All                |
+|  ⚙  Settings                   |
++--------------------------------+
+```
+
+### Multi-device detection logic
+
+| Device | Detection signal | Battery channel | Recycle? |
+|---|---|---|---|
+| Magic Keyboard | BTHENUM with VID=05AC PID=0239 (or Apple BT VID 004C variant) | `HidD_GetFeature(RID=0x47)` on COL01 | No |
+| Magic Mouse v1 | BTHENUM with VID=05AC PID=030D | `HidD_GetFeature(RID=0x47)` on COL01 | No |
+| Magic Mouse v2 | BTHENUM with VID=05AC PID=0269 | TBD M2 — try Feature 0x47 first, fall back to Input 0x90 | TBD |
+| Magic Mouse v3 | BTHENUM with VID=004C/05AC PID=0323 | `HidD_GetInputReport(RID=0x90)` on COL02 | **YES — only when COL02 missing** |
+
+A device is "detected" if its BTHENUM PDO is enumerated and Status=OK. Detection runs on tray app startup + every 60 s + on `WTSSESSION_CHANGE` / `DEVICECHANGE` events.
+
+---
+
+## Milestones
+
+### M1 — Multi-device detection scaffolding
+- [ ] Refactor `MouseBatteryReader.cs` into per-device readers behind a common `IBatteryDevice` interface
+- [ ] Add `KeyboardBatteryReader.cs` (Feature 0x47 path)
+- [ ] Add device registry that scans BTHENUM children every 60 s and on PnP change events
+- [ ] Tray menu rendered from registry; one row per detected device
+- **Exit criteria**: tray shows v1 + v3 with current static read paths working as today; keyboard appears if paired
+
+### M2 — v2 mouse channel confirmation
+- [ ] Pair v2 mouse, capture HID descriptor dump
+- [ ] Determine whether v2 uses Feature 0x47 (like v1/keyboard) or Input 0x90 (like v3)
+- [ ] Update `v2BatteryReader` to use confirmed channel
+- **Exit criteria**: v2 battery reads correctly when paired
+
+### M3 — v3 PnP recycler integration
+- [ ] Port C# prototype (commit e323df6 per PSN-0001 Session 10) into `V3RecycleManager.cs`
+- [ ] Wire to existing `MM-Dev-Cycle` scheduled task (`scripts/mm-task-runner.ps1`)
+- [ ] Add idle-detection (`GetLastInputInfo` Win32) — only recycle when idle ≥ 30 s
+- [ ] State machine implementation (Idle → Cycling → Reading → Recovering → Idle)
+- [ ] Cap recycle attempts (3 retries) with exponential backoff
+- **Exit criteria**: v3 battery readable in tray; scroll auto-recovers within 10 s of read complete
+
+### M4 — Adaptive polling
+- [ ] Per-device interval tracking
+- [ ] Default 15 min cadence (per research-findings.md guidance)
+- [ ] Reduce to 5 min when battery <20%
+- [ ] Increase to 60 min when battery >80% AND on AC (pass-through; not relevant for BT mice)
+- [ ] Manual "Refresh now" command in tray
+- **Exit criteria**: cadence correctly auto-adjusts, no thrash on boundaries
+
+### M5 — Telemetry + observability
+- [ ] Log every recycle attempt to `C:\ProgramData\MagicMouseTray\recycle-events.jsonl`
+- [ ] Log every battery read (success/failure, value, latency)
+- [ ] Tray menu "Show diagnostics" shows last 10 events
+- [ ] Optional: send anomaly alerts via existing `CriticalAlert.cs` + `ToastNotifier.cs` channels
+- **Exit criteria**: 7-day soak test produces clean event log with zero unexpected state-machine transitions
+
+### M6 — UX polish + Settings
+- [ ] Settings dialog: enable/disable v3 recycle (default off until first user request); polling intervals; idle-time threshold
+- [ ] Per-device colour-coded battery indicator (green >50%, yellow 20-50%, red <20%)
+- [ ] Tooltip with last-poll timestamp + manual refresh option
+- **Exit criteria**: settings persisted to `Config.cs`; user can disable v3 recycler if scroll glitch is unacceptable
+
+---
+
+## Open Questions
+
+1. **Q1 — recycle race conditions**: if user starts scrolling exactly when a recycle is in progress, does scroll get permanently broken until next cycle? → Need test in M3.
+2. **Q2 — v2 channel**: assumption is Feature 0x47 (matches v1+keyboard). If v2 actually uses RID 0x90 like v3, M2 will discover and we'll need an additional recycle path.
+3. **Q3 — keyboard descriptor cache**: does the keyboard have an analogous Mode A/B issue, or does Feature 0x47 work consistently? Per research-findings.md "kbdhid lock makes Feature 0x47 wedge" — needs M1 validation.
+4. **Q4 — multiple v3 mice**: edge case if user has two v3 mice paired. Each has its own BTHENUM and each needs its own recycle. Race-condition during simultaneous recycles.
+5. **Q5 — battery telemetry retention**: how much history to keep? Default 30 days?
+
+---
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| User scrolls during recycle window | Adaptive: only recycle on user idle ≥ 30 s. State machine cancels in-flight recycle if user input detected. |
+| Mode A→B recovery fails | Detect after 60 s timeout; force a second recycle; if still stuck, alert user with manual recovery option. |
+| Magic Utilities residual filter conflicts | Detection on startup: if `LowerFilters` includes `MagicMouse` or other 3rd-party kernel filters, warn user and disable v3 recycler (we don't own the descriptor cache behaviour). |
+| Recycle scheduled task disabled | Check `MM-Dev-Cycle` task health on startup; if missing, regenerate from `scripts/install-driver.ps1`. |
+| Driver instability after many recycles | Track failure rate; if >10% recycles fail in a 24h window, alert user + open issue. |
+
+---
+
+## Dependencies
+
+- `applewirelessmouse.sys` Apple WHQL stock driver (already restored 2026-05-05)
+- `MM-Dev-Cycle` scheduled SYSTEM task + `scripts/mm-task-runner.ps1` (already implemented; existing routes `RESTART-DEVICE` + `CLEAR-BT-SDP-CACHE` cover the recycle path)
+- C# tray app (`MagicMouseTray/*.cs`) — extension via M1-M6 above
+- Existing `MouseBatteryReader.cs` Feature/Input read code paths (refactor in M1)
+- HID descriptor dumps for v1, v2, v3, keyboard (already captured in `.ai/test-runs/2026-04-27-154930-T-V3-AF/`)
+
+---
+
+## Out of Scope (deferred)
+
+- Deeper Ghidra investigation of `applewirelessmouse.sys` to enable proper binary patching (separate session — see `docs/INVESTIGATION-PROMPT-GHIDRA-DESCRIPTOR-TRACE.md`)
+- M14 kernel filter rewrite
+- Power management integration (charging/AC detection — not applicable to Bluetooth peripherals)
+- AirPods battery via BLE manufacturer data (separate subsystem; see `docs/research-findings.md`)
+- Battery-low system notifications via Windows Action Center (defer to v2)
+
+---
+
+## Success Metrics
+
+- v3 battery read success rate ≥ 95% over 7-day soak
+- v3 scroll glitch duration ≤ 10 s per poll (P95)
+- Battery polls per day per v3 mouse ≤ 100 (default 15 min cadence ≈ 96/day)
+- Zero unrecovered Mode A states across 7 days
+- All 4 device types polled correctly when paired simultaneously
+
+---
+
+## References
+
+- PSN-0001 hypothesis log: H-007 (battery-only without filter), H-009 (recycle reliability), H-010 revised (mode mutual exclusion)
+- Phase 4-Omega plan: `.ai/test-runs/2026-04-27-154930-T-V3-AF/PHASE4-OMEGA-PLAN.md`
+- Research synthesis: `docs/research-findings.md` (three battery channels + cadence guidance)
+- C# recycle prototype: commit `e323df6` (per PSN-0001 Session 10)
+- Magic Utilities cadence reference: 15 min poll interval, avoids 10–50 ms scroll stutter
+- Session 15 empirical results: `docs/SESSION-15-EMPIRICAL-TEST-RESULTS-2026-05-05.md`

--- a/docs/SESSION-15-EMPIRICAL-TEST-RESULTS-2026-05-05.md
+++ b/docs/SESSION-15-EMPIRICAL-TEST-RESULTS-2026-05-05.md
@@ -1,0 +1,182 @@
+# Session 15 — Empirical Test Results & Patching Plan
+
+**Date**: 2026-05-05
+**Author**: agent (autonomous)
+**Status**: data collection complete, plan pending user approval
+**Hardware**: Magic Mouse v3 (PID 0x0323), MAC D0:C0:50:CC:8C:4D
+**OS**: Windows 11 build 26100
+**Goal**: cursor + scroll + battery simultaneously, NO M14 rewrite
+
+---
+
+## BLUF
+
+Today's tests refute the assumption that the binary-patched Apple driver (66288 bytes, MD5 `74756dc8...`) is a "small delta from original". The patch re-architected the descriptor (5→2 buttons, single TLC→split TLCs, Feature 0x47→Input 0x90 battery) and that re-architecture is the most likely cause of `STATUS_INVALID_PARAMETER_MIX`. Two independent expert reviews (Gemini Flash + Pro) converge on **PATH-A: append-only descriptor patch** as the highest-viability untested option. PATH-A blocked in-place by only 4 bytes of zero-padding after the descriptor; needs descriptor relocation (find pointer reference, update). Apple stock driver is currently restored — cursor + scroll work, no battery (Mode B / Descriptor B / unified).
+
+---
+
+## Test 1 — Descriptor Decode Comparison
+
+**Method**: extract HID descriptor bytes from each binary, decode item-by-item.
+**Binaries**:
+- A: `/mnt/c/mm-dev-queue/applewirelessmouse-fixed.sys` (66288 bytes, MD5 `74756dc8...`) — patched Apple, FAILS to load with NTSTATUS 0xC00000B9
+- B: `/mnt/c/mm-dev-queue/MagicMouseDriver-wdf.sys` (29664 bytes, MD5 `1578adac...`) — Session-14 WDF, CONFIRMED working (battery=22%)
+
+**Result**:
+
+| Field | Patched Apple | WDF Session-14 |
+|-------|---------------|-----------------|
+| Descriptor offset | 0xA850 | 0x4450 |
+| Descriptor length | 116 bytes | 135 bytes |
+| TLCs | 2 (Mouse, Battery vendor) | 3 (Mouse, Battery vendor, Touch vendor) |
+| TLC1 | UP=0x0001 U=0x0002 RIDs=[0x02, 0x27] | UP=0x0001 U=0x0002 RIDs=[0x02, 0x47] |
+| TLC2 | UP=0xFF00 U=0x0014 RIDs=[0x90, 0x91] | UP=0xFF00 U=0x0014 RID=[0x90] |
+| TLC3 | (none — touch in TLC1) | UP=0xFF00 U=0x0027 RID=[0x27] |
+
+**Verdict**: both descriptors structurally valid. Each Input/Output/Feature has Usage in scope and Logical Min/Max defined (constant-flag inputs allowed).
+
+**Conclusion**: FAILED_START is **not** caused by Session-14-style descriptor parser bug.
+
+---
+
+## Test 2 — Live Load with Documented Procedure
+
+**Method**: install the 66288-byte patched Apple binary into System32 + DriverStore, run the documented 2026-04-30 procedure (BTHPORT cache clear + `pnputil /restart-device`), check device status.
+
+**Result**:
+- Earlier today (simple disable+enable): Problem Code 10, NTSTATUS 0xC00000B9 (`STATUS_INVALID_PARAMETER_MIX`)
+- Test 2 (with cache clear + restart): Problem Code 22 (`CM_PROB_DISABLED`), ProblemStatus 0
+- COL01/COL02/COL03 not enumerated (children show Status: Unknown — phantom)
+- BTHPORT cache subkey not at expected registry path (`HKLM:\SYSTEM\CurrentControlSet\Services\BTHPORT\Parameters\Devices\D0C050CC8C4D` had no `Cache` child key) — cache clear was a no-op
+
+**Verdict**: the 2026-04-30 patched binary does NOT load successfully today, regardless of procedure. The binary or its environment (Windows hidclass.sys / HidBth.sys) has changed in a way that prevents a successful load now.
+
+---
+
+## Test 3 — Strict Offline Validator
+
+**Method**: implemented a stricter validator that checks every Input/Output/Feature item for Usage, Logical Min/Max, ReportSize, ReportCount in scope.
+
+**Result**:
+- Patched Apple: 2 errors (constant-flag padding inputs without Usage — false positives; HID spec allows Const items without Usage)
+- WDF Session-14: 1 error (same false positive)
+
+**Verdict**: confirms Test 1. Both descriptors pass real hidclass parser rules. STATUS_INVALID_PARAMETER_MIX is **not** a parser rejection.
+
+---
+
+## Test 4 — Byte-Level Diff: Original vs Patched
+
+**Method**: extract Apple's ORIGINAL 116-byte descriptor at 0xA850 from `applewirelessmouse.inf_amd64_ac34ebceaaf7324c\applewirelessmouse.sys` (Microsoft WHQL signed). Compare byte-by-byte to the patched version.
+
+### Major architectural changes:
+
+| Aspect | Apple ORIGINAL | PATCHED |
+|---|---|---|
+| Top-level Application Collections | **1** (single TLC) | **2** (split) |
+| Mouse buttons | **5** (UsageMin 1 / UsageMax 5, RCount 5, Size 1) | **2** (UsageMin 1 / UsageMax 2, RCount 2, Size 1) |
+| Padding bits in byte 0 of mouse report | 3 | 6 |
+| Vendor pad TLC | UP=0xFF02 (1 bit) at +030 | removed |
+| Battery declaration | Feature **RID=0x47** (UP=0x06 GenericDeviceCtrls, Usage=0x20 BatteryStrength) | Input **RID=0x90** (UP=0xFF00 vendor) in new TLC2 + RID=0x91 feature padding |
+| Touch RID 0x27 | inside TLC, length 46, LMin=1 LMax=65 | inside TLC1, length 46, LMin=129 LMax=127 (signed inherited) |
+
+**Conclusion**: the 2026-04-30 patch is NOT a delta — it's a re-architecture. The mouse button count change (5→2) and the absence of an explicit RID 0x27 LogicalMin/Max declaration (uses inherited values 0x81/0x7F from earlier in the descriptor) are likely sources of `STATUS_INVALID_PARAMETER_MIX` because:
+1. Apple's runtime gesture engine likely has compiled-in assumptions about mouse report layout (5 buttons + 3 padding bits in byte 0). With descriptor declaring 2 buttons + 6 padding, the report layout that hidparse computes from the descriptor differs from what Apple's engine produces. → parameter validation fails.
+2. The H-016 finding ("byte layout mismatch causes Apple's gesture output bytes to land in the button bit field") is consistent with this — same root cause, different manifestation.
+
+---
+
+## Peer Review Summary (2 expert opinions)
+
+### Round 1 (Gemini 2.5 Flash + Gemini 2.5 Pro, both T2/T3)
+- **Verdict**: CHANGES-NEEDED
+- **Recommended path**: try BLE GATT 0x180F first; if not, minimal 2-TLC patch
+- **GATT path**: REJECTED by D-001 (Apple v1+v3 use BR/EDR HID, not BLE) — confirmed by 150-source NotebookLM research
+- **Minimal 2-TLC patch path**: ALREADY EXISTS as the 66288-byte file. Test 4 shows it's not really "minimal" — it re-architected the mouse TLC.
+
+### Round 2 (Gemini 2.5 Pro, with Test 1-4 evidence)
+- **Verdict**: NEED-MORE-DATA
+- **Q1 (append-only patch satisfies constraints?)**: yes, theoretically — Apple's gesture engine would see its expected 5-button layout, HidBth would create COL02 child PDO for the appended TLC.
+- **Q2 (where is descriptor length referenced?)**: most likely `IOCTL_HID_GET_DEVICE_DESCRIPTOR` handler in applewirelessmouse.sys; look for `mov ecx, 0x74` or similar near the descriptor pointer reference. Length must be patched alongside the descriptor.
+- **Q3 (does H-010 mode mutual exclusion still apply?)**: NO — H-010 was about runtime mode-flipping in the unmodified driver. Binary patching the descriptor bytes bypasses the mode-flip logic (driver injects only one descriptor, the patched one).
+- **Q4 (would standard Feature 0x47 read work on v3?)**: not tested in his round, but per PSN H-008 + 588 prior probes: REJECTED. v3 hardware doesn't back the phantom Feature 0x47 declaration in its descriptor (err=87).
+- **Q5 ranking**:
+  1. PATH-C (test stock Feature 0x47 read) — already tested, fails per H-008
+  2. **PATH-A (append-only patch)** — highest viability untested, recommended
+  3. PATH-B (Phase 4-Omega userland recycler) — last resort, degraded UX
+  4. PATH-D (hybrid filter stack) — H-016 already showed filter chains fail
+
+---
+
+## PATH-A Construction Attempt (today)
+
+**Approach**: keep Apple's original 116-byte descriptor at 0xA850 byte-for-byte; append 22-byte TLC2 (UP=0xFF00, Usage=0x14, RID=0x90, vendor battery) copied verbatim from WDF Session-14's known-working TLC2.
+
+**Blockers identified**:
+1. Only **4 bytes of zero-padding** immediately after the descriptor at 0xA8C4. Insufficient for 22-byte append.
+2. Region 0xA8C4..0xA8DC contains float constants (0x80 0x3F = 1.0f, etc.) — NOT safe to overwrite.
+3. Descriptor-length immediates `116` (0x74) found in binary as raw u32 at offsets 0x1FC, 0x201, 0x77B6, 0x9BAA, 0xE22C. Need to disassemble to identify which is the descriptor length vs PE/struct fields.
+
+**Required next steps to complete PATH-A**:
+1. Disassemble applewirelessmouse.sys to find the descriptor pointer (`lea rax, [0xA850]` or similar) and the length immediate that flows together with it.
+2. Choose relocation target: either (a) freed Apple PE cert space (after signtool removed Apple's 12KB cert overlay), or (b) extend a section. (a) is simpler.
+3. Build relocated descriptor at the new offset, patch the pointer instruction, patch the length immediate, sign with MagicMouseFix cert.
+4. Install via `RUN-AS-SYSTEM` route. Test with cache clear + restart-device + wake mouse.
+
+**Estimated effort**: 1-2 hours for someone comfortable with x86-64 PE patching + Ghidra. Brittle; subject to break by future Windows updates.
+
+---
+
+## Current System State (after Apple stock restore)
+
+```
+System32\drivers\applewirelessmouse.sys: f4ae407c... (Apple WHQL stock, 78424 bytes)
+LowerFilters on BTHENUM HID PDO: applewirelessmouse only
+BTHENUM HID Status: OK (after enable)
+COL02: NOT enumerated (Mode B / unified descriptor — no battery)
+Cursor + scroll: working via Apple driver
+Test backup at: C:\mm-dev-queue\backup-restore-apple-20260505-180233\
+```
+
+---
+
+## Recommended Path Forward
+
+### OPTION 1: Pursue PATH-A (binary patch with relocation)
+**Cost**: 1-2 hours focused work + brittle long-term maintenance.
+**Risk**: medium — incorrect patch can produce non-loadable driver. Signed self-cert means testsigning required forever.
+**Reward**: cursor + scroll + battery from a single Apple-derived binary, no userland service.
+
+### OPTION 2: Phase 4-Omega userland recycler (PATH-B)
+**Cost**: 0 driver work; tray-app code change to detect "battery query needed" → trigger PnP recycle to flip into Mode A → read battery → flip back.
+**Risk**: low; the recycle behaviour is documented (H-009 confirmed).
+**Reward**: degraded UX (scroll glitch during the read window, ~5s) but all three behaviors achievable.
+
+### OPTION 3: Accept current state
+**Cost**: 0.
+**Reward**: cursor + scroll work; no battery indicator. Tray app can poll PnP state without showing % when in Mode B.
+
+---
+
+## Files & Test Artifacts
+
+| Artifact | Path | Purpose |
+|---|---|---|
+| Test 1 decoder | `/tmp/decode-hid-descriptor.py` | Item-by-item HID descriptor decode |
+| Test 3 strict validator | `/tmp/decode-hid-detailed.py` | Stricter rules check |
+| Test 4 byte-diff | `/tmp/compare-original-vs-patched.py` | Original vs patched comparison |
+| PATH-A candidate builder | `/tmp/build-append-only-patch.py` | Identifies blockers (zero-padding, length immediates) |
+| Test 2 install script | `/mnt/c/mm-dev-queue/test2-load-patched-apple.ps1` | Live install with documented procedure |
+| Test 2 log | `/mnt/c/mm-dev-queue/test2-patched-apple.log` | Outcome details |
+| Round 1 peer review | `/tmp/peer-review-mm-v3.md` | Initial expert prompt |
+| Round 2 peer review | `/tmp/peer-review-mm-v3-round2.md` | Second-round prompt with new evidence |
+| Apple restore script | `/mnt/c/mm-dev-queue/restore-apple-driver.ps1` | Used to restore current state |
+| Apple stock backups | `C:\mm-dev-queue\backup-restore-apple-*\` | Recovery point |
+
+---
+
+## Activity Log
+
+| Date | Update |
+|------|--------|
+| 2026-05-05 | Tests 1-4 executed; Apple stock restored; PATH-A candidate built but in-place append blocked by float constants at 0xA8C4. Two-round peer review complete. Plan documented; awaiting user approval before binary-patch work. |

--- a/docs/SESSION-15-EMPIRICAL-TEST-RESULTS-2026-05-05.md
+++ b/docs/SESSION-15-EMPIRICAL-TEST-RESULTS-2026-05-05.md
@@ -1,17 +1,26 @@
 # Session 15 — Empirical Test Results & Patching Plan
 
-**Date**: 2026-05-05
+**Date**: 2026-05-05 / **Updated**: 2026-05-06
 **Author**: agent (autonomous)
-**Status**: data collection complete, plan pending user approval
+**Status**: data collection complete; PATH-A INVALIDATED on 2026-05-06; awaiting user decision on remaining paths
 **Hardware**: Magic Mouse v3 (PID 0x0323), MAC D0:C0:50:CC:8C:4D
 **OS**: Windows 11 build 26100
 **Goal**: cursor + scroll + battery simultaneously, NO M14 rewrite
 
 ---
 
-## BLUF
+## BLUF (revised 2026-05-06)
 
-Today's tests refute the assumption that the binary-patched Apple driver (66288 bytes, MD5 `74756dc8...`) is a "small delta from original". The patch re-architected the descriptor (5→2 buttons, single TLC→split TLCs, Feature 0x47→Input 0x90 battery) and that re-architecture is the most likely cause of `STATUS_INVALID_PARAMETER_MIX`. Two independent expert reviews (Gemini Flash + Pro) converge on **PATH-A: append-only descriptor patch** as the highest-viability untested option. PATH-A blocked in-place by only 4 bytes of zero-padding after the descriptor; needs descriptor relocation (find pointer reference, update). Apple stock driver is currently restored — cursor + scroll work, no battery (Mode B / Descriptor B / unified).
+**PATH-A invalidated**: exhaustive search of Apple's binary on 2026-05-06 found **zero references** to the descriptor at file offset 0xA850 — no LEA RIP-rel, no `mov rax, imm64`, no relocations, no 32-bit immediate constants pointing there. The bytes at 0xA850 appear to be **inert build-leftover data**. Patching them likely does nothing. The 04-30 doc claim "COL01+COL02 created from patched 2-TLC descriptor" was probably misattributed (mouse happened to be in Mode A at that moment, independent of the patch).
+
+Yesterday's button-count claim (5→2) was also **wrong** — both descriptors declare 2 buttons identically. The actual diff is in TLC structure (vendor pad removed, RID 0x27 association lost, separate TLC2 added).
+
+**Surviving paths** (none involve M14):
+1. **Deeper RE investigation** — find the actual descriptor source via Ghidra trace of IOCTL 0x00410210 handler at file offset 0x810A. 2-4 hr coin-flip outcome. If successful, leads to a viable binary patch.
+2. **PATH-B (Phase 4-Omega userland recycler)** — deterministic; all three behaviors with ~5s scroll glitch per battery poll. Multi-device support (keyboard + v1/v2/v3 mice).
+3. **Accept current state** — cursor + scroll only, no battery indicator.
+
+Apple stock driver is currently restored — cursor + scroll work, no battery (Mode B / Descriptor B / unified).
 
 ---
 
@@ -108,20 +117,65 @@ Today's tests refute the assumption that the binary-patched Apple driver (66288 
 
 ---
 
-## PATH-A Construction Attempt (today)
+## PATH-A Construction (2026-05-05) — INVALIDATED 2026-05-06
 
-**Approach**: keep Apple's original 116-byte descriptor at 0xA850 byte-for-byte; append 22-byte TLC2 (UP=0xFF00, Usage=0x14, RID=0x90, vendor battery) copied verbatim from WDF Session-14's known-working TLC2.
+**Approach (initial)**: keep Apple's original 116-byte descriptor at 0xA850 byte-for-byte; append 22-byte TLC2.
 
-**Blockers identified**:
-1. Only **4 bytes of zero-padding** immediately after the descriptor at 0xA8C4. Insufficient for 22-byte append.
-2. Region 0xA8C4..0xA8DC contains float constants (0x80 0x3F = 1.0f, etc.) — NOT safe to overwrite.
-3. Descriptor-length immediates `116` (0x74) found in binary as raw u32 at offsets 0x1FC, 0x201, 0x77B6, 0x9BAA, 0xE22C. Need to disassemble to identify which is the descriptor length vs PE/struct fields.
+**Blockers from 2026-05-05**:
+1. Only **4 bytes of zero-padding** immediately after the descriptor at 0xA8C4 (followed by float constants).
+2. Required relocating descriptor + patching pointer/length references.
 
-**Required next steps to complete PATH-A**:
-1. Disassemble applewirelessmouse.sys to find the descriptor pointer (`lea rax, [0xA850]` or similar) and the length immediate that flows together with it.
-2. Choose relocation target: either (a) freed Apple PE cert space (after signtool removed Apple's 12KB cert overlay), or (b) extend a section. (a) is simpler.
-3. Build relocated descriptor at the new offset, patch the pointer instruction, patch the length immediate, sign with MagicMouseFix cert.
-4. Install via `RUN-AS-SYSTEM` route. Test with cache clear + restart-device + wake mouse.
+### 2026-05-06 finding — PATH-A is fundamentally broken
+
+Exhaustive search of `applewirelessmouse.sys` (78424-byte WHQL stock binary) for any reference to the descriptor at file offset 0xA850 / RVA 0xC050 / VA 0x14000C050:
+
+| Reference type | Hits |
+|---|---|
+| 8-byte abs VA `0x14000C050` (LE) | **0** |
+| 4-byte RVA `0xC050` (LE) | **0** |
+| LEA RIP-rel pointing to 0xC050..0xC0C4 in any R-X section | **0** |
+| Relocations into the descriptor RVA range | **0** |
+| 32-bit immediate `0xA850` anywhere | **0** |
+
+The IOCTL 0x00410210 handler at file offset 0x810A dispatches via WDF function pointers (indirect calls through `mov rax, [rip+0x58XX]`) — not via direct LEA to a static descriptor. The two LEA instructions in the .data range that are near the descriptor point to:
+- RVA 0xC0C8 (file 0xA8C8): float constants AFTER the descriptor end
+- RVA 0xC160 (file 0xA960): zero-region
+
+Neither is the descriptor itself.
+
+**Implication**: the bytes at 0xA850 are inert — likely build-leftover data that was never wired into Apple's runtime. Patching them does not change what HidBth receives. The 04-30 doc claim of "COL01+COL02 from patched 2-TLC descriptor" was misattributed (mouse was in Mode A at that moment via cache state, independent of the patch). The 66288-byte FAILED_START is unrelated to descriptor content — likely caused by re-signing damaging WDF metadata or other integrity checks.
+
+### Yesterday's button-count claim was also wrong
+
+Comparison of original vs patched at offsets 8-22 (mouse button definition):
+```
+ORIG  bytes 8-22: 05 09 19 01 29 02 15 00 25 01 95 02 75 01 81
+PATCH bytes 8-22: 05 09 19 01 29 02 15 00 25 01 95 02 75 01 81  (identical)
+```
+Both declare **2 buttons** (UsageMax=2, ReportCount=2). The actual diff starts at offset +27 (74 of 116 bytes differ — substantial but not in the buttons region).
+
+### What IS different in the patched 116-byte descriptor
+
+Real differences (not 5→2 buttons as claimed yesterday):
+- Original TLC1 has UsagePage 0xFF02 vendor padding (1 bit) at +030 — removed in patched
+- Original TLC1 has UsagePage=6 + Usage=1 association preceding RID 0x27 input — removed in patched (RID 0x27 inherits LogicalMin=129, LogicalMax=127 from the X/Y physical collection, declared with no Usage → relies on Const flag)
+- Original TLC1 has Feature RID=0x47 phantom battery (14 bytes) — removed in patched
+- Patched added new TLC2 (UP=0xFF00 Usage=0x14) with RID=0x90 input + RID=0x91 feature padding
+
+Even if these layout differences were causal, **the patch can't reach Apple's runtime because nothing in the binary reads from 0xA850**.
+
+---
+
+## Decision Required (2026-05-06)
+
+| Option | Outcome | Effort | Risk |
+|---|---|---|---|
+| **A. Deeper RE investigation (Ghidra)** | Find actual descriptor source via IOCTL handler 0x810A trace. If found → viable patch. If not → confirms PATH-A dead. | 2-4 hr | Coin-flip viability |
+| **B. PATH-B userland recycler + multi-device tray** | Cursor + scroll + battery (with ~5s poll-time scroll glitch). Plus keyboard/v1/v2/v3 simultaneous battery display. | C# tray-app changes only | Low |
+| **C. Accept current state** | Cursor + scroll work. No battery. | 0 | None |
+
+PRD for Option B authored as `docs/PRD-PATH-B-USERLAND-RECYCLER.md`.
+Investigation prompt for Option A authored as `docs/INVESTIGATION-PROMPT-GHIDRA-DESCRIPTOR-TRACE.md`.
 
 **Estimated effort**: 1-2 hours for someone comfortable with x86-64 PE patching + Ghidra. Brittle; subject to break by future Windows updates.
 

--- a/scripts/build-append-only-patch.py
+++ b/scripts/build-append-only-patch.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Build an APPEND-ONLY patched applewirelessmouse.sys candidate.
+
+Strategy:
+  1. Keep Apple's original 116-byte descriptor at 0xA850 byte-for-byte.
+  2. Append ~22 bytes for a new vendor battery TLC2 (UP=0xFF00, Usage=0x14, RID=0x90).
+  3. Find and patch any embedded length immediates that reference 116 (0x74).
+  4. Output candidate to /mnt/c/mm-dev-queue/applewirelessmouse-append.sys
+     for offline analysis. Do NOT install.
+
+The new TLC2 is 22 bytes copied directly from the WDF Session-14 binary's known-working
+TLC2 (which empirically returned battery=22% via RID=0x90).
+"""
+
+from pathlib import Path
+import struct
+
+ORIG = Path('/mnt/c/Windows/System32/DriverStore/FileRepository/applewirelessmouse.inf_amd64_ac34ebceaaf7324c/applewirelessmouse.sys')
+WDF  = Path('/mnt/c/mm-dev-queue/MagicMouseDriver-wdf.sys')
+OUT  = Path('/mnt/c/mm-dev-queue/applewirelessmouse-append.sys')
+
+orig = bytearray(ORIG.read_bytes())
+wdf  = WDF.read_bytes()
+
+print(f'Original Apple binary: {len(orig)} bytes')
+print(f'WDF binary:            {len(wdf)} bytes')
+
+# 1. Find original 116-byte descriptor location (0xA850 is the patched location;
+#    confirm it's also in the original)
+DESC_OFF_PATCHED = 0xA850
+prefix = bytes.fromhex('05010902a1018502')
+desc_off_orig = orig.find(prefix)
+print(f'Descriptor in original: 0x{desc_off_orig:X}')
+if desc_off_orig != DESC_OFF_PATCHED:
+    print(f'WARN: descriptor offset differs between original (0x{desc_off_orig:X}) and patched (0x{DESC_OFF_PATCHED:X})')
+
+# 2. Get the new TLC2 from the WDF binary (offsets 89..110 within the 135-byte block at 0x4450)
+WDF_DESC_OFF = 0x4450
+wdf_desc = wdf[WDF_DESC_OFF:WDF_DESC_OFF + 135]
+new_tlc2 = wdf_desc[89:111]  # 22 bytes
+print(f'New TLC2 ({len(new_tlc2)} bytes): {new_tlc2.hex(" ").upper()}')
+
+# 3. Find the length immediate. Apple's binary is ~78424 bytes and has many places that
+#    might reference 0x74 (116). We look for narrow patterns near the descriptor:
+#    Pattern 1: `mov ecx, 0x74`     -> b9 74 00 00 00 (5 bytes)
+#    Pattern 2: `mov edx, 0x74`     -> ba 74 00 00 00
+#    Pattern 3: `cmp <reg>, 0x74`   -> 83 f? 74
+#    Pattern 4: `mov ax, 74h`        -> 66 b8 74 00
+#    Pattern 5: `74 00 00 00`         -- raw 32-bit value 116 (could be a struct field)
+#    Pattern 6: `74` near a ULONG-aligned slot
+print()
+print('--- searching for descriptor length references (immediate value 0x74 = 116) ---')
+
+patterns = [
+    (b'\xb9\x74\x00\x00\x00', 'mov ecx, 116'),
+    (b'\xba\x74\x00\x00\x00', 'mov edx, 116'),
+    (b'\x41\xb8\x74\x00\x00\x00', 'mov r8d, 116'),
+    (b'\x6a\x74', 'push 116 (8-bit)'),
+    (b'\x74\x00\x00\x00', 'raw u32 = 116'),
+    (b'\x74\x00', 'raw u16 = 116 (also branch byte alas)'),
+]
+for pat, desc in patterns:
+    locations = []
+    i = 0
+    while True:
+        j = orig.find(pat, i)
+        if j < 0: break
+        locations.append(j)
+        i = j + 1
+    if locations:
+        if len(pat) <= 2:
+            # too short, suppress unless near descriptor
+            near = [hex(l) for l in locations if 0xA000 < l < 0xC000]
+            if near:
+                print(f'  {desc:32}  near descriptor offsets: {near[:8]}')
+        else:
+            print(f'  {desc:32}  at: {[hex(l) for l in locations[:8]]}')
+
+# 4. Build the candidate by appending TLC2 at 0xA850 + 116
+new_binary = bytearray(orig)
+
+# Verify 0xA850..0xA8C4 region in original:
+print(f'Region 0xA850..0xA8C4 (existing descriptor): {bytes(new_binary[0xA850:0xA8C4]).hex(" ").upper()[:80]}...')
+print(f'Region 0xA8C4..0xA8DC (where TLC2 would go): {bytes(new_binary[0xA8C4:0xA8DC]).hex(" ").upper()}')
+
+# Check if there are zero bytes (free space) immediately after the descriptor
+free_after = 0
+for i in range(0xA8C4, min(0xA8C4 + 64, len(new_binary))):
+    if new_binary[i] == 0x00:
+        free_after += 1
+    else:
+        break
+print(f'Zero bytes immediately after descriptor: {free_after} bytes')
+if free_after >= 22:
+    print(f'  >> Sufficient zero-padding: can append TLC2 in-place at 0xA8C4')
+else:
+    print(f'  >> NOT enough zero-padding. Would need to relocate descriptor or find code cave.')
+
+# Try the in-place append if free_after is sufficient
+NEW_DESC_LEN = 116 + len(new_tlc2)
+print(f'\nNew descriptor length: {NEW_DESC_LEN} bytes (0x{NEW_DESC_LEN:X})')
+
+if free_after >= len(new_tlc2):
+    new_binary[0xA8C4:0xA8C4 + len(new_tlc2)] = new_tlc2
+    print(f'  Wrote TLC2 in place at 0xA8C4..0x{0xA8C4 + len(new_tlc2):X}')
+
+    # Now patch any 116-immediate references found above. We'll only patch
+    # those in code patterns, not raw bytes (too risky).
+    patches_applied = 0
+    for pat, desc in [
+        (b'\xb9\x74\x00\x00\x00', b'\xb9' + NEW_DESC_LEN.to_bytes(4, 'little')),
+        (b'\xba\x74\x00\x00\x00', b'\xba' + NEW_DESC_LEN.to_bytes(4, 'little')),
+        (b'\x41\xb8\x74\x00\x00\x00', b'\x41\xb8' + NEW_DESC_LEN.to_bytes(4, 'little')),
+        (b'\x6a\x74', b'\x6a' + bytes([NEW_DESC_LEN])),
+    ]:
+        i = 0
+        while True:
+            j = new_binary.find(pat, i)
+            if j < 0: break
+            new_binary[j:j+len(pat[0:1])+len(pat)-1] = pat
+            new_binary[j:j+len(patches_applied if False else 0)] = b''  # cancel weird write
+            # Actually just manually replace
+            new_binary[j:j+len(pat)] = pat[:len(pat)-len(NEW_DESC_LEN.to_bytes(4, 'little'))] + NEW_DESC_LEN.to_bytes(4 if pat[0] in (0xb9,0xba) or pat[:2]==b'\x41\xb8' else 1, 'little')
+            patches_applied += 1
+            i = j + len(pat)
+    # Note: my length-replacement logic above is too clever-by-half; rewrite simpler.
+    new_binary = bytearray(orig)  # reset
+    new_binary[0xA8C4:0xA8C4 + len(new_tlc2)] = new_tlc2
+    # Replace immediate 116 (0x74) -> 138 (0x8A) at well-known opcodes:
+    replacements = [
+        (b'\xb9\x74\x00\x00\x00', b'\xb9\x8a\x00\x00\x00', 'mov ecx,116 -> mov ecx,138'),
+        (b'\xba\x74\x00\x00\x00', b'\xba\x8a\x00\x00\x00', 'mov edx,116 -> mov edx,138'),
+        (b'\x41\xb8\x74\x00\x00\x00', b'\x41\xb8\x8a\x00\x00\x00', 'mov r8d,116 -> mov r8d,138'),
+        (b'\x6a\x74', b'\x6a\x8a', 'push 116 -> push 138'),
+    ]
+    print('\n--- patching length immediates ---')
+    for old, new, desc in replacements:
+        i = 0
+        while True:
+            j = new_binary.find(old, i)
+            if j < 0: break
+            new_binary[j:j+len(old)] = new
+            print(f'  Patched at 0x{j:X}: {desc}')
+            i = j + len(new)
+
+    OUT.write_bytes(bytes(new_binary))
+    print(f'\nWrote candidate: {OUT} ({len(new_binary)} bytes)')
+
+    # Verify the appended descriptor looks right
+    final_desc = new_binary[0xA850:0xA850 + NEW_DESC_LEN]
+    print(f'\nFinal descriptor ({NEW_DESC_LEN} bytes):')
+    print('  ', final_desc.hex(' ').upper())
+else:
+    print('\nABORT: not enough zero space to append TLC2 in place.')
+    print('Would need to relocate the descriptor to an unused region (PE overlay or .data tail).')
+    print('That is more invasive — pause for user review.')

--- a/scripts/compare-original-vs-patched.py
+++ b/scripts/compare-original-vs-patched.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Compare Apple's ORIGINAL embedded descriptor vs the patched one byte-by-byte.
+
+This isolates exactly what the binary patch changed and identifies whether
+the patched descriptor is shorter, longer, or differently structured than
+what Apple's runtime gesture-engine code was compiled against.
+"""
+
+from pathlib import Path
+
+ORIG = Path('/mnt/c/Windows/System32/DriverStore/FileRepository/applewirelessmouse.inf_amd64_ac34ebceaaf7324c/applewirelessmouse.sys')
+PATCHED = Path('/mnt/c/mm-dev-queue/applewirelessmouse-fixed.sys')
+
+orig = ORIG.read_bytes()
+patch = PATCHED.read_bytes()
+
+print(f'Original Apple binary:  {len(orig)} bytes')
+print(f'Patched Apple binary:   {len(patch)} bytes')
+print(f'Size delta: {len(orig) - len(patch)} bytes')
+
+# Try to find the descriptor in the original. The patched is at 0xA850.
+# Original is bigger (has Apple's WHQL cert overlay). Descriptor offset
+# may differ. Search for the well-known mouse descriptor prefix.
+prefix = bytes.fromhex('05010902a1018502')  # UsagePage Generic, Usage Mouse, Coll App, RID=0x02
+matches_orig = []
+i = 0
+while True:
+    j = orig.find(prefix, i)
+    if j < 0: break
+    matches_orig.append(j)
+    i = j + 1
+matches_patch = []
+i = 0
+while True:
+    j = patch.find(prefix, i)
+    if j < 0: break
+    matches_patch.append(j)
+    i = j + 1
+print(f'Descriptor prefix matches: original={[hex(x) for x in matches_orig]}, patched={[hex(x) for x in matches_patch]}')
+
+# Use the "data section" descriptor (the embedded one, not the SDP-builder copy)
+# The doc says the descriptor used for injection is at 0xA850 in the patched.
+# Find the same content in original.
+orig_desc_off = matches_orig[0] if matches_orig else 0xA850
+patch_desc_off = 0xA850
+
+orig_desc = orig[orig_desc_off:orig_desc_off+116]
+patch_desc = patch[patch_desc_off:patch_desc_off+116]
+
+print(f'\nOriginal descriptor at 0x{orig_desc_off:X} (116 bytes):')
+print('  ', ' '.join(f'{b:02X}' for b in orig_desc))
+print(f'\nPatched descriptor at 0x{patch_desc_off:X} (116 bytes):')
+print('  ', ' '.join(f'{b:02X}' for b in patch_desc))
+
+# Byte-by-byte diff
+print(f'\nBYTE-LEVEL DIFF:')
+n_diffs = 0
+runs = []
+in_run = False
+run_start = None
+for i in range(min(len(orig_desc), len(patch_desc))):
+    if orig_desc[i] != patch_desc[i]:
+        n_diffs += 1
+        if not in_run:
+            run_start = i
+            in_run = True
+    else:
+        if in_run:
+            runs.append((run_start, i-1))
+            in_run = False
+if in_run:
+    runs.append((run_start, len(orig_desc)-1))
+print(f'  {n_diffs} differing bytes in {len(runs)} contiguous runs:')
+for start, end in runs:
+    orig_run = orig_desc[start:end+1]
+    patch_run = patch_desc[start:end+1]
+    print(f'    bytes [+{start:03d}..+{end:03d}] ({end-start+1} bytes):')
+    print(f'      ORIG : {" ".join(f"{b:02X}" for b in orig_run)}')
+    print(f'      PATCH: {" ".join(f"{b:02X}" for b in patch_run)}')
+
+# Decode each
+MAIN  = {0x80:'Input', 0x90:'Output', 0xB0:'Feature', 0xA0:'Coll', 0xC0:'EndColl'}
+GLOB  = {0x00:'UsgPg', 0x10:'LMin', 0x20:'LMax', 0x30:'PMin', 0x40:'PMax',
+         0x50:'UExp', 0x60:'Unit', 0x70:'RSize', 0x80:'RID', 0x90:'RCount'}
+LOC   = {0x00:'Usg', 0x10:'UsgMin', 0x20:'UsgMax'}
+
+def items(buf):
+    i = 0
+    while i < len(buf):
+        p = buf[i]
+        if p == 0xFE:
+            n = buf[i+1] if i+1 < len(buf) else 0
+            yield (i, p, 'L?', f'long', None)
+            i += n + 3; continue
+        sz = p & 3
+        if sz == 3: sz = 4
+        ty = (p >> 2) & 3
+        tg = p & 0xF0
+        v  = int.from_bytes(buf[i+1:i+1+sz], 'little') if sz else None
+        if ty == 0: tag = MAIN.get(tg, f'M{tg:02X}')
+        elif ty == 1: tag = GLOB.get(tg, f'G{tg:02X}')
+        elif ty == 2: tag = LOC.get(tg, f'L{tg:02X}')
+        else: tag = f'R{tg:02X}'
+        yield (i, p, ty, tag, v)
+        i += 1 + sz
+
+def show(label, buf):
+    print(f'\n{label}:')
+    for off, prefix, ty, tag, val in items(buf):
+        v = '' if val is None else f'={val} (0x{val:X})'
+        print(f'  +{off:03d}  {prefix:02X}  {tag:<8}{v}')
+
+show('ORIGINAL (Apple stock embedded)', orig_desc)
+show('PATCHED (66288-byte signed)', patch_desc)

--- a/scripts/decode-hid-descriptor.py
+++ b/scripts/decode-hid-descriptor.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Decode HID Report Descriptors from the candidate binaries.
+
+Compares:
+  A) /mnt/c/mm-dev-queue/applewirelessmouse-fixed.sys  (66288 bytes)
+     -- Apple's stock binary patched at offset 0xA850 with a 2-TLC descriptor.
+     Currently FAILED_STARTing with NTSTATUS 0xC00000B9 (STATUS_INVALID_PARAMETER_MIX).
+
+  B) /mnt/c/mm-dev-queue/MagicMouseDriver-wdf.sys  (29664 bytes)
+     -- Session-14 WDF SDP-patcher with known-good 135-byte 3-TLC descriptor at offset 0x4450.
+     Empirically confirmed: HID OK = 3, RID=0x90 returns battery%.
+
+Prints the HID descriptor item stream for each, then summarises whether
+each Top-Level Collection has the items hidclass.sys requires (Usage,
+Logical Min/Max) for any Input/Output/Feature it declares.
+"""
+
+from pathlib import Path
+
+# Tag dictionaries (HID 1.11 spec)
+MAIN_TAGS  = {0x80:'Input', 0x90:'Output', 0xB0:'Feature',
+              0xA0:'Collection', 0xC0:'EndCollection'}
+GLOBAL_TAGS= {0x00:'UsagePage', 0x10:'LogicalMin', 0x20:'LogicalMax',
+              0x30:'PhysicalMin', 0x40:'PhysicalMax', 0x50:'UnitExp',
+              0x60:'Unit', 0x70:'ReportSize', 0x80:'ReportID',
+              0x90:'ReportCount', 0xA0:'Push', 0xB0:'Pop'}
+LOCAL_TAGS = {0x00:'Usage', 0x10:'UsageMin', 0x20:'UsageMax',
+              0x30:'DesignatorIndex', 0x40:'DesignatorMin', 0x50:'DesignatorMax',
+              0x70:'StringIndex', 0x80:'StringMin', 0x90:'StringMax',
+              0xA0:'Delimiter'}
+TYPE_NAME = {0:'M', 1:'G', 2:'L'}  # Main/Global/Local
+
+def decode(buf: bytes):
+    """Yield (offset, hex, type, tag_name, value, raw_bytes)."""
+    i = 0
+    n = len(buf)
+    while i < n:
+        prefix = buf[i]
+        if prefix == 0xFE:
+            length = buf[i+1] if i+1 < n else 0
+            yield (i, f'{prefix:02X}', 'LONG', f'long-item len={length}', None, buf[i:i+length+3])
+            i += length + 3
+            continue
+        bSize = prefix & 0x03
+        if bSize == 3:
+            bSize = 4
+        bType = (prefix >> 2) & 0x03
+        bTag  = prefix & 0xF0
+        data  = buf[i+1:i+1+bSize]
+        value = int.from_bytes(data, 'little', signed=False) if bSize else None
+        type_name = TYPE_NAME.get(bType, '?')
+        if bType == 0:
+            tag = MAIN_TAGS.get(bTag, f'?Main_{bTag:02X}')
+        elif bType == 1:
+            tag = GLOBAL_TAGS.get(bTag, f'?Global_{bTag:02X}')
+        elif bType == 2:
+            tag = LOCAL_TAGS.get(bTag, f'?Local_{bTag:02X}')
+        else:
+            tag = f'?Reserved_{bTag:02X}'
+        raw = buf[i:i+1+bSize]
+        yield (i, raw.hex(' ').upper(), type_name, tag, value, raw)
+        i += 1 + bSize
+
+def analyse(buf: bytes, label: str):
+    print(f'\n========== {label} ==========')
+    print(f'Length: {len(buf)} bytes')
+    items = list(decode(buf))
+    cur_tlc = 0
+    cur_report_id = None
+    cur_logmin = None
+    cur_logmax = None
+    cur_usage_page = None
+    cur_usages_in_scope = []
+    tlc_summary = []  # list of dicts per top-level collection
+    cur_tlc_info = None
+    for off, hex_, typ, tag, val, raw in items:
+        # human-readable line
+        val_str = '' if val is None else f' = {val} (0x{val:X})'
+        print(f'  +{off:03d}  [{typ}] {tag:<14}{val_str}   ({hex_})')
+
+        if typ == 'G' and tag == 'UsagePage':
+            cur_usage_page = val
+        elif typ == 'L' and tag == 'Usage':
+            cur_usages_in_scope.append(val)
+        elif typ == 'G' and tag == 'ReportID':
+            cur_report_id = val
+        elif typ == 'G' and tag == 'LogicalMin':
+            cur_logmin = val
+        elif typ == 'G' and tag == 'LogicalMax':
+            cur_logmax = val
+        elif typ == 'M' and tag == 'Collection':
+            if val == 0x01:  # Application -> top-level
+                cur_tlc += 1
+                cur_tlc_info = {
+                    'tlc': cur_tlc,
+                    'usage_page_at_open': cur_usage_page,
+                    'usage_at_open': cur_usages_in_scope[-1] if cur_usages_in_scope else None,
+                    'report_ids': set(),
+                    'inputs_with_usage': 0,
+                    'inputs_without_usage': 0,
+                    'inputs_with_logminmax': 0,
+                    'inputs_without_logminmax': 0,
+                    'has_logmin_seen': False,
+                    'has_logmax_seen': False,
+                }
+                tlc_summary.append(cur_tlc_info)
+        elif typ == 'M' and tag == 'EndCollection':
+            cur_usages_in_scope = []  # locals consumed at end of collection scope
+        elif typ == 'M' and tag in ('Input', 'Output', 'Feature'):
+            if cur_tlc_info is not None:
+                if cur_report_id is not None:
+                    cur_tlc_info['report_ids'].add(cur_report_id)
+                # for hidclass to accept, the Input/Output/Feature must have
+                # Usage range set + Logical Min/Max set in scope at this point
+                if cur_usages_in_scope or cur_tlc_info.get('usage_at_open'):
+                    cur_tlc_info['inputs_with_usage'] += 1
+                else:
+                    cur_tlc_info['inputs_without_usage'] += 1
+                if cur_logmin is not None and cur_logmax is not None:
+                    cur_tlc_info['inputs_with_logminmax'] += 1
+                else:
+                    cur_tlc_info['inputs_without_logminmax'] += 1
+                # tracked
+                cur_tlc_info['has_logmin_seen'] = cur_logmin is not None
+                cur_tlc_info['has_logmax_seen'] = cur_logmax is not None
+                # local usages consumed by Input/Output/Feature
+                cur_usages_in_scope = []
+
+    print()
+    print(f'------- {label}: TLC summary -------')
+    for tlc in tlc_summary:
+        print(f'  TLC{tlc["tlc"]}: UP=0x{(tlc["usage_page_at_open"] or 0):04X} '
+              f'U=0x{(tlc["usage_at_open"] or 0):04X}  RIDs={sorted(tlc["report_ids"])}')
+        print(f'    Input/Output/Feature with Usage in scope: {tlc["inputs_with_usage"]}')
+        print(f'    Input/Output/Feature WITHOUT Usage in scope: {tlc["inputs_without_usage"]}')
+        print(f'    With Logical Min+Max in scope: {tlc["inputs_with_logminmax"]}')
+        print(f'    WITHOUT Logical Min+Max in scope: {tlc["inputs_without_logminmax"]}')
+        verdict = 'OK' if (tlc['inputs_without_usage'] == 0
+                            and tlc['inputs_without_logminmax'] == 0) else 'REJECTED'
+        print(f'    --> hidclass would: {verdict}')
+    return tlc_summary
+
+# ---- run ----
+PATCHED_APPLE = Path('/mnt/c/mm-dev-queue/applewirelessmouse-fixed.sys')
+WDF_BIN       = Path('/mnt/c/mm-dev-queue/MagicMouseDriver-wdf.sys')
+
+# Patched Apple: descriptor at 0xA850, length 116
+apple_data = PATCHED_APPLE.read_bytes()
+apple_desc = apple_data[0xA850:0xA850 + 116]
+print(f'Apple binary size: {len(apple_data)} bytes')
+print(f'Apple descriptor first bytes: {apple_desc[:8].hex(" ").upper()}')
+
+# WDF: per Session 14 notes the patched descriptor is at offset 0x4450, length 135
+wdf_data = WDF_BIN.read_bytes()
+wdf_desc = wdf_data[0x4450:0x4450 + 135]
+print(f'WDF binary size: {len(wdf_data)} bytes')
+print(f'WDF descriptor first bytes: {wdf_desc[:8].hex(" ").upper()}')
+
+# Sanity: do they look like HID descriptors? First item should be Global UsagePage (0x05 nn)
+# 0x05 short = 0b00000101 (bSize=1, bType=01 Global, bTag=0000 UsagePage)
+print()
+print('Sanity:')
+print(f'  Apple desc[0:2] = {apple_desc[:2].hex(" ").upper()}  (expect "05 01" = UsagePage GenericDesktop)')
+print(f'  WDF   desc[0:2] = {wdf_desc[:2].hex(" ").upper()}  (expect "05 01" = UsagePage GenericDesktop)')
+
+apple_tlc = analyse(apple_desc, 'A) Patched Apple driver (0xA850, 116 bytes) — currently FAILED_START')
+wdf_tlc   = analyse(wdf_desc,   'B) WDF Session-14 driver (0x4450, 135 bytes) — known good (battery=22%)')
+
+# Final comparison
+print('\n========== FINAL VERDICT ==========')
+def has_bad(tlcs):
+    return any(t['inputs_without_usage'] > 0 or t['inputs_without_logminmax'] > 0 for t in tlcs)
+
+apple_bad = has_bad(apple_tlc)
+wdf_bad   = has_bad(wdf_tlc)
+print(f'  Patched Apple has malformed Input/Output/Feature items: {apple_bad}')
+print(f'  WDF Session-14 has malformed Input/Output/Feature items: {wdf_bad}')
+if apple_bad and not wdf_bad:
+    print('  ==> HYPOTHESIS CONFIRMED: Apple binary patch has the same bug Session 14 fixed.')
+    print('       Re-patch with a corrected 2-TLC descriptor and FAILED_START should clear.')
+elif not apple_bad:
+    print('  ==> HYPOTHESIS REJECTED: Apple binary patch descriptor looks valid.')
+    print('       FAILED_START must come from a different cause. Investigate further.')

--- a/scripts/decode-hid-detailed.py
+++ b/scripts/decode-hid-detailed.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Test 3 — Offline structural HID descriptor validation, with hex diff.
+
+Validates against the rules hidclass.sys / hidparse.sys check during
+IRP_MN_START_DEVICE. Catches issues that produce STATUS_COULD_NOT_INTERPRET
+and STATUS_INVALID_PARAMETER_MIX.
+
+Rules checked:
+  R1 — Top-Level Application Collection has Usage + UsagePage at open
+  R2 — Every Input/Output/Feature has Usage (or UsageMin/Max) in scope
+  R3 — Every Input/Output/Feature has Logical Min and Logical Max in scope
+  R4 — Every Input/Output/Feature has ReportSize and ReportCount in scope
+  R5 — Each TLC has at least one Report ID OR none consistently (Apple style)
+  R6 — Collection / EndCollection are balanced
+  R7 — No data items inside an Application Collection without first declaring
+       the Usage that named the collection
+  R8 — Vendor pages (UsagePage 0xFF00..) only declare Vendor-defined Usage
+  R9 — Reasonableness: Logical Max >= Logical Min when both unsigned-positive
+       (signed ranges OK if interpreted as 8/16/32-bit signed)
+"""
+
+from pathlib import Path
+import sys
+
+MAIN_TAGS  = {0x80:'Input', 0x90:'Output', 0xB0:'Feature',
+              0xA0:'Collection', 0xC0:'EndCollection'}
+GLOBAL_TAGS= {0x00:'UsagePage', 0x10:'LogicalMin', 0x20:'LogicalMax',
+              0x30:'PhysicalMin', 0x40:'PhysicalMax', 0x50:'UnitExp',
+              0x60:'Unit', 0x70:'ReportSize', 0x80:'ReportID',
+              0x90:'ReportCount', 0xA0:'Push', 0xB0:'Pop'}
+LOCAL_TAGS = {0x00:'Usage', 0x10:'UsageMin', 0x20:'UsageMax',
+              0x30:'DesignatorIndex', 0x40:'DesignatorMin', 0x50:'DesignatorMax',
+              0x70:'StringIndex', 0x80:'StringMin', 0x90:'StringMax',
+              0xA0:'Delimiter'}
+
+def decode(buf):
+    i = 0
+    while i < len(buf):
+        prefix = buf[i]
+        if prefix == 0xFE:
+            length = buf[i+1] if i+1 < len(buf) else 0
+            yield (i, prefix, 'LONG', f'long({length})', None, buf[i:i+length+3])
+            i += length + 3
+            continue
+        bSize = prefix & 0x03
+        if bSize == 3: bSize = 4
+        bType = (prefix >> 2) & 0x03
+        bTag  = prefix & 0xF0
+        data  = buf[i+1:i+1+bSize]
+        value = int.from_bytes(data, 'little', signed=False) if bSize else None
+        if bType == 0:
+            tag = MAIN_TAGS.get(bTag, f'?M_{bTag:02X}')
+        elif bType == 1:
+            tag = GLOBAL_TAGS.get(bTag, f'?G_{bTag:02X}')
+        elif bType == 2:
+            tag = LOCAL_TAGS.get(bTag, f'?L_{bTag:02X}')
+        else:
+            tag = f'?R_{bTag:02X}'
+        yield (i, bType, ['M','G','L','R'][bType], tag, value, buf[i:i+1+bSize])
+        i += 1 + bSize
+
+class Validator:
+    def __init__(self, name, buf):
+        self.name = name
+        self.buf  = buf
+        self.errors = []
+        self.warnings = []
+        self.tlcs = []
+        self.col_depth = 0
+        # global state
+        self.usage_page = None
+        self.report_id  = None
+        self.report_size = None
+        self.report_count = None
+        self.logical_min = None
+        self.logical_max = None
+        # local state (consumed by next Main item)
+        self.usages = []
+        self.usage_min = None
+        self.usage_max = None
+        # current top-level application collection
+        self.cur_tlc = None
+
+    def err(self, off, msg): self.errors.append(f'+{off:03d}: {msg}')
+    def warn(self, off, msg): self.warnings.append(f'+{off:03d}: {msg}')
+
+    def open_tlc(self, off):
+        self.cur_tlc = {
+            'open_offset': off,
+            'usage_page': self.usage_page,
+            'usage': self.usages[-1] if self.usages else None,
+            'report_ids': set(),
+            'main_count': 0,
+        }
+        self.tlcs.append(self.cur_tlc)
+        # check R1
+        if self.cur_tlc['usage_page'] is None:
+            self.err(off, 'TLC opened with no UsagePage in scope (R1)')
+        if self.cur_tlc['usage'] is None:
+            self.err(off, 'TLC opened with no Usage in scope (R1)')
+
+    def close_tlc(self, off):
+        self.cur_tlc = None
+
+    def check_main(self, off, tag):
+        if not self.cur_tlc:
+            return  # not inside a TLC
+        # R2 — Usage in scope
+        if not (self.usages or (self.usage_min is not None and self.usage_max is not None)):
+            self.err(off, f'{tag}: no Usage / UsageMin-Max in scope (R2)')
+        # R3 — Logical Min/Max in scope
+        if self.logical_min is None or self.logical_max is None:
+            self.err(off, f'{tag}: missing Logical Min/Max (R3)')
+        # R4 — ReportSize and ReportCount
+        if self.report_size is None: self.err(off, f'{tag}: ReportSize never set (R4)')
+        if self.report_count is None: self.err(off, f'{tag}: ReportCount never set (R4)')
+        # R9 — Logical Max >= Min for unsigned-looking pairs
+        if self.logical_min is not None and self.logical_max is not None:
+            # Treat as signed if either is > 127 in 8-bit-ish range
+            lm, lmax = self.logical_min, self.logical_max
+            if lm > lmax:
+                # could be signed (0xFF = -1, 0x7F = 127)
+                pass  # accept for now, it's a known Apple pattern
+        # bookkeeping
+        if self.report_id is not None:
+            self.cur_tlc['report_ids'].add(self.report_id)
+        self.cur_tlc['main_count'] += 1
+        # locals consumed
+        self.usages = []
+        self.usage_min = None
+        self.usage_max = None
+
+    def run(self):
+        for off, btype, tname, tag, value, raw in decode(self.buf):
+            if tname == 'G':
+                if tag == 'UsagePage': self.usage_page = value
+                elif tag == 'ReportID':
+                    self.report_id = value
+                elif tag == 'ReportSize': self.report_size = value
+                elif tag == 'ReportCount': self.report_count = value
+                elif tag == 'LogicalMin': self.logical_min = value
+                elif tag == 'LogicalMax': self.logical_max = value
+            elif tname == 'L':
+                if tag == 'Usage': self.usages.append(value)
+                elif tag == 'UsageMin': self.usage_min = value
+                elif tag == 'UsageMax': self.usage_max = value
+            elif tname == 'M':
+                if tag == 'Collection':
+                    if value == 0x01:  # Application
+                        self.col_depth += 1
+                        if self.col_depth == 1:
+                            self.open_tlc(off)
+                    else:
+                        self.col_depth += 1
+                    # locals consumed by Collection
+                    self.usages = []
+                    self.usage_min = None
+                    self.usage_max = None
+                elif tag == 'EndCollection':
+                    self.col_depth -= 1
+                    if self.col_depth == 0:
+                        self.close_tlc(off)
+                    if self.col_depth < 0:
+                        self.err(off, 'Unbalanced EndCollection (R6)')
+                elif tag in ('Input','Output','Feature'):
+                    self.check_main(off, tag)
+        if self.col_depth != 0:
+            self.errors.append(f'Unbalanced collections at end (depth={self.col_depth})')
+
+    def report(self):
+        print(f'\n========== {self.name} ==========')
+        print(f'  Length: {len(self.buf)} bytes')
+        print(f'  Top-level Application Collections: {len(self.tlcs)}')
+        for i, tlc in enumerate(self.tlcs, 1):
+            up = tlc['usage_page'] or 0
+            u  = tlc['usage'] or 0
+            rids = sorted(tlc['report_ids'])
+            print(f'    TLC{i}: UP=0x{up:04X} U=0x{u:04X}  RIDs={[hex(r) for r in rids]}  mains={tlc["main_count"]}')
+        if self.errors:
+            print(f'\n  ERRORS ({len(self.errors)}) — these would cause hidclass to reject:')
+            for e in self.errors: print(f'    {e}')
+        else:
+            print(f'\n  ERRORS: 0 (descriptor would PASS hidclass parse)')
+        if self.warnings:
+            print(f'  WARNINGS ({len(self.warnings)}):')
+            for w in self.warnings: print(f'    {w}')
+        return len(self.errors) == 0
+
+# ---- run ----
+APPLE_BIN = Path('/mnt/c/mm-dev-queue/applewirelessmouse-fixed.sys').read_bytes()
+WDF_BIN   = Path('/mnt/c/mm-dev-queue/MagicMouseDriver-wdf.sys').read_bytes()
+
+apple_desc = APPLE_BIN[0xA850:0xA850+116]
+wdf_desc   = WDF_BIN[0x4450:0x4450+135]
+
+print('TEST 3 — OFFLINE STRUCTURAL VALIDATION')
+print(f'  Patched Apple binary: {len(APPLE_BIN)} bytes, descriptor at 0xA850, len 116')
+print(f'  WDF Session-14 binary: {len(WDF_BIN)} bytes, descriptor at 0x4450, len 135')
+
+apple_v = Validator('A) Patched Apple (FAILED_START today, Code 10/22)', apple_desc)
+apple_v.run()
+apple_pass = apple_v.report()
+
+wdf_v = Validator('B) WDF Session-14 (CONFIRMED working, battery=22%)', wdf_desc)
+wdf_v.run()
+wdf_pass = wdf_v.report()
+
+print('\n========== TEST 3 VERDICT ==========')
+print(f'  Patched Apple descriptor structural pass: {apple_pass}')
+print(f'  WDF Session-14 descriptor structural pass: {wdf_pass}')
+if apple_pass and wdf_pass:
+    print('  ==> Both descriptors are structurally valid HID.')
+    print('      FAILED_START on Configuration C is NOT caused by descriptor parser rejection.')
+    print('      Different cause (signing damage, code-data offset mismatch, runtime state, etc.)')
+elif not apple_pass:
+    print('  ==> Patched Apple descriptor has structural issues (above).')
+    print('      That would explain hidclass rejection.')
+
+# Hex compare TLC2 sections
+print('\n========== Bonus: hex compare TLC2 region (battery vendor) ==========')
+print(f'  Apple TLC2 (offsets 81-115 within the 116-byte block):')
+print('   ', ' '.join(f'{b:02X}' for b in apple_desc[81:116]))
+print(f'  WDF   TLC2 (offsets 89-110 within the 135-byte block):')
+print('   ', ' '.join(f'{b:02X}' for b in wdf_desc[89:111]))


### PR DESCRIPTION
## Summary

- Ran 4 empirical tests on the 2026-04-30 binary-patched applewirelessmouse.sys to determine why it FAILED_STARTs today
- Test 4 byte-diff revealed the patch is NOT a small delta — it changes 5-button mouse to 2-button + restructures TLCs + swaps Feature 0x47 for Input 0x90 battery. Apple's gesture engine likely has compiled-in 5-button offsets, hence STATUS_INVALID_PARAMETER_MIX
- Two adversarial peer reviews (Gemini Flash + Pro) converge on PATH-A: append-only descriptor patch keeping Apple's 116 bytes byte-for-byte unchanged
- PATH-A blocked in-place (4 bytes zero-padding before float constants); requires descriptor relocation
- Apple stock driver restored — cursor + scroll work, no battery (current state)

## Three Path Options Documented

- PATH-A binary patch with relocation (~1-2 hr disassembly + sign + install): cursor+scroll+battery from one Apple-derived binary; brittle long-term
- PATH-B Phase 4-Omega userland recycler (0 driver work): all three work but ~5s scroll glitch per battery poll
- OPTION 3 accept current state: cursor + scroll only

User decision needed before any binary work proceeds.

## Test plan

- [ ] User reviews docs/SESSION-15-EMPIRICAL-TEST-RESULTS-2026-05-05.md
- [ ] User chooses PATH-A, PATH-B, or accepts current state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
