### PR TITLE
feat(m1): multi-device battery detection scaffolding (PRD-26)

### DIFF
--- a/MagicMouseTray/AdaptivePoller.cs
+++ b/MagicMouseTray/AdaptivePoller.cs
@@ -1,14 +1,18 @@
 // SPDX-License-Identifier: MIT
 namespace MagicMouseTray;
 
-// Polls MouseBatteryReader at adaptive intervals based on battery level.
+// Polls all discovered Apple HID battery devices at adaptive intervals.
 // Tiers: >50%=2h  |  20-50%=30m  |  10-20%=10m  |  <10% or disconnected=5m
 //
 // BatteryChanged is raised from a thread-pool thread — callers must marshal
-// to the UI thread before touching WPF/NotifyIcon objects (done in M4 TrayApp).
+// to the UI thread before touching WPF/NotifyIcon objects (done in TrayApp).
+//
+// Interval is driven by the lowest battery level across all discovered devices.
+// pct=-1 (no devices) falls into the <10 tier — recheck frequently.
 internal sealed class AdaptivePoller : IDisposable
 {
-    // (percent, deviceName) — percent is -1 when mouse is disconnected
+    // Fired once per discovered device per poll cycle.
+    // percent sentinel values: -1=not found/disconnected, -2=present but unreadable (Mode B).
     internal event Action<int, string>? BatteryChanged;
 
     CancellationTokenSource _cts = new();
@@ -16,8 +20,7 @@ internal sealed class AdaptivePoller : IDisposable
 
     internal void Start() => _pollTask = PollLoop(_cts.Token);
 
-    // Cancels the current wait and polls immediately.
-    // Safe to call from any thread.
+    // Cancels the current wait and polls immediately. Safe to call from any thread.
     internal void RefreshNow()
     {
         var old = Interlocked.Exchange(ref _cts, new CancellationTokenSource());
@@ -37,22 +40,36 @@ internal sealed class AdaptivePoller : IDisposable
     {
         while (!ct.IsCancellationRequested)
         {
-            var (pct, name) = MouseBatteryReader.GetBatteryLevel();
+            var devices = DeviceRegistry.Discover();
 
-            // Fire always — pct=-1 means disconnected; callers handle both cases
-            BatteryChanged?.Invoke(pct, name);
+            int lowestPct = -1;
+            if (devices.Count == 0)
+            {
+                // No devices — fire a single synthetic event so callers can clear state
+                BatteryChanged?.Invoke(-1, string.Empty);
+            }
+            else
+            {
+                foreach (var device in devices)
+                {
+                    int pct = device.GetBatteryPercent();
+                    BatteryChanged?.Invoke(pct, device.DeviceName);
+                    if (pct >= 0 && (lowestPct < 0 || pct < lowestPct))
+                        lowestPct = pct;
+                }
+            }
 
-            var interval = GetInterval(pct);
-            Logger.Log($"POLL_SCHEDULED pct={pct} next_in={interval}");
+            var interval = GetInterval(lowestPct);
+            Logger.Log($"POLL_SCHEDULED devices={devices.Count} lowest_pct={lowestPct} next_in={interval}");
 
             try { await Task.Delay(interval, ct); }
             catch (TaskCanceledException) { break; }
         }
     }
 
-    // Returns the polling interval for a given battery %.
-    // pct=-1 (disconnected) falls into the <10 tier — recheck frequently.
-    internal static TimeSpan GetInterval(int pct) => pct switch
+    // Returns the polling interval based on the lowest battery level across all devices.
+    // lowestPct=-1 (no devices or all unreadable) → recheck frequently.
+    internal static TimeSpan GetInterval(int lowestPct) => lowestPct switch
     {
         > 50  => TimeSpan.FromHours(2),
         >= 20 => TimeSpan.FromMinutes(30),

--- a/MagicMouseTray/DeviceRegistry.cs
+++ b/MagicMouseTray/DeviceRegistry.cs
@@ -1,0 +1,46 @@
+// Discovers all connected Apple HID battery devices by scanning the HID device interface list.
+// Returns a fresh snapshot per call — no caching. AdaptivePoller drives the poll cadence.
+
+namespace MagicMouseTray;
+
+internal static class DeviceRegistry
+{
+    /// <summary>
+    /// Scans all present HID interfaces and returns one IBatteryDevice per matched Apple device.
+    /// Matching priority: mouse VID/PID checked first, then keyboard VID/PID.
+    /// </summary>
+    public static IReadOnlyList<IBatteryDevice> Discover()
+    {
+        var results = new List<IBatteryDevice>();
+
+        foreach (var path in HidNative.EnumerateHidPaths())
+        {
+            var device = TryClassify(path);
+            if (device is not null)
+                results.Add(device);
+        }
+
+        return results;
+    }
+
+    static IBatteryDevice? TryClassify(string path)
+    {
+        // Magic Mouse — check all variants
+        foreach (var entry in MouseBatteryDevice.KnownMice)
+        {
+            if (path.Contains(entry.VidPattern, StringComparison.OrdinalIgnoreCase) &&
+                path.Contains(entry.PidPattern, StringComparison.OrdinalIgnoreCase))
+                return new MouseBatteryDevice(path, entry.DisplayName, entry.Kind);
+        }
+
+        // Magic Keyboard
+        foreach (var entry in KeyboardBatteryDevice.KnownKeyboards)
+        {
+            if (path.Contains(entry.VidPattern, StringComparison.OrdinalIgnoreCase) &&
+                path.Contains(entry.PidPattern, StringComparison.OrdinalIgnoreCase))
+                return new KeyboardBatteryDevice(path, entry.DisplayName);
+        }
+
+        return null;
+    }
+}

--- a/MagicMouseTray/HidNative.cs
+++ b/MagicMouseTray/HidNative.cs
@@ -1,0 +1,172 @@
+// P/Invoke declarations for HID and SetupDi APIs shared across all device readers.
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace MagicMouseTray;
+
+internal static class HidNative
+{
+    internal const uint FILE_SHARE_READ    = 0x00000001;
+    internal const uint FILE_SHARE_WRITE   = 0x00000002;
+    internal const uint OPEN_EXISTING      = 3;
+    internal const uint DIGCF_PRESENT      = 0x02;
+    internal const uint DIGCF_DEVICEINTERFACE = 0x10;
+    internal const int  HIDP_STATUS_SUCCESS = 0x00110000;
+    internal static readonly IntPtr INVALID_HANDLE_VALUE = new(-1);
+
+    internal static readonly Guid HidGuid = new("4d1e55b2-f16f-11cf-88cb-001111000030");
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    internal static extern SafeFileHandle CreateFile(string lpFileName, uint dwDesiredAccess,
+        uint dwShareMode, IntPtr lpSecurityAttributes, uint dwCreationDisposition,
+        uint dwFlagsAndAttributes, IntPtr hTemplateFile);
+
+    [DllImport("hid.dll", SetLastError = true)]
+    internal static extern bool HidD_GetInputReport(SafeFileHandle HidDeviceObject,
+        byte[] ReportBuffer, int ReportBufferLength);
+
+    [DllImport("hid.dll", SetLastError = true)]
+    internal static extern bool HidD_GetFeature(SafeFileHandle HidDeviceObject,
+        byte[] ReportBuffer, int ReportBufferLength);
+
+    [DllImport("hid.dll")]
+    internal static extern bool HidD_GetPreparsedData(SafeFileHandle HidDeviceObject,
+        out IntPtr PreparsedData);
+
+    [DllImport("hid.dll")]
+    internal static extern bool HidD_FreePreparsedData(IntPtr PreparsedData);
+
+    [DllImport("hid.dll")]
+    internal static extern int HidP_GetCaps(IntPtr PreparsedData, ref HIDP_CAPS Capabilities);
+
+    [DllImport("hid.dll")]
+    internal static extern int HidP_GetValueCaps(int ReportType,
+        [In, Out] HIDP_VALUE_CAPS[] ValueCaps,
+        ref ushort ValueCapsLength, IntPtr PreparsedData);
+
+    [DllImport("setupapi.dll", SetLastError = true)]
+    internal static extern IntPtr SetupDiGetClassDevs(ref Guid ClassGuid, string? Enumerator,
+        IntPtr hwndParent, uint Flags);
+
+    [DllImport("setupapi.dll", SetLastError = true)]
+    internal static extern bool SetupDiEnumDeviceInterfaces(IntPtr DeviceInfoSet,
+        IntPtr DeviceInfoData, ref Guid InterfaceClassGuid, uint MemberIndex,
+        ref SP_DEVICE_INTERFACE_DATA DeviceInterfaceData);
+
+    [DllImport("setupapi.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    internal static extern bool SetupDiGetDeviceInterfaceDetail(IntPtr DeviceInfoSet,
+        ref SP_DEVICE_INTERFACE_DATA DeviceInterfaceData,
+        ref SP_DEVICE_INTERFACE_DETAIL_DATA DeviceInterfaceDetailData,
+        uint DeviceInterfaceDetailDataSize, out uint RequiredSize,
+        IntPtr DeviceInfoData);
+
+    [DllImport("setupapi.dll")]
+    internal static extern bool SetupDiDestroyDeviceInfoList(IntPtr DeviceInfoSet);
+
+    // Enumerates all present HID device interface paths.
+    internal static IEnumerable<string> EnumerateHidPaths()
+    {
+        var guid = HidGuid;
+        var devs = SetupDiGetClassDevs(ref guid, null, IntPtr.Zero,
+            DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+        if (devs == IntPtr.Zero || devs == INVALID_HANDLE_VALUE)
+            yield break;
+
+        try
+        {
+            uint index = 0;
+            while (true)
+            {
+                var iface = new SP_DEVICE_INTERFACE_DATA();
+                iface.cbSize = (uint)Marshal.SizeOf<SP_DEVICE_INTERFACE_DATA>();
+                if (!SetupDiEnumDeviceInterfaces(devs, IntPtr.Zero, ref guid, index++, ref iface))
+                    yield break;
+
+                var detail = new SP_DEVICE_INTERFACE_DETAIL_DATA();
+                detail.cbSize = IntPtr.Size == 8 ? 8u : 6u;
+                SetupDiGetDeviceInterfaceDetail(devs, ref iface, ref detail, 512,
+                    out _, IntPtr.Zero);
+
+                if (!string.IsNullOrEmpty(detail.DevicePath))
+                    yield return detail.DevicePath;
+            }
+        }
+        finally
+        {
+            SetupDiDestroyDeviceInfoList(devs);
+        }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct SP_DEVICE_INTERFACE_DATA
+    {
+        public uint cbSize;
+        public Guid InterfaceClassGuid;
+        public uint Flags;
+        public IntPtr Reserved;
+    }
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+    internal struct SP_DEVICE_INTERFACE_DETAIL_DATA
+    {
+        public uint cbSize;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 512)]
+        public string DevicePath;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct HIDP_CAPS
+    {
+        public ushort Usage;
+        public ushort UsagePage;
+        public ushort InputReportByteLength;
+        public ushort OutputReportByteLength;
+        public ushort FeatureReportByteLength;
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 17)]
+        public ushort[] Reserved;
+        public ushort NumberLinkCollectionNodes;
+        public ushort NumberInputButtonCaps;
+        public ushort NumberInputValueCaps;
+        public ushort NumberInputDataIndices;
+        public ushort NumberOutputButtonCaps;
+        public ushort NumberOutputValueCaps;
+        public ushort NumberOutputDataIndices;
+        public ushort NumberFeatureButtonCaps;
+        public ushort NumberFeatureValueCaps;
+        public ushort NumberFeatureDataIndices;
+    }
+
+    // Layout matches hidpi.h (Pack=4, 96 bytes on x64). Only IsRange=false fields used.
+    [StructLayout(LayoutKind.Sequential, Pack = 4)]
+    internal struct HIDP_VALUE_CAPS
+    {
+        public ushort UsagePage;
+        public byte ReportID;
+        [MarshalAs(UnmanagedType.U1)] public bool IsAlias;
+        public ushort BitField;
+        public ushort LinkCollection;
+        public ushort LinkUsage;
+        public ushort LinkUsagePage;
+        [MarshalAs(UnmanagedType.U1)] public bool IsRange;
+        [MarshalAs(UnmanagedType.U1)] public bool IsStringRange;
+        [MarshalAs(UnmanagedType.U1)] public bool IsDesignatorRange;
+        [MarshalAs(UnmanagedType.U1)] public bool IsAbsolute;
+        [MarshalAs(UnmanagedType.U1)] public bool HasNull;
+        public byte Reserved;
+        public ushort BitSize;
+        public ushort ReportCount;
+        public ushort Reserved1, Reserved2, Reserved3, Reserved4, Reserved5;
+        public uint UnitsExp;
+        public uint Units;
+        public int LogicalMin, LogicalMax;
+        public int PhysicalMin, PhysicalMax;
+        public ushort Usage;      // [NotRange] Usage (same slot as [Range] UsageMin)
+        public ushort UsageMax;
+        public ushort StringMin;
+        public ushort StringMax;
+        public ushort DesigMin;
+        public ushort DesigMax;
+        public ushort DataIdxMin;
+        public ushort DataIdxMax;
+    }
+}

--- a/MagicMouseTray/IBatteryDevice.cs
+++ b/MagicMouseTray/IBatteryDevice.cs
@@ -1,0 +1,22 @@
+namespace MagicMouseTray;
+
+public enum DeviceKind
+{
+    MagicMouseV1,
+    MagicMouseV2,
+    MagicMouseV3,
+    MagicKeyboard,
+}
+
+public interface IBatteryDevice
+{
+    string DeviceName { get; }
+    DeviceKind Kind { get; }
+
+    /// <summary>
+    /// Returns battery percentage (0–100), or a sentinel:
+    ///   -1  device not found
+    ///   -2  device present but descriptor blocks read (unified/Mode-B)
+    /// </summary>
+    int GetBatteryPercent();
+}

--- a/MagicMouseTray/KeyboardBatteryDevice.cs
+++ b/MagicMouseTray/KeyboardBatteryDevice.cs
@@ -1,0 +1,105 @@
+// IBatteryDevice implementation for Apple Magic Keyboard.
+//
+// Battery is reported via HID Generic Device Battery Strength (UsagePage=0x0006/Usage=0x0020),
+// Feature Report 0x47. Unlike the Magic Mouse unified-mode path, the keyboard driver does NOT
+// appear to block Feature 0x47 reads. To be confirmed empirically in M2.
+using System.Runtime.InteropServices;
+
+namespace MagicMouseTray;
+
+internal sealed class KeyboardBatteryDevice : IBatteryDevice
+{
+    // Known Magic Keyboard VID/PID entries (BT only; USB keyboards power from USB and don't report).
+    internal record struct VidPidEntry(string VidPattern, string PidPattern, string DisplayName);
+
+    internal static readonly VidPidEntry[] KnownKeyboards =
+    [
+        new("000205AC", "PID&0239", "Magic Keyboard"),       // BT, VID=Apple USB-IF 0x05AC
+        new("000205AC", "PID&0267", "Magic Keyboard Touch"), // BT, Touch ID variant
+    ];
+
+    const ushort UP_GENDEV_BATTERY     = 0x0006;
+    const ushort USG_GENDEV_BATTSTRENG = 0x0020;
+
+    readonly string _path;
+
+    public string DeviceName { get; }
+    public DeviceKind Kind => DeviceKind.MagicKeyboard;
+
+    internal KeyboardBatteryDevice(string path, string displayName)
+    {
+        _path = path;
+        DeviceName = displayName;
+    }
+
+    public int GetBatteryPercent()
+    {
+        using var handle = HidNative.CreateFile(
+            _path,
+            0,
+            HidNative.FILE_SHARE_READ | HidNative.FILE_SHARE_WRITE,
+            IntPtr.Zero,
+            HidNative.OPEN_EXISTING,
+            0,
+            IntPtr.Zero);
+
+        if (handle.IsInvalid)
+        {
+            Logger.Log($"KB_OPEN_FAILED path={_path} err={Marshal.GetLastWin32Error()}");
+            return -1;
+        }
+
+        if (!HidNative.HidD_GetPreparsedData(handle, out var preparsed)) return -1;
+
+        byte featureRid = 0;
+        int featureLen = 0;
+        bool found = false;
+
+        try
+        {
+            var caps = new HidNative.HIDP_CAPS();
+            if (HidNative.HidP_GetCaps(preparsed, ref caps) != HidNative.HIDP_STATUS_SUCCESS) return -1;
+            featureLen = caps.FeatureReportByteLength;
+
+            if (caps.NumberFeatureValueCaps > 0)
+            {
+                var fcaps = new HidNative.HIDP_VALUE_CAPS[caps.NumberFeatureValueCaps];
+                ushort len = caps.NumberFeatureValueCaps;
+                if (HidNative.HidP_GetValueCaps(2, fcaps, ref len, preparsed) == HidNative.HIDP_STATUS_SUCCESS)
+                {
+                    for (int i = 0; i < len; i++)
+                    {
+                        if (fcaps[i].UsagePage == UP_GENDEV_BATTERY && fcaps[i].Usage == USG_GENDEV_BATTSTRENG)
+                        {
+                            featureRid = fcaps[i].ReportID;
+                            found = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        finally
+        {
+            HidNative.HidD_FreePreparsedData(preparsed);
+        }
+
+        if (!found || featureLen == 0) return -1;
+
+        var buf = new byte[Math.Max(featureLen, 2)];
+        buf[0] = featureRid;
+        if (HidNative.HidD_GetFeature(handle, buf, buf.Length))
+        {
+            int pct = buf[1];
+            if (pct is >= 0 and <= 100)
+            {
+                Logger.Log($"KB_BATTERY_OK device={DeviceName} pct={pct}%");
+                return pct;
+            }
+            return -1;
+        }
+
+        Logger.Log($"KB_FEATURE_FAILED device={DeviceName} err={Marshal.GetLastWin32Error()}");
+        return -1;
+    }
+}

--- a/MagicMouseTray/MouseBatteryDevice.cs
+++ b/MagicMouseTray/MouseBatteryDevice.cs
@@ -1,0 +1,143 @@
+// IBatteryDevice implementation for Apple Magic Mouse (all generations).
+//
+// Battery read strategy:
+//   Split path (COL02, Mode A): UsagePage=0xFF00/Usage=0x0014, Input Report 0x90, buf[2]=pct.
+//     Requires applewirelessmouse NOT in LowerFilters (PATH-B via FLIP:NoFilter).
+//   Unified path (Mode B): Feature 0x47 Battery Strength — blocked by Apple driver (err=87).
+//     Returns -2 so callers can distinguish "present but unreadable" from "not found".
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace MagicMouseTray;
+
+internal sealed class MouseBatteryDevice : IBatteryDevice
+{
+    internal record struct VidPidEntry(string VidPattern, string PidPattern, string DisplayName, DeviceKind Kind);
+
+    internal static readonly VidPidEntry[] KnownMice =
+    [
+        new("0001004C", "PID&0323", "Magic Mouse 2024", DeviceKind.MagicMouseV3), // BT v3
+        new("VID_05AC",  "PID_0323", "Magic Mouse 2024", DeviceKind.MagicMouseV3), // USB v3
+        new("000205AC", "PID&030D", "Magic Mouse v1",   DeviceKind.MagicMouseV1), // BT v1
+        new("000205AC", "PID&0269", "Magic Mouse v2",   DeviceKind.MagicMouseV2), // BT v2 (M2 confirm pending)
+    ];
+
+    const ushort UP_VENDOR_BATTERY     = 0xFF00;
+    const ushort USG_VENDOR_BATTERY    = 0x0014;
+    const ushort UP_GENDEV_BATTERY     = 0x0006;
+    const ushort USG_GENDEV_BATTSTRENG = 0x0020;
+    const byte   BatteryReportId       = 0x90;
+
+    readonly string _path;
+
+    public string DeviceName { get; }
+    public DeviceKind Kind { get; }
+
+    internal MouseBatteryDevice(string path, string displayName, DeviceKind kind)
+    {
+        _path = path;
+        DeviceName = displayName;
+        Kind = kind;
+    }
+
+    public int GetBatteryPercent()
+    {
+        using var handle = HidNative.CreateFile(
+            _path,
+            0,  // zero access — avoids err=5 on mouhid-owned interfaces
+            HidNative.FILE_SHARE_READ | HidNative.FILE_SHARE_WRITE,
+            IntPtr.Zero,
+            HidNative.OPEN_EXISTING,
+            0,
+            IntPtr.Zero);
+
+        if (handle.IsInvalid)
+        {
+            Logger.Log($"MOUSE_OPEN_FAILED path={_path} err={Marshal.GetLastWin32Error()}");
+            return -1;
+        }
+
+        if (!HidNative.HidD_GetPreparsedData(handle, out var preparsed)) return -1;
+
+        bool splitVendor = false;
+        bool unifiedApple = false;
+        byte unifiedRid = 0;
+        int featureLen = 0;
+
+        try
+        {
+            var caps = new HidNative.HIDP_CAPS();
+            if (HidNative.HidP_GetCaps(preparsed, ref caps) != HidNative.HIDP_STATUS_SUCCESS) return -1;
+
+            featureLen = caps.FeatureReportByteLength;
+
+            if (caps.NumberFeatureValueCaps > 0)
+            {
+                var fcaps = new HidNative.HIDP_VALUE_CAPS[caps.NumberFeatureValueCaps];
+                ushort len = caps.NumberFeatureValueCaps;
+                if (HidNative.HidP_GetValueCaps(2, fcaps, ref len, preparsed) == HidNative.HIDP_STATUS_SUCCESS)
+                {
+                    for (int i = 0; i < len; i++)
+                    {
+                        if (fcaps[i].UsagePage == UP_GENDEV_BATTERY && fcaps[i].Usage == USG_GENDEV_BATTSTRENG)
+                        {
+                            unifiedApple = true;
+                            unifiedRid = fcaps[i].ReportID;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            if (caps.UsagePage == UP_VENDOR_BATTERY && caps.Usage == USG_VENDOR_BATTERY
+                && caps.InputReportByteLength >= 3)
+                splitVendor = true;
+        }
+        finally
+        {
+            HidNative.HidD_FreePreparsedData(preparsed);
+        }
+
+        if (splitVendor)
+        {
+            var buf = new byte[3];
+            for (int attempt = 0; attempt < 3; attempt++)
+            {
+                buf[0] = BatteryReportId;
+                if (HidNative.HidD_GetInputReport(handle, buf, buf.Length))
+                {
+                    if (buf[0] != BatteryReportId) return -1;
+                    int pct = buf[2];
+                    if (pct is < 0 or > 100) return -1;
+                    Logger.Log($"MOUSE_BATTERY_OK device={DeviceName} pct={pct}% (split)");
+                    return pct;
+                }
+                if (attempt < 2) Thread.Sleep(50);
+            }
+            Logger.Log($"MOUSE_READ_FAILED device={DeviceName} err={Marshal.GetLastWin32Error()}");
+            return -1;
+        }
+
+        if (unifiedApple && featureLen > 0)
+        {
+            var fbuf = new byte[Math.Max(featureLen, 2)];
+            fbuf[0] = unifiedRid;
+            if (HidNative.HidD_GetFeature(handle, fbuf, fbuf.Length))
+            {
+                int pct = fbuf[1];
+                if (pct is >= 0 and <= 100)
+                {
+                    Logger.Log($"MOUSE_BATTERY_OK device={DeviceName} pct={pct}% (unified Feature 0x{unifiedRid:X2})");
+                    return pct;
+                }
+                return -1;
+            }
+            int err = Marshal.GetLastWin32Error();
+            // Apple driver (6.2.0.0) traps Feature 0x47 — empirically confirmed 2026-04-27.
+            Logger.Log($"MOUSE_UNIFIED_BLOCKED device={DeviceName} err={err} (Mode B — needs PATH-B recycle)");
+            return -2;
+        }
+
+        return -1;
+    }
+}

--- a/MagicMouseTray/SelfHealRequest.cs
+++ b/MagicMouseTray/SelfHealRequest.cs
@@ -19,6 +19,7 @@
 // false; caller (SelfHealManager) gives up and enters Failed state.
 
 using System.Diagnostics;
+using System.IO;
 
 namespace MagicMouseTray;
 

--- a/MagicMouseTray/TrayApp.cs
+++ b/MagicMouseTray/TrayApp.cs
@@ -18,14 +18,14 @@ internal sealed class TrayApp : IDisposable
     readonly ToolStripMenuItem[] _thresholdItems;
     readonly ToolStripMenuItem _startupItem;
 
-    int _lastPct = -1;
-    string _lastName = string.Empty;
+    // Per-device battery state, keyed by device name. Updated per poll event.
+    // Cleared when no devices are detected (empty name from AdaptivePoller).
+    readonly Dictionary<string, int> _deviceBatteries = new(StringComparer.OrdinalIgnoreCase);
 
-    // Tracks which alert boundaries have already fired this drain cycle.
-    // Boundaries: [user threshold, 10%]. Cleared when battery returns above threshold or disconnects.
-    readonly HashSet<int> _firedBoundaries = new();
+    // Alert boundaries fired per-device this drain cycle. Cleared per-device when battery recovers.
+    readonly Dictionary<string, HashSet<int>> _firedBoundaries = new(StringComparer.OrdinalIgnoreCase);
 
-    // Persistent critical alert shown at 1%; auto-closed when mouse plugs in (pct=-1).
+    // Persistent critical alert shown at 1%; auto-closed when mouse unplugs.
     CriticalAlert? _criticalAlert;
 
     readonly DriverStatus _driverStatus;
@@ -125,8 +125,8 @@ internal sealed class TrayApp : IDisposable
         var testToast = new ToolStripMenuItem("Test Notification");
         testToast.Click += (_, _) =>
         {
-            var dev = _lastName.Length > 0 ? _lastName : "Magic Mouse";
-            ToastNotifier.Show(_lastPct >= 0 ? _lastPct : 15, dev);
+            var (name, pct) = _deviceBatteries.FirstOrDefault(kv => kv.Value >= 0);
+            ToastNotifier.Show(pct >= 0 ? pct : 15, name?.Length > 0 ? name : "Magic Mouse");
         };
         menu.Items.Add(testToast);
 
@@ -156,71 +156,103 @@ internal sealed class TrayApp : IDisposable
         // Marshal to WPF/STA thread — NotifyIcon was created there
         System.Windows.Application.Current.Dispatcher.Invoke(() =>
         {
-            _lastPct = pct;
-            if (!string.IsNullOrEmpty(name)) _lastName = name;
-
-            bool isLow = pct >= 0 && pct < _config.Threshold;
-            var device = _lastName.Length > 0 ? _lastName : "Magic Mouse";
-
-            // Cascading alerts: fire at user threshold, then again at 10% critical boundary.
-            // _firedBoundaries resets when battery recovers above threshold or disconnects.
-            if (pct < 0 || pct >= _config.Threshold)
+            if (string.IsNullOrEmpty(name))
             {
+                // Sentinel from AdaptivePoller: no devices found this cycle — clear all state
+                _deviceBatteries.Clear();
                 _firedBoundaries.Clear();
             }
             else
             {
-                var boundaries = _config.Threshold > 10
-                    ? new[] { _config.Threshold, 10 }
-                    : new[] { _config.Threshold };
+                _deviceBatteries[name] = pct;
 
-                foreach (var boundary in boundaries)
+                // Per-device alert boundaries
+                if (pct < 0 || pct >= _config.Threshold)
                 {
-                    if (pct < boundary && _firedBoundaries.Add(boundary))
+                    _firedBoundaries.Remove(name);
+                }
+                else
+                {
+                    if (!_firedBoundaries.TryGetValue(name, out var fired))
+                        _firedBoundaries[name] = fired = new HashSet<int>();
+
+                    var boundaries = _config.Threshold > 10
+                        ? new[] { _config.Threshold, 10 }
+                        : new[] { _config.Threshold };
+
+                    foreach (var boundary in boundaries)
                     {
-                        ToastNotifier.Show(pct, device);
-                        break; // one toast per poll cycle
+                        if (pct < boundary && fired.Add(boundary))
+                        {
+                            ToastNotifier.Show(pct, name);
+                            break;
+                        }
                     }
+                }
+
+                // Critical alert at 1% — use first device that hits it
+                if (pct == 1 && _criticalAlert == null)
+                {
+                    _criticalAlert = new CriticalAlert(pct, name);
+                    _criticalAlert.FormClosed += (_, _) => _criticalAlert = null;
+                    _criticalAlert.Show();
+                    Logger.Log($"CRITICAL_ALERT_SHOWN device={name} pct={pct}");
                 }
             }
 
-            // Persistent critical alert at 1% — auto-closes when mouse plugs in (pct=-1)
-            if (pct == 1 && _criticalAlert == null)
-            {
-                _criticalAlert = new CriticalAlert(pct, device);
-                _criticalAlert.FormClosed += (_, _) => _criticalAlert = null;
-                _criticalAlert.Show();
-                Logger.Log($"CRITICAL_ALERT_SHOWN pct={pct}");
-            }
-            else if (pct < 0 && _criticalAlert != null)
+            // Close critical alert when all devices are gone or the alerting device reconnects
+            if (_criticalAlert != null && (_deviceBatteries.Count == 0 ||
+                _deviceBatteries.Values.All(p => p < 0)))
             {
                 _criticalAlert.Close();
-                Logger.Log("CRITICAL_ALERT_CLOSED reason=charging");
+                Logger.Log("CRITICAL_ALERT_CLOSED reason=no_devices");
             }
 
-            // Update icon (badge dot in corner when driver not OK)
-            var newIcon = MakeIcon(pct, isLow, _driverStatus != DriverStatus.Ok);
-            var oldIcon = _currentIcon;
-            _tray.Icon = newIcon;
-            _currentIcon = newIcon;
-            oldIcon?.Dispose();
-
-            // Update tooltip (max 63 chars — Windows limit).
-            // pct=-1 means disconnected (no Apple Magic Mouse path responded).
-            // pct=-2 means inaccessible (path found, Apple driver in unified-mode trapping
-            // Feature Report 0x47 behind mouhid exclusivity — see PRD-184 / MouseBatteryReader).
-            var interval = AdaptivePoller.GetInterval(pct);
-            var pctStr = pct switch {
-                >= 0 => $"{pct}%",
-                -2   => "battery N/A",
-                _    => "disconnected",
-            };
-            var baseTip = $"{device} - {pctStr} · Next: {FormatInterval(interval)}";
-            var tip = _driverStatus != DriverStatus.Ok ? $"⚠ Driver | {baseTip}" : baseTip;
-            _tray.Text = tip.Length > 63 ? tip[..63] : tip;
-
-            Logger.Log($"TRAY_UPDATE pct={pct} isLow={isLow} tooltip=\"{_tray.Text}\"");
+            UpdateTrayIcon();
         });
+    }
+
+    void UpdateTrayIcon()
+    {
+        // Icon driven by the lowest valid battery across all devices
+        int lowestPct = _deviceBatteries.Count == 0
+            ? -1
+            : _deviceBatteries.Values.Aggregate(-1, (acc, p) =>
+                p >= 0 ? (acc < 0 ? p : Math.Min(acc, p)) : acc);
+
+        bool anyLow = lowestPct >= 0 && lowestPct < _config.Threshold;
+
+        var newIcon = MakeIcon(lowestPct, anyLow, _driverStatus != DriverStatus.Ok);
+        var oldIcon = _currentIcon;
+        _tray.Icon = newIcon;
+        _currentIcon = newIcon;
+        oldIcon?.Dispose();
+
+        // Tooltip: list all devices, truncate to 63 chars (Windows limit)
+        string tip;
+        if (_deviceBatteries.Count == 0)
+        {
+            tip = "Magic Mouse Battery — no devices detected";
+        }
+        else
+        {
+            var parts = _deviceBatteries.Select(kv =>
+            {
+                var pctStr = kv.Value switch {
+                    >= 0 => $"{kv.Value}%",
+                    -2   => "N/A",
+                    _    => "—",
+                };
+                return $"{kv.Key}: {pctStr}";
+            });
+            var joined = string.Join(" | ", parts);
+            var interval = AdaptivePoller.GetInterval(lowestPct);
+            tip = $"{joined} · {FormatInterval(interval)}";
+            if (_driverStatus != DriverStatus.Ok) tip = $"⚠ {tip}";
+        }
+
+        _tray.Text = tip.Length > 63 ? tip[..63] : tip;
+        Logger.Log($"TRAY_UPDATE devices={_deviceBatteries.Count} lowest={lowestPct} tooltip=\"{_tray.Text}\"");
     }
 
     static string FormatInterval(TimeSpan t)


### PR DESCRIPTION
## Summary

- **IBatteryDevice** interface + **DeviceKind** enum (MagicMouseV1/V2/V3, MagicKeyboard)
- **HidNative.cs** — shared P/Invoke layer extracted from MouseBatteryReader; includes `EnumerateHidPaths()` helper
- **MouseBatteryDevice** — IBatteryDevice for all Magic Mouse variants; same split/unified read logic as MouseBatteryReader but per-instance
- **KeyboardBatteryDevice** — IBatteryDevice for Magic Keyboard (Feature 0x47; empirical confirmation pending M2)
- **DeviceRegistry.Discover()** — fresh SetupDi scan per call → `IReadOnlyList<IBatteryDevice>`
- **AdaptivePoller** — now iterates DeviceRegistry; poll interval driven by lowest battery across all devices
- **TrayApp** — per-device state dict; tooltip lists all devices; icon tinted by lowest battery pct
- Fix `SelfHealRequest.cs` missing `using System.IO` (pre-existing build error)

## Architecture

```
AdaptivePoller.PollLoop()
  → DeviceRegistry.Discover()          # fresh SetupDi scan
      → MouseBatteryDevice (v1/v2/v3)  # split COL02 or unified path
      → KeyboardBatteryDevice           # Feature 0x47
  → BatteryChanged(pct, name)          # one event per device per cycle
  → TrayApp._deviceBatteries[name]=pct # accumulates per-device state
```

MouseBatteryReader.cs is NOT removed — SelfHealManager compatibility + legacy static API preserved.

## Test Plan

- [ ] Build succeeds: `dotnet build` → 0 errors, 0 warnings ✅
- [ ] Deploy to Windows test machine with v3 mouse paired
- [ ] Verify tray tooltip shows `Magic Mouse 2024: 17%` (Mode A, post-PATH-B recycle)
- [ ] Verify tray tooltip shows `Magic Mouse 2024: N/A` in Mode B (unified)
- [ ] Pair Magic Keyboard → verify second row appears in tooltip
- [ ] Disconnect keyboard → verify row eventually disappears (M4 will improve stale detection)

## Related

- PRD-26 PATH-B Userland Recycler — M1 milestone
- M0 validation: 25/25 PASS (commit e288820)
- Next: M2 (v2 mouse channel confirmation), M3 (V3RecycleManager)

🤖 Generated with [Claude Code](https://claude.com/claude-code)