### PR TITLE
fix(m3): DEVPKEY_Device_Stack for Mode B detection — replace IsV3MouseClassPresent false positive

### DIFF
--- a/MagicMouseTray/Config.cs
+++ b/MagicMouseTray/Config.cs
@@ -18,6 +18,7 @@ internal sealed class Config
 
     internal int Threshold { get; private set; } = 20;
     internal bool StartWithWindows { get; private set; }
+    internal bool EnableV3Recycle { get; private set; } = true;
 
     internal static Config Load()
     {
@@ -35,6 +36,8 @@ internal sealed class Config
                 cfg.Threshold = t;
             else if (key == "start_with_windows" && bool.TryParse(val, out bool s))
                 cfg.StartWithWindows = s;
+            else if (key == "enable_v3_recycle" && bool.TryParse(val, out bool r))
+                cfg.EnableV3Recycle = r;
         }
         return cfg;
     }
@@ -55,6 +58,13 @@ internal sealed class Config
         Logger.Log($"CONFIG start_with_windows={value}");
     }
 
+    internal void SetEnableV3Recycle(bool value)
+    {
+        EnableV3Recycle = value;
+        Persist();
+        Logger.Log($"CONFIG enable_v3_recycle={value}");
+    }
+
     static bool IsValid(int t) => t is 10 or 15 or 20 or 25;
 
     void Persist()
@@ -64,7 +74,8 @@ internal sealed class Config
             Directory.CreateDirectory(Path.GetDirectoryName(ConfigPath)!);
             File.WriteAllLines(ConfigPath, [
                 $"threshold={Threshold}",
-                $"start_with_windows={StartWithWindows.ToString().ToLower()}"
+                $"start_with_windows={StartWithWindows.ToString().ToLower()}",
+                $"enable_v3_recycle={EnableV3Recycle.ToString().ToLower()}"
             ]);
         }
         catch { }

--- a/MagicMouseTray/HidNative.cs
+++ b/MagicMouseTray/HidNative.cs
@@ -1,5 +1,6 @@
 // P/Invoke declarations for HID and SetupDi APIs shared across all device readers.
 using System.Runtime.InteropServices;
+using System.Text;
 using Microsoft.Win32.SafeHandles;
 
 namespace MagicMouseTray;
@@ -62,6 +63,62 @@ internal static class HidNative
 
     [DllImport("setupapi.dll")]
     internal static extern bool SetupDiDestroyDeviceInfoList(IntPtr DeviceInfoSet);
+
+    [DllImport("setupapi.dll", SetLastError = true)]
+    static extern bool SetupDiEnumDeviceInfo(IntPtr DeviceInfoSet, uint MemberIndex,
+        ref SP_DEVINFO_DATA DeviceInfoData);
+
+    // cfgmgr32: read device instance ID string from devnode handle
+    [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode)]
+    static extern uint CM_Get_Device_ID(uint dnDevInst, StringBuilder Buffer, uint BufferLen, uint ulFlags);
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct SP_DEVINFO_DATA
+    {
+        public uint cbSize;
+        public Guid ClassGuid;
+        public uint DevInst;
+        public IntPtr Reserved;
+    }
+
+    // GUID_DEVCLASS_MOUSE — Mouse class devices created by mouhid.sys when it binds to HID device
+    static readonly Guid MouseClassGuid = new("4d36e96f-e325-11ce-bfc1-08002be10318");
+
+    // Returns true if a Mouse class device with a v3 Magic Mouse instance ID exists and is present.
+    // mouhid.sys creates a Mouse class device only after it successfully binds — this is the
+    // definitive signal that cursor input is restored (unlike CreateFile which fires at PnP enumeration,
+    // before mouhid has attached). The Mouse class device instance ID directly encodes VID/PID.
+    //
+    // Note: uses DIGCF_PRESENT only (not DIGCF_DEVICEINTERFACE) — Mouse class devices are device
+    // instances, not HID interface paths. Using DIGCF_DEVICEINTERFACE returns an empty set.
+    internal static bool IsV3MouseClassPresent()
+    {
+        var guid = MouseClassGuid;
+        var devs = SetupDiGetClassDevs(ref guid, null, IntPtr.Zero, DIGCF_PRESENT);
+        if (devs == IntPtr.Zero || devs == INVALID_HANDLE_VALUE) return false;
+        try
+        {
+            uint idx = 0;
+            while (true)
+            {
+                var info = new SP_DEVINFO_DATA();
+                info.cbSize = (uint)Marshal.SizeOf<SP_DEVINFO_DATA>();
+                if (!SetupDiEnumDeviceInfo(devs, idx++, ref info)) break;
+
+                // The Mouse class device instance ID directly contains VID/PID markers.
+                // e.g. HID\{00001124-...}_VID&0001004C_PID&0323\A&31E5D054&1B&0000
+                var idBuf = new StringBuilder(512);
+                if (CM_Get_Device_ID(info.DevInst, idBuf, (uint)idBuf.Capacity, 0) != 0) continue;
+                var id = idBuf.ToString().ToLowerInvariant();
+
+                if ((id.Contains("0001004c") && id.Contains("0323")) ||
+                    (id.Contains("vid_05ac") && id.Contains("pid_0323")))
+                    return true;
+            }
+        }
+        finally { SetupDiDestroyDeviceInfoList(devs); }
+        return false;
+    }
 
     // Enumerates all present HID device interface paths.
     internal static IEnumerable<string> EnumerateHidPaths()

--- a/MagicMouseTray/HidNative.cs
+++ b/MagicMouseTray/HidNative.cs
@@ -89,6 +89,11 @@ internal static class HidNative
     [DllImport("cfgmgr32.dll")]
     static extern uint CM_Get_DevNode_Status(out uint pulStatus, out uint pulProblemNumber, uint dnDevInst, uint ulFlags);
 
+    // cfgmgr32: read a typed device property from devnode (Windows 10+)
+    [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode, EntryPoint = "CM_Get_DevNode_PropertyW")]
+    static extern uint CM_Get_DevNode_Property(uint dnDevInst, ref DEVPROPKEY PropertyKey,
+        out uint PropertyType, [Out] byte[] PropertyBuffer, ref uint PropertyBufferSize, uint ulFlags);
+
     const uint DN_STARTED = 0x00000008; // driver start routine completed — device is running
 
     [StructLayout(LayoutKind.Sequential)]
@@ -99,6 +104,17 @@ internal static class HidNative
         public uint DevInst;
         public IntPtr Reserved;
     }
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct DEVPROPKEY { public Guid fmtid; public uint pid; }
+
+    // DEVPKEY_Device_Stack {a45c254e-df1c-4efd-8020-67d146a850e0} pid=14
+    // STRING_LIST of drivers in the active kernel stack, populated after driver load completes.
+    static readonly DEVPROPKEY s_devpkeyStack = new()
+    {
+        fmtid = new Guid(0xa45c254e, 0xdf1c, 0x4efd, 0x80, 0x20, 0x67, 0xd1, 0x46, 0xa8, 0x50, 0xe0),
+        pid = 14
+    };
 
     // GUID_DEVCLASS_MOUSE — Mouse class devices created by mouhid.sys when it binds to HID device
     static readonly Guid MouseClassGuid = new("4d36e96f-e325-11ce-bfc1-08002be10318");
@@ -178,6 +194,51 @@ internal static class HidNative
 
                 CM_Get_DevNode_Status(out uint status, out _, info.DevInst, 0);
                 return (status & DN_STARTED) != 0;
+            }
+        }
+        finally { SetupDiDestroyDeviceInfoList(devs); }
+        return false;
+    }
+
+    // Returns true if applewirelessmouse.sys is in the active kernel driver stack of the
+    // v3 Magic Mouse BTHENUM parent device (DEVPKEY_Device_Stack). Authoritative Mode B
+    // discriminator — only present after the filter driver loads following FLIP:AppleFilter
+    // + enable. mouhid.sys DN_STARTED (Mouse class device) stays True in Mode A and is a
+    // false positive; it must NOT be used for Mode B detection (confirmed 2026-05-07).
+    internal static bool IsApplewirelessmouseInStack()
+    {
+        const uint DIGCF_PRESENT_ALLCLASSES = 0x06;
+        const uint CR_SUCCESS = 0;
+        var devs = SetupDiGetClassDevs(IntPtr.Zero, "BTHENUM", IntPtr.Zero, DIGCF_PRESENT_ALLCLASSES);
+        if (devs == IntPtr.Zero || devs == INVALID_HANDLE_VALUE) return false;
+        try
+        {
+            uint idx = 0;
+            while (true)
+            {
+                var info = new SP_DEVINFO_DATA();
+                info.cbSize = (uint)Marshal.SizeOf<SP_DEVINFO_DATA>();
+                if (!SetupDiEnumDeviceInfo(devs, idx++, ref info)) break;
+
+                var idBuf = new StringBuilder(512);
+                if (CM_Get_Device_ID(info.DevInst, idBuf, (uint)idBuf.Capacity, 0) != 0) continue;
+                var id = idBuf.ToString().ToLowerInvariant();
+
+                if (!id.Contains("00001124")) continue;
+                if (!((id.Contains("0001004c") && id.Contains("0323")) ||
+                      (id.Contains("vid_05ac") && id.Contains("pid_0323"))))
+                    continue;
+
+                var key = s_devpkeyStack;
+                uint bufSize = 4096;
+                var buf = new byte[bufSize];
+                if (CM_Get_DevNode_Property(info.DevInst, ref key, out _, buf, ref bufSize, 0) != CR_SUCCESS)
+                    return false;
+
+                // DEVPROP_TYPE_STRING_LIST: UTF-16 entries separated by null chars
+                var raw = Encoding.Unicode.GetString(buf, 0, (int)bufSize);
+                return raw.Split('\0', StringSplitOptions.RemoveEmptyEntries)
+                          .Any(e => e.IndexOf("applewireless", StringComparison.OrdinalIgnoreCase) >= 0);
             }
         }
         finally { SetupDiDestroyDeviceInfoList(devs); }

--- a/MagicMouseTray/HidNative.cs
+++ b/MagicMouseTray/HidNative.cs
@@ -66,6 +66,14 @@ internal static class HidNative
         uint DeviceInterfaceDetailDataSize, out uint RequiredSize,
         IntPtr DeviceInfoData);
 
+    // Overload: captures SP_DEVINFO_DATA (devnode) alongside the interface detail
+    [DllImport("setupapi.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    static extern bool SetupDiGetDeviceInterfaceDetail(IntPtr DeviceInfoSet,
+        ref SP_DEVICE_INTERFACE_DATA DeviceInterfaceData,
+        ref SP_DEVICE_INTERFACE_DETAIL_DATA DeviceInterfaceDetailData,
+        uint DeviceInterfaceDetailDataSize, out uint RequiredSize,
+        ref SP_DEVINFO_DATA DeviceInfoData);
+
     [DllImport("setupapi.dll")]
     internal static extern bool SetupDiDestroyDeviceInfoList(IntPtr DeviceInfoSet);
 
@@ -160,11 +168,57 @@ internal static class HidNative
                 if (CM_Get_Device_ID(info.DevInst, idBuf, (uint)idBuf.Capacity, 0) != 0) continue;
                 var id = idBuf.ToString().ToLowerInvariant();
 
+                // Require HID service UUID {00001124} — avoids matching Generic Access
+                // Profile {00001200} or other BTHENUM-enumerated profiles on the same device.
+                if (!id.Contains("00001124")) continue;
+
                 if (!((id.Contains("0001004c") && id.Contains("0323")) ||
                       (id.Contains("vid_05ac") && id.Contains("pid_0323"))))
                     continue;
 
                 CM_Get_DevNode_Status(out uint status, out _, info.DevInst, 0);
+                return (status & DN_STARTED) != 0;
+            }
+        }
+        finally { SetupDiDestroyDeviceInfoList(devs); }
+        return false;
+    }
+
+    // Returns true if the v3 col02 HID interface path exists AND its devnode has DN_STARTED.
+    // col02 appearing in HID enumeration precedes HID class driver initialisation —
+    // DN_STARTED is the empirical proof the stack is ready for HidD_GetInputReport.
+    internal static bool IsV3Col02Ready()
+    {
+        var guid = HidGuid;
+        var devs = SetupDiGetClassDevs(ref guid, null, IntPtr.Zero,
+            DIGCF_PRESENT | DIGCF_DEVICEINTERFACE);
+        if (devs == IntPtr.Zero || devs == INVALID_HANDLE_VALUE) return false;
+        try
+        {
+            uint index = 0;
+            while (true)
+            {
+                var iface = new SP_DEVICE_INTERFACE_DATA();
+                iface.cbSize = (uint)Marshal.SizeOf<SP_DEVICE_INTERFACE_DATA>();
+                if (!SetupDiEnumDeviceInterfaces(devs, IntPtr.Zero, ref guid, index++, ref iface))
+                    break;
+
+                var detail = new SP_DEVICE_INTERFACE_DETAIL_DATA();
+                detail.cbSize = IntPtr.Size == 8 ? 8u : 6u;
+                var devInfo = new SP_DEVINFO_DATA();
+                devInfo.cbSize = (uint)Marshal.SizeOf<SP_DEVINFO_DATA>();
+                SetupDiGetDeviceInterfaceDetail(devs, ref iface, ref detail, 512, out _, ref devInfo);
+
+                if (string.IsNullOrEmpty(detail.DevicePath)) continue;
+                var p = detail.DevicePath;
+                if (!p.Contains("col02", StringComparison.OrdinalIgnoreCase)) continue;
+                if (!((p.Contains("0001004c", StringComparison.OrdinalIgnoreCase) &&
+                       p.Contains("pid&0323", StringComparison.OrdinalIgnoreCase)) ||
+                      (p.Contains("vid_05ac", StringComparison.OrdinalIgnoreCase) &&
+                       p.Contains("pid_0323", StringComparison.OrdinalIgnoreCase))))
+                    continue;
+
+                CM_Get_DevNode_Status(out uint status, out _, devInfo.DevInst, 0);
                 return (status & DN_STARTED) != 0;
             }
         }

--- a/MagicMouseTray/HidNative.cs
+++ b/MagicMouseTray/HidNative.cs
@@ -49,6 +49,11 @@ internal static class HidNative
     internal static extern IntPtr SetupDiGetClassDevs(ref Guid ClassGuid, string? Enumerator,
         IntPtr hwndParent, uint Flags);
 
+    // Overload: null ClassGuid with enumerator string (DIGCF_ALLCLASSES required)
+    [DllImport("setupapi.dll", SetLastError = true)]
+    static extern IntPtr SetupDiGetClassDevs(IntPtr ClassGuid, string Enumerator,
+        IntPtr hwndParent, uint Flags);
+
     [DllImport("setupapi.dll", SetLastError = true)]
     internal static extern bool SetupDiEnumDeviceInterfaces(IntPtr DeviceInfoSet,
         IntPtr DeviceInfoData, ref Guid InterfaceClassGuid, uint MemberIndex,
@@ -126,6 +131,41 @@ internal static class HidNative
                 CM_Get_DevNode_Status(out uint status, out _, info.DevInst, 0);
                 if ((status & DN_STARTED) != 0)
                     return true;
+            }
+        }
+        finally { SetupDiDestroyDeviceInfoList(devs); }
+        return false;
+    }
+
+    // Returns true if the v3 Magic Mouse BTHENUM parent device has DN_STARTED set.
+    // This is the pre-flip baseline check — if BTHENUM is not started before the flip,
+    // the BT stack is already wedged and the cycle should be skipped.
+    // Searches the BTHENUM enumerator directly (DIGCF_PRESENT|DIGCF_ALLCLASSES = 0x06),
+    // independent of mouhid binding state.
+    internal static bool IsV3BtStackHealthy()
+    {
+        const uint DIGCF_PRESENT_ALLCLASSES = 0x06;
+        var devs = SetupDiGetClassDevs(IntPtr.Zero, "BTHENUM", IntPtr.Zero, DIGCF_PRESENT_ALLCLASSES);
+        if (devs == IntPtr.Zero || devs == INVALID_HANDLE_VALUE) return false;
+        try
+        {
+            uint idx = 0;
+            while (true)
+            {
+                var info = new SP_DEVINFO_DATA();
+                info.cbSize = (uint)Marshal.SizeOf<SP_DEVINFO_DATA>();
+                if (!SetupDiEnumDeviceInfo(devs, idx++, ref info)) break;
+
+                var idBuf = new StringBuilder(512);
+                if (CM_Get_Device_ID(info.DevInst, idBuf, (uint)idBuf.Capacity, 0) != 0) continue;
+                var id = idBuf.ToString().ToLowerInvariant();
+
+                if (!((id.Contains("0001004c") && id.Contains("0323")) ||
+                      (id.Contains("vid_05ac") && id.Contains("pid_0323"))))
+                    continue;
+
+                CM_Get_DevNode_Status(out uint status, out _, info.DevInst, 0);
+                return (status & DN_STARTED) != 0;
             }
         }
         finally { SetupDiDestroyDeviceInfoList(devs); }

--- a/MagicMouseTray/HidNative.cs
+++ b/MagicMouseTray/HidNative.cs
@@ -72,6 +72,12 @@ internal static class HidNative
     [DllImport("cfgmgr32.dll", CharSet = CharSet.Unicode)]
     static extern uint CM_Get_Device_ID(uint dnDevInst, StringBuilder Buffer, uint BufferLen, uint ulFlags);
 
+    // cfgmgr32: query devnode operational status flags
+    [DllImport("cfgmgr32.dll")]
+    static extern uint CM_Get_DevNode_Status(out uint pulStatus, out uint pulProblemNumber, uint dnDevInst, uint ulFlags);
+
+    const uint DN_STARTED = 0x00000008; // driver start routine completed — device is running
+
     [StructLayout(LayoutKind.Sequential)]
     struct SP_DEVINFO_DATA
     {
@@ -84,13 +90,13 @@ internal static class HidNative
     // GUID_DEVCLASS_MOUSE — Mouse class devices created by mouhid.sys when it binds to HID device
     static readonly Guid MouseClassGuid = new("4d36e96f-e325-11ce-bfc1-08002be10318");
 
-    // Returns true if a Mouse class device with a v3 Magic Mouse instance ID exists and is present.
-    // mouhid.sys creates a Mouse class device only after it successfully binds — this is the
-    // definitive signal that cursor input is restored (unlike CreateFile which fires at PnP enumeration,
-    // before mouhid has attached). The Mouse class device instance ID directly encodes VID/PID.
+    // Returns true if a Mouse class device for the v3 Magic Mouse exists, is present,
+    // AND has DN_STARTED set — meaning mouhid.sys has completed its start routine and
+    // is actively processing input. Device node existence alone is not sufficient;
+    // DN_STARTED is the empirical proof that the driver stack is operational.
     //
-    // Note: uses DIGCF_PRESENT only (not DIGCF_DEVICEINTERFACE) — Mouse class devices are device
-    // instances, not HID interface paths. Using DIGCF_DEVICEINTERFACE returns an empty set.
+    // Note: uses DIGCF_PRESENT only (not DIGCF_DEVICEINTERFACE) — Mouse class devices
+    // are device instances, not HID interface paths.
     internal static bool IsV3MouseClassPresent()
     {
         var guid = MouseClassGuid;
@@ -105,14 +111,20 @@ internal static class HidNative
                 info.cbSize = (uint)Marshal.SizeOf<SP_DEVINFO_DATA>();
                 if (!SetupDiEnumDeviceInfo(devs, idx++, ref info)) break;
 
-                // The Mouse class device instance ID directly contains VID/PID markers.
-                // e.g. HID\{00001124-...}_VID&0001004C_PID&0323\A&31E5D054&1B&0000
+                // Instance ID directly contains VID/PID markers:
+                // HID\{00001124-...}_VID&0001004C_PID&0323\A&31E5D054&1B&0000
                 var idBuf = new StringBuilder(512);
                 if (CM_Get_Device_ID(info.DevInst, idBuf, (uint)idBuf.Capacity, 0) != 0) continue;
                 var id = idBuf.ToString().ToLowerInvariant();
 
-                if ((id.Contains("0001004c") && id.Contains("0323")) ||
-                    (id.Contains("vid_05ac") && id.Contains("pid_0323")))
+                if (!((id.Contains("0001004c") && id.Contains("0323")) ||
+                      (id.Contains("vid_05ac") && id.Contains("pid_0323"))))
+                    continue;
+
+                // Empirical proof: mouhid must have DN_STARTED — driver start routine complete.
+                // Device node existing without DN_STARTED means mouhid is still initializing.
+                CM_Get_DevNode_Status(out uint status, out _, info.DevInst, 0);
+                if ((status & DN_STARTED) != 0)
                     return true;
             }
         }

--- a/MagicMouseTray/SelfHealRequest.cs
+++ b/MagicMouseTray/SelfHealRequest.cs
@@ -20,8 +20,11 @@
 
 using System.Diagnostics;
 using System.IO;
+using System.Threading;
 
 namespace MagicMouseTray;
+
+internal enum FlipPhase { NoFilter, AppleFilter }
 
 internal static class SelfHealRequest
 {
@@ -33,14 +36,62 @@ internal static class SelfHealRequest
     // Phase that triggers a no-op LowerFilters mutation + a forced disable+enable.
     // mm-state-flip.ps1 detects "already in target state" but still runs the
     // recycle, which is exactly what we want.
-    const string Phase = "FLIP:AppleFilter";
+    const string PhaseAppleFilter = "FLIP:AppleFilter";
+
+    // Phase that removes applewirelessmouse from LowerFilters → Mode A (COL02 present).
+    // PATH-B: used to expose COL02 for battery read. Requires FLIP:AppleFilter after.
+    const string PhaseNoFilter = "FLIP:NoFilter";
 
     /// <summary>
-    /// Submits a recycle request via the MM-Dev-Cycle queue + triggers the task.
-    /// Returns true if the queue was written + task triggered. Does NOT wait for
-    /// completion — caller polls result.txt or waits for next BatteryChanged.
+    /// Submits FLIP:AppleFilter (Mode B restore). Fire-and-forget — does not wait for completion.
+    /// Backward-compat wrapper for SelfHealManager.
     /// </summary>
     internal static bool RequestRecycle()
+        => TriggerFlip(PhaseAppleFilter);
+
+    /// <summary>
+    /// Submits a flip phase and waits for the MM-Dev-Cycle task to report completion.
+    /// Polls result.txt for up to timeoutMs. Returns true if task completed with exit 0.
+    /// Used by V3RecycleManager for synchronous flip-and-wait sequencing.
+    /// </summary>
+    internal static bool SubmitFlipAndWait(FlipPhase phase, int timeoutMs = 30_000)
+    {
+        var phaseStr = phase == FlipPhase.NoFilter ? PhaseNoFilter : PhaseAppleFilter;
+        var nonce = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
+
+        if (!WriteRequest(phaseStr, nonce)) return false;
+        if (!StartTask(phaseStr)) return false;
+
+        // Poll result.txt for EXITCODE|NONCE match
+        var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+        while (DateTime.UtcNow < deadline)
+        {
+            Thread.Sleep(100);
+            try
+            {
+                if (!File.Exists(ResultFile)) continue;
+                var raw = File.ReadAllText(ResultFile).Trim();
+                if (!raw.EndsWith($"|{nonce}")) continue;
+
+                var exitCode = int.TryParse(raw.Split('|', 2)[0], out var rc) ? rc : -1;
+                Logger.Log($"FLIP phase={phaseStr} exitCode={exitCode} nonce={nonce}");
+                return exitCode == 0;
+            }
+            catch { }
+        }
+
+        Logger.Log($"FLIP timeout phase={phaseStr} nonce={nonce} after {timeoutMs}ms");
+        return false;
+    }
+
+    static bool TriggerFlip(string phase)
+    {
+        var nonce = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
+        if (!WriteRequest(phase, nonce)) return false;
+        return StartTask(phase);
+    }
+
+    static bool WriteRequest(string phase, string nonce)
     {
         try
         {
@@ -49,13 +100,21 @@ internal static class SelfHealRequest
                 Logger.Log($"SELFHEAL queue dir missing at {QueueDir} — task not installed?");
                 return false;
             }
+            File.WriteAllText(RequestFile, $"{phase}|{nonce}");
+            Logger.Log($"FLIP queued: phase={phase} nonce={nonce}");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.Log($"FLIP write exception: {ex.Message}");
+            return false;
+        }
+    }
 
-            var nonce = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString();
-            File.WriteAllText(RequestFile, $"{Phase}|{nonce}");
-            Logger.Log($"SELFHEAL request queued: phase={Phase} nonce={nonce}");
-
-            // Trigger via schtasks.exe /run — non-elevated invocation works because
-            // the task has Principal RunLevel=HighestAvailable.
+    static bool StartTask(string phase)
+    {
+        try
+        {
             var psi = new ProcessStartInfo
             {
                 FileName = "schtasks.exe",
@@ -65,27 +124,15 @@ internal static class SelfHealRequest
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
             };
-
             using var p = Process.Start(psi);
-            if (p is null)
-            {
-                Logger.Log("SELFHEAL Process.Start returned null");
-                return false;
-            }
-
-            // Don't block the poll thread — fire and forget; the task runs async.
+            if (p is null) { Logger.Log("SELFHEAL Process.Start returned null"); return false; }
             p.WaitForExit(5000);
-            if (p.ExitCode != 0)
-            {
-                Logger.Log($"SELFHEAL schtasks.exe exit={p.ExitCode}");
-                return false;
-            }
-
+            if (p.ExitCode != 0) { Logger.Log($"SELFHEAL schtasks.exe exit={p.ExitCode}"); return false; }
             return true;
         }
         catch (Exception ex)
         {
-            Logger.Log($"SELFHEAL request exception: {ex.Message}");
+            Logger.Log($"SELFHEAL start exception: {ex.Message}");
             return false;
         }
     }

--- a/MagicMouseTray/ToastNotifier.cs
+++ b/MagicMouseTray/ToastNotifier.cs
@@ -43,6 +43,26 @@ internal static class ToastNotifier
         }
     }
 
+    internal static void ShowError(string title, string message)
+    {
+        try
+        {
+            EnsureAumid();
+            var doc = new XmlDocument();
+            doc.LoadXml($"""
+                <toast>
+                    <visual><binding template="ToastGeneric">
+                        <text>{title}</text>
+                        <text>{message}</text>
+                    </binding></visual>
+                </toast>
+                """);
+            ToastNotificationManager.CreateToastNotifier(Aumid).Show(new ToastNotification(doc));
+            Logger.Log($"TOAST_ERROR title={title}");
+        }
+        catch (Exception ex) { Logger.Log($"TOAST_FAILED err={ex.Message}"); }
+    }
+
     // Writes DisplayName under HKCU\SOFTWARE\Classes\AppUserModelId\<Aumid> so Windows
     // attributes the toast to "Magic Mouse Battery" rather than an anonymous app.
     static void EnsureAumid()

--- a/MagicMouseTray/TrayApp.cs
+++ b/MagicMouseTray/TrayApp.cs
@@ -29,6 +29,7 @@ internal sealed class TrayApp : IDisposable
     CriticalAlert? _criticalAlert;
 
     readonly DriverStatus _driverStatus;
+    readonly V3RecycleManager _recycleManager;
 
     Icon? _currentIcon;
 
@@ -56,6 +57,9 @@ internal sealed class TrayApp : IDisposable
         _poller = new AdaptivePoller();
         _poller.BatteryChanged += OnBatteryChanged;
         _poller.Start();
+
+        _recycleManager = new V3RecycleManager(_config);
+        _recycleManager.BatteryRead += OnBatteryChanged;
     }
 
     ContextMenuStrip BuildMenu(
@@ -115,6 +119,20 @@ internal sealed class TrayApp : IDisposable
             menu.Items.Add(driverItem);
             menu.Items.Add(new ToolStripSeparator());
         }
+
+        // --- Battery Reads toggle (PATH-B v3 recycle on/off) ---
+        var battReadItem = new ToolStripMenuItem("Battery Reads [On]")
+        {
+            Checked = _config.EnableV3Recycle
+        };
+        battReadItem.Click += (_, _) =>
+        {
+            _config.SetEnableV3Recycle(!_config.EnableV3Recycle);
+            battReadItem.Text = _config.EnableV3Recycle ? "Battery Reads [On]" : "Battery Reads [Off]";
+            battReadItem.Checked = _config.EnableV3Recycle;
+            if (_config.EnableV3Recycle) _recycleManager.ReEnable();
+        };
+        menu.Items.Add(battReadItem);
 
         // --- Refresh Now ---
         var refresh = new ToolStripMenuItem("Refresh Now");
@@ -260,6 +278,8 @@ internal sealed class TrayApp : IDisposable
 
     public void Dispose()
     {
+        _recycleManager.BatteryRead -= OnBatteryChanged;
+        _recycleManager.Dispose();
         _poller.BatteryChanged -= OnBatteryChanged;
         _poller.Dispose();
         _criticalAlert?.Close();

--- a/MagicMouseTray/V3RecycleManager.cs
+++ b/MagicMouseTray/V3RecycleManager.cs
@@ -237,14 +237,15 @@ internal sealed class V3RecycleManager : IDisposable
         return false;
     }
 
-    // Polls until a v3 col02 path appears (Mode A / split descriptor active).
-    // Returns true if Mode A confirmed within timeoutMs.
+    // Polls until v3 col02 path exists AND its devnode has DN_STARTED.
+    // col02 appears in HID enumeration before the HID class driver finishes initialising
+    // the device — DN_STARTED is the empirical proof the stack is ready for GetInputReport.
     static bool WaitForModeA(int timeoutMs)
     {
         var deadline = Environment.TickCount64 + timeoutMs;
         do
         {
-            if (IsV3InModeA()) return true;
+            if (HidNative.IsV3Col02Ready()) return true;
             Thread.Sleep(100);
         } while (Environment.TickCount64 < deadline);
         return false;

--- a/MagicMouseTray/V3RecycleManager.cs
+++ b/MagicMouseTray/V3RecycleManager.cs
@@ -1,0 +1,218 @@
+// V3RecycleManager.cs — PATH-B battery read via PnP recycle (PRD-26 M3).
+//
+// Periodically flips the v3 Magic Mouse from Mode B (scroll works, battery N/A) into
+// Mode A (battery readable, scroll broken) to read battery, then restores Mode B.
+//
+// Recycle sequence (all steps synchronous within the loop task):
+//   1. Wait for user idle ≥30s (GetLastInputInfo)
+//   2. FLIP:NoFilter  — removes applewirelessmouse from LowerFilters + disable/enable
+//   3. Wait for task completion (poll result.txt, P95=343ms, timeout 30s)
+//   4. Read battery via DeviceRegistry.Discover() → first MagicMouseV3 device
+//   5. FLIP:AppleFilter — re-adds filter + disable/enable (Mode B restore)
+//   6. Wait for task completion (P95=370ms, timeout 30s)
+//   7. Raise BatteryRead(pct, name) — TrayApp updates display
+//
+// Failure model:
+//   - Up to 3 retry attempts per cycle (500ms delay between) before marking cycle failed
+//   - Consecutive failure cap: 3 → toast + pause 2h before next attempt
+//   - 24h failure rate: if >10 failures in rolling 24h window → auto-disable + toast
+//   - FLIP:AppleFilter is ALWAYS attempted even if battery read failed (Mode B is the safe state)
+//
+// Note: SelfHealManager.OnBatteryObserved sees pct>=0 (split mode) during the recycle window
+// (~8–16s). Because SelfHealManager requires 2 *consecutive* AdaptivePoller poll events showing
+// split before triggering, and the recycle completes within seconds, there is no interference.
+// If FLIP:AppleFilter fails, SelfHealManager provides a fallback restore on the next poll cycle.
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace MagicMouseTray;
+
+internal sealed class V3RecycleManager : IDisposable
+{
+    internal event Action<int, string>? BatteryRead;
+
+    static readonly TimeSpan DefaultCadence   = TimeSpan.FromMinutes(15);
+    static readonly TimeSpan LowBatteryCadence = TimeSpan.FromMinutes(5);   // pct < 20%
+    const int IdleThresholdMs   = 30_000; // 30s
+    const int RetryDelayMs      = 500;
+    const int MaxRetries        = 3;
+    const int ConsecutiveFailCap = 3;
+    const int DailyFailCap      = 10;    // >10 failures in 24h → auto-disable
+
+    CancellationTokenSource _cts = new();
+    Task _loop;
+    int _consecutiveFailures = 0;
+    bool _autoDisabled = false;
+
+    // 24h failure tracking: timestamps of recent failures
+    readonly Queue<DateTime> _failureTimestamps = new();
+
+    readonly Config _config;
+    int _lastKnownPct = -1; // used to decide cadence
+
+    internal V3RecycleManager(Config config)
+    {
+        _config = config;
+        _loop = RunLoop(_cts.Token);
+    }
+
+    internal bool AutoDisabled => _autoDisabled;
+
+    // Re-enable after user manually disables auto-disable. Resets failure counters.
+    internal void ReEnable()
+    {
+        _autoDisabled = false;
+        _consecutiveFailures = 0;
+        _failureTimestamps.Clear();
+        Logger.Log("V3RECYCLE re-enabled by user");
+    }
+
+    public void Dispose()
+    {
+        _cts.Cancel();
+        try { _loop.Wait(TimeSpan.FromSeconds(5)); } catch { }
+        _cts.Dispose();
+    }
+
+    async Task RunLoop(CancellationToken ct)
+    {
+        // Initial delay: allow tray to start and show before first recycle
+        try { await Task.Delay(TimeSpan.FromSeconds(30), ct); } catch { return; }
+
+        while (!ct.IsCancellationRequested)
+        {
+            if (!_autoDisabled && _config.EnableV3Recycle)
+            {
+                await WaitForUserIdle(ct);
+                if (!ct.IsCancellationRequested)
+                    await ExecuteRecycleCycle(ct);
+            }
+
+            var interval = _lastKnownPct is >= 0 and < 20 ? LowBatteryCadence : DefaultCadence;
+            Logger.Log($"V3RECYCLE next in {interval} pct={_lastKnownPct}");
+            try { await Task.Delay(interval, ct); } catch { return; }
+        }
+    }
+
+    async Task WaitForUserIdle(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested && GetIdleMs() < IdleThresholdMs)
+            try { await Task.Delay(1000, ct); } catch { return; }
+    }
+
+    async Task ExecuteRecycleCycle(CancellationToken ct)
+    {
+        Logger.Log("V3RECYCLE cycle start");
+
+        for (int attempt = 1; attempt <= MaxRetries; attempt++)
+        {
+            if (ct.IsCancellationRequested) return;
+
+            if (attempt > 1)
+            {
+                Logger.Log($"V3RECYCLE retry attempt {attempt}/{MaxRetries}");
+                try { await Task.Delay(RetryDelayMs, ct); } catch { return; }
+            }
+
+            // Step 1: Flip to Mode A
+            bool flipOk = await Task.Run(
+                () => SelfHealRequest.SubmitFlipAndWait(FlipPhase.NoFilter, 30_000), ct);
+
+            if (!flipOk)
+            {
+                Logger.Log($"V3RECYCLE FLIP:NoFilter failed attempt={attempt}");
+                // Don't retry flips — if the task is broken, retries won't help
+                RecordFailure("FLIP:NoFilter failed");
+                return;
+            }
+
+            // Step 2: Read battery — DeviceRegistry now shows split v3 (COL02 present)
+            string deviceName = string.Empty;
+            int pct = -1;
+
+            var devices = DeviceRegistry.Discover();
+            var v3 = devices.FirstOrDefault(d => d.Kind == DeviceKind.MagicMouseV3);
+
+            if (v3 is not null)
+            {
+                deviceName = v3.DeviceName;
+                pct = v3.GetBatteryPercent();
+                Logger.Log($"V3RECYCLE battery read: device={deviceName} pct={pct} attempt={attempt}");
+            }
+            else
+            {
+                Logger.Log($"V3RECYCLE COL02 not found in DeviceRegistry attempt={attempt}");
+            }
+
+            // Step 3: ALWAYS restore Mode B — Mode B is the safe state
+            bool restoreOk = await Task.Run(
+                () => SelfHealRequest.SubmitFlipAndWait(FlipPhase.AppleFilter, 30_000), ct);
+
+            if (!restoreOk)
+                Logger.Log("V3RECYCLE FLIP:AppleFilter failed — SelfHealManager will restore on next poll");
+
+            // Step 4: Evaluate result
+            if (pct >= 0)
+            {
+                _lastKnownPct = pct;
+                _consecutiveFailures = 0;
+                BatteryRead?.Invoke(pct, deviceName);
+                Logger.Log($"V3RECYCLE cycle SUCCESS pct={pct}");
+                return;
+            }
+
+            // Battery read failed — retry if we have attempts left
+        }
+
+        // All retries exhausted
+        RecordFailure("all retries exhausted");
+    }
+
+    void RecordFailure(string reason)
+    {
+        _consecutiveFailures++;
+        var now = DateTime.UtcNow;
+        _failureTimestamps.Enqueue(now);
+
+        // Prune timestamps older than 24h
+        while (_failureTimestamps.Count > 0 && (now - _failureTimestamps.Peek()) > TimeSpan.FromHours(24))
+            _failureTimestamps.Dequeue();
+
+        Logger.Log($"V3RECYCLE failure reason={reason} consecutive={_consecutiveFailures} 24h={_failureTimestamps.Count}");
+
+        if (_consecutiveFailures >= ConsecutiveFailCap)
+        {
+            Logger.Log($"V3RECYCLE {ConsecutiveFailCap} consecutive failures — pausing 2h");
+            // Don't auto-disable for consecutive failures; just slow down. Auto-disable only for daily cap.
+            _consecutiveFailures = 0; // reset so next successful cycle clears the count
+        }
+
+        if (_failureTimestamps.Count >= DailyFailCap)
+        {
+            _autoDisabled = true;
+            Logger.Log($"V3RECYCLE auto-disabled: {DailyFailCap}+ failures in 24h");
+            ToastNotifier.ShowError("Magic Mouse Battery", "Battery reads failing too often — auto-disabled. Re-enable in settings.");
+        }
+    }
+
+    // --- P/Invoke: idle time detection ---
+
+    [DllImport("user32.dll")]
+    static extern bool GetLastInputInfo(ref LASTINPUTINFO plii);
+
+    [StructLayout(LayoutKind.Sequential)]
+    struct LASTINPUTINFO
+    {
+        public uint cbSize;
+        public uint dwTime; // GetTickCount() tick of last input event
+    }
+
+    static int GetIdleMs()
+    {
+        var info = new LASTINPUTINFO();
+        info.cbSize = (uint)Marshal.SizeOf<LASTINPUTINFO>();
+        if (!GetLastInputInfo(ref info)) return 0;
+        // Cast to uint before subtract to handle 32-bit tick count wraparound
+        return (int)((uint)Environment.TickCount - info.dwTime);
+    }
+}

--- a/MagicMouseTray/V3RecycleManager.cs
+++ b/MagicMouseTray/V3RecycleManager.cs
@@ -238,36 +238,16 @@ internal sealed class V3RecycleManager : IDisposable
         return false;
     }
 
-    // Polls until v3 is in Mode B (unified HID path + fresh mouhid bind). Two-phase:
-    // if a Mouse class device is present at entry (stale from a prior PnP cycle), waits
-    // for PnP disable to remove it before accepting any Mouse class presence as a fresh bind.
-    // Prevents false-positive when Mouse class from the previous cycle outlasts the NoFilter flip.
+    // Polls until the v3 unified path appears (no col0x) and mouhid has bound (Mode B).
+    // Returns true if Mode B confirmed within timeoutMs.
     static bool WaitForModeB(int timeoutMs)
     {
         var deadline = Environment.TickCount64 + timeoutMs;
-
-        // Phase 1: stale Mouse class present → wait for PnP disable to clear it.
-        bool purgingStale = HidNative.IsV3MouseClassPresent();
-        if (purgingStale)
-            Logger.Log("V3RECYCLE WaitForModeB: stale Mouse class at entry — waiting for PnP disable to clear");
-
         do
         {
-            if (purgingStale)
-            {
-                if (!HidNative.IsV3MouseClassPresent())
-                {
-                    purgingStale = false;
-                    Logger.Log("V3RECYCLE WaitForModeB: stale cleared — waiting for fresh mouhid bind");
-                }
-            }
-            else if (IsV3InModeB())
-            {
-                return true;
-            }
+            if (IsV3InModeB()) return true;
             Thread.Sleep(100);
         } while (Environment.TickCount64 < deadline);
-
         return false;
     }
 

--- a/MagicMouseTray/V3RecycleManager.cs
+++ b/MagicMouseTray/V3RecycleManager.cs
@@ -238,16 +238,36 @@ internal sealed class V3RecycleManager : IDisposable
         return false;
     }
 
-    // Polls until the v3 unified path appears (no col0x) and is openable (mouhid bound, Mode B).
-    // Returns true if Mode B confirmed within timeoutMs.
+    // Polls until v3 is in Mode B (unified HID path + fresh mouhid bind). Two-phase:
+    // if a Mouse class device is present at entry (stale from a prior PnP cycle), waits
+    // for PnP disable to remove it before accepting any Mouse class presence as a fresh bind.
+    // Prevents false-positive when Mouse class from the previous cycle outlasts the NoFilter flip.
     static bool WaitForModeB(int timeoutMs)
     {
         var deadline = Environment.TickCount64 + timeoutMs;
+
+        // Phase 1: stale Mouse class present → wait for PnP disable to clear it.
+        bool purgingStale = HidNative.IsV3MouseClassPresent();
+        if (purgingStale)
+            Logger.Log("V3RECYCLE WaitForModeB: stale Mouse class at entry — waiting for PnP disable to clear");
+
         do
         {
-            if (IsV3InModeB()) return true;
+            if (purgingStale)
+            {
+                if (!HidNative.IsV3MouseClassPresent())
+                {
+                    purgingStale = false;
+                    Logger.Log("V3RECYCLE WaitForModeB: stale cleared — waiting for fresh mouhid bind");
+                }
+            }
+            else if (IsV3InModeB())
+            {
+                return true;
+            }
             Thread.Sleep(100);
         } while (Environment.TickCount64 < deadline);
+
         return false;
     }
 

--- a/MagicMouseTray/V3RecycleManager.cs
+++ b/MagicMouseTray/V3RecycleManager.cs
@@ -257,8 +257,11 @@ internal sealed class V3RecycleManager : IDisposable
             IsV3Path(p) &&
             p.Contains("col02", StringComparison.OrdinalIgnoreCase));
 
-    // True if a v3 Magic Mouse unified path exists (no split collections) and is accessible.
-    // Accessibility via CreateFile(0 access) confirms mouhid.sys has finished binding.
+    // True if a v3 Magic Mouse is in Mode B: unified HID path exists (no col0x splits)
+    // AND mouhid.sys has bound (confirmed via Mouse class device enumeration).
+    // mouhid creates a Mouse class device node only after successful binding — this is the
+    // definitive signal that cursor input is restored. CreateFile(0) fires at PnP enumeration
+    // time, which precedes mouhid binding by 0–2s and is NOT a reliable proxy (2026-05-06).
     static bool IsV3InModeB()
     {
         var v3Paths = HidNative.EnumerateHidPaths()
@@ -271,12 +274,8 @@ internal sealed class V3RecycleManager : IDisposable
         if (v3Paths.Any(p => p.Contains("&col0", StringComparison.OrdinalIgnoreCase)))
             return false;
 
-        // Confirm mouhid has bound by verifying the unified path is openable
-        var unifiedPath = v3Paths[0];
-        using var h = HidNative.CreateFile(unifiedPath, 0,
-            HidNative.FILE_SHARE_READ | HidNative.FILE_SHARE_WRITE,
-            IntPtr.Zero, HidNative.OPEN_EXISTING, 0, IntPtr.Zero);
-        return !h.IsInvalid;
+        // Confirm mouhid has bound: Mouse class device with v3 parent exists in device tree
+        return HidNative.IsV3MouseClassPresent();
     }
 
     // True if the HID device path belongs to a Magic Mouse v3 (BT or USB).

--- a/MagicMouseTray/V3RecycleManager.cs
+++ b/MagicMouseTray/V3RecycleManager.cs
@@ -259,7 +259,8 @@ internal sealed class V3RecycleManager : IDisposable
         return false;
     }
 
-    // Polls until the v3 unified path appears (no col0x) and mouhid has bound (Mode B).
+    // Polls until the v3 unified path appears (no col0x) and applewirelessmouse.sys is
+    // in the kernel stack (Mode B). Empirical P95 latency: ~563ms (2026-05-07).
     // Returns true if Mode B confirmed within timeoutMs.
     static bool WaitForModeB(int timeoutMs)
     {
@@ -279,10 +280,12 @@ internal sealed class V3RecycleManager : IDisposable
             p.Contains("col02", StringComparison.OrdinalIgnoreCase));
 
     // True if a v3 Magic Mouse is in Mode B: unified HID path exists (no col0x splits)
-    // AND mouhid.sys has bound (confirmed via Mouse class device enumeration).
-    // mouhid creates a Mouse class device node only after successful binding — this is the
-    // definitive signal that cursor input is restored. CreateFile(0) fires at PnP enumeration
-    // time, which precedes mouhid binding by 0–2s and is NOT a reliable proxy (2026-05-06).
+    // AND applewirelessmouse.sys is in the active kernel stack (DEVPKEY_Device_Stack).
+    // DEVPKEY_Device_Stack is the authoritative Mode B discriminator — the entry only
+    // appears after the filter driver loads following FLIP:AppleFilter + enable.
+    // mouhid.sys DN_STARTED (Mouse class device) is a false positive in Mode A: mouhid
+    // stays bound to col01 and DN_STARTED remains True even when the device is in Mode A.
+    // Empirical: real WaitForModeB latency ~563ms (confirmed 2026-05-07).
     static bool IsV3InModeB()
     {
         var v3Paths = HidNative.EnumerateHidPaths()
@@ -295,8 +298,8 @@ internal sealed class V3RecycleManager : IDisposable
         if (v3Paths.Any(p => p.Contains("&col0", StringComparison.OrdinalIgnoreCase)))
             return false;
 
-        // Confirm mouhid has bound: Mouse class device with v3 parent exists in device tree
-        return HidNative.IsV3MouseClassPresent();
+        // Confirm applewirelessmouse.sys is in the active kernel stack
+        return HidNative.IsApplewirelessmouseInStack();
     }
 
     // True if the HID device path belongs to a Magic Mouse v3 (BT or USB).

--- a/MagicMouseTray/V3RecycleManager.cs
+++ b/MagicMouseTray/V3RecycleManager.cs
@@ -4,24 +4,28 @@
 // Mode A (battery readable, scroll broken) to read battery, then restores Mode B.
 //
 // Recycle sequence (all steps synchronous within the loop task):
+//   0. Pre-check: confirm device is in Mode B (IsV3InModeA() == false)
 //   1. Wait for user idle ≥30s (GetLastInputInfo)
 //   2. FLIP:NoFilter  — removes applewirelessmouse from LowerFilters + disable/enable
-//   3. Wait for task completion (poll result.txt, P95=343ms, timeout 30s)
+//   3. Verify Mode A reached: poll HID paths for col02 presence (P95 <500ms, timeout 2s)
 //   4. Read battery via DeviceRegistry.Discover() → first MagicMouseV3 device
 //   5. FLIP:AppleFilter — re-adds filter + disable/enable (Mode B restore)
-//   6. Wait for task completion (P95=370ms, timeout 30s)
+//   6. Verify Mode B restored: poll HID paths, confirm unified path openable (timeout 5s)
+//      mouhid.sys binds asynchronously — exit=0 from MM-Dev-Cycle ≠ mouhid bound.
+//      Up to 3 FLIP:AppleFilter retries if Mode B not confirmed (live fix: 2026-05-06).
 //   7. Raise BatteryRead(pct, name) — TrayApp updates display
 //
 // Failure model:
-//   - Up to 3 retry attempts per cycle (500ms delay between) before marking cycle failed
-//   - Consecutive failure cap: 3 → toast + pause 2h before next attempt
-//   - 24h failure rate: if >10 failures in rolling 24h window → auto-disable + toast
-//   - FLIP:AppleFilter is ALWAYS attempted even if battery read failed (Mode B is the safe state)
+//   - Up to 3 battery-read retry attempts per cycle (500ms delay between)
+//   - FLIP:NoFilter failure → RecordFailure + return immediately (task broken)
+//   - Mode B restore failure → critical toast + RecordFailure + return (unsafe state)
+//   - Consecutive failure cap: 3 → log + reset counter
+//   - 24h failure rate: >10 failures → auto-disable + toast
 //
 // Note: SelfHealManager.OnBatteryObserved sees pct>=0 (split mode) during the recycle window
 // (~8–16s). Because SelfHealManager requires 2 *consecutive* AdaptivePoller poll events showing
 // split before triggering, and the recycle completes within seconds, there is no interference.
-// If FLIP:AppleFilter fails, SelfHealManager provides a fallback restore on the next poll cycle.
+// If Mode B restore fails, SelfHealManager provides a fallback restore on the next poll cycle.
 using System.Runtime.InteropServices;
 using System.Threading;
 
@@ -31,13 +35,16 @@ internal sealed class V3RecycleManager : IDisposable
 {
     internal event Action<int, string>? BatteryRead;
 
-    static readonly TimeSpan DefaultCadence   = TimeSpan.FromMinutes(15);
+    static readonly TimeSpan DefaultCadence    = TimeSpan.FromMinutes(15);
     static readonly TimeSpan LowBatteryCadence = TimeSpan.FromMinutes(5);   // pct < 20%
-    const int IdleThresholdMs   = 30_000; // 30s
-    const int RetryDelayMs      = 500;
-    const int MaxRetries        = 3;
+    const int IdleThresholdMs    = 30_000; // 30s
+    const int RetryDelayMs       = 500;
+    const int MaxRetries         = 3;
+    const int MaxRestoreAttempts = 3;      // FLIP:AppleFilter retries for Mode B restore
+    const int ModeAVerifyMs      = 2_000;  // poll budget for Mode A confirmation
+    const int ModeBVerifyMs      = 5_000;  // poll budget for Mode B confirmation (mouhid is slow)
     const int ConsecutiveFailCap = 3;
-    const int DailyFailCap      = 10;    // >10 failures in 24h → auto-disable
+    const int DailyFailCap       = 10;    // >10 failures in 24h → auto-disable
 
     CancellationTokenSource _cts = new();
     Task _loop;
@@ -104,6 +111,15 @@ internal sealed class V3RecycleManager : IDisposable
     {
         Logger.Log("V3RECYCLE cycle start");
 
+        // Pre-check: device must be in Mode B before we start.
+        // Mode A at entry means a prior cycle crashed mid-flip — skip and let SelfHealManager restore.
+        bool preCheckModeA = await Task.Run(IsV3InModeA, ct);
+        if (preCheckModeA)
+        {
+            Logger.Log("V3RECYCLE pre-check: device already in Mode A — skip cycle, SelfHealManager will restore");
+            return;
+        }
+
         for (int attempt = 1; attempt <= MaxRetries; attempt++)
         {
             if (ct.IsCancellationRequested) return;
@@ -114,44 +130,61 @@ internal sealed class V3RecycleManager : IDisposable
                 try { await Task.Delay(RetryDelayMs, ct); } catch { return; }
             }
 
-            // Step 1: Flip to Mode A
+            // Step 1: Flip to Mode A (removes LowerFilters, disable/enable PnP device)
             bool flipOk = await Task.Run(
                 () => SelfHealRequest.SubmitFlipAndWait(FlipPhase.NoFilter, 30_000), ct);
 
             if (!flipOk)
             {
                 Logger.Log($"V3RECYCLE FLIP:NoFilter failed attempt={attempt}");
-                // Don't retry flips — if the task is broken, retries won't help
+                // Task failure is not transient — retrying won't help
                 RecordFailure("FLIP:NoFilter failed");
                 return;
             }
 
-            // Step 2: Read battery — DeviceRegistry now shows split v3 (COL02 present)
+            // Step 2: Verify Mode A reached (col02 collection visible in HID paths)
+            // mouhid releases the device during disable/enable — poll until col02 appears
+            bool modeAReached = await Task.Run(() => WaitForModeA(ModeAVerifyMs), ct);
+            Logger.Log($"V3RECYCLE mode_a_reached={modeAReached} attempt={attempt}");
+
+            // Step 3: Read battery (only if Mode A confirmed — col02 must be present)
             string deviceName = string.Empty;
             int pct = -1;
 
-            var devices = DeviceRegistry.Discover();
-            var v3 = devices.FirstOrDefault(d => d.Kind == DeviceKind.MagicMouseV3);
-
-            if (v3 is not null)
+            if (modeAReached)
             {
-                deviceName = v3.DeviceName;
-                pct = v3.GetBatteryPercent();
-                Logger.Log($"V3RECYCLE battery read: device={deviceName} pct={pct} attempt={attempt}");
+                var devices = DeviceRegistry.Discover();
+                var v3 = devices.FirstOrDefault(d => d.Kind == DeviceKind.MagicMouseV3);
+
+                if (v3 is not null)
+                {
+                    deviceName = v3.DeviceName;
+                    pct = v3.GetBatteryPercent();
+                    Logger.Log($"V3RECYCLE battery read: device={deviceName} pct={pct} attempt={attempt}");
+                }
+                else
+                {
+                    Logger.Log($"V3RECYCLE COL02 not found in DeviceRegistry attempt={attempt}");
+                }
             }
-            else
+
+            // Step 4: ALWAYS restore Mode B — Mode B is the safe state.
+            // FLIP:AppleFilter exit=0 does NOT guarantee mouhid.sys has rebound (async).
+            // RestoreModeBWithRetry retries FLIP:AppleFilter and verifies with HID path polling.
+            bool restored = await Task.Run(RestoreModeBWithRetry, ct);
+
+            if (!restored)
             {
-                Logger.Log($"V3RECYCLE COL02 not found in DeviceRegistry attempt={attempt}");
+                Logger.Log("V3RECYCLE CRITICAL: Mode B restore failed after all retries — mouhid may not be bound");
+                ToastNotifier.ShowError("Magic Mouse Battery",
+                    "Mouse scroll may be broken. Unplug/replug cable or toggle Battery Reads in menu.");
+                RecordFailure("Mode B restore failed");
+                return; // Do NOT retry battery read — device state is unknown
             }
 
-            // Step 3: ALWAYS restore Mode B — Mode B is the safe state
-            bool restoreOk = await Task.Run(
-                () => SelfHealRequest.SubmitFlipAndWait(FlipPhase.AppleFilter, 30_000), ct);
+            Logger.Log("V3RECYCLE Mode B confirmed restored");
 
-            if (!restoreOk)
-                Logger.Log("V3RECYCLE FLIP:AppleFilter failed — SelfHealManager will restore on next poll");
-
-            // Step 4: Evaluate result
+            // Step 5: Evaluate result
             if (pct >= 0)
             {
                 _lastKnownPct = pct;
@@ -161,12 +194,97 @@ internal sealed class V3RecycleManager : IDisposable
                 return;
             }
 
-            // Battery read failed — retry if we have attempts left
+            // Battery read failed but Mode B is intact — retry the full cycle
         }
 
-        // All retries exhausted
+        // All retries exhausted with successful Mode B restores each time
         RecordFailure("all retries exhausted");
     }
+
+    // Attempts FLIP:AppleFilter up to MaxRestoreAttempts times, verifying Mode B after each.
+    // mouhid.sys binds asynchronously — WaitForModeB polls until the unified path is accessible.
+    bool RestoreModeBWithRetry()
+    {
+        for (int i = 1; i <= MaxRestoreAttempts; i++)
+        {
+            if (i > 1)
+            {
+                Logger.Log($"V3RECYCLE FLIP:AppleFilter retry {i}/{MaxRestoreAttempts} — Mode B not yet confirmed");
+                Thread.Sleep(500);
+            }
+
+            bool flipOk = SelfHealRequest.SubmitFlipAndWait(FlipPhase.AppleFilter, 30_000);
+            Logger.Log($"V3RECYCLE FLIP:AppleFilter attempt={i} ok={flipOk}");
+
+            if (WaitForModeB(ModeBVerifyMs))
+                return true;
+
+            Logger.Log($"V3RECYCLE Mode B not confirmed after FLIP:AppleFilter attempt={i}/{MaxRestoreAttempts}");
+        }
+
+        return false;
+    }
+
+    // Polls until a v3 col02 path appears (Mode A / split descriptor active).
+    // Returns true if Mode A confirmed within timeoutMs.
+    static bool WaitForModeA(int timeoutMs)
+    {
+        var deadline = Environment.TickCount64 + timeoutMs;
+        do
+        {
+            if (IsV3InModeA()) return true;
+            Thread.Sleep(100);
+        } while (Environment.TickCount64 < deadline);
+        return false;
+    }
+
+    // Polls until the v3 unified path appears (no col0x) and is openable (mouhid bound, Mode B).
+    // Returns true if Mode B confirmed within timeoutMs.
+    static bool WaitForModeB(int timeoutMs)
+    {
+        var deadline = Environment.TickCount64 + timeoutMs;
+        do
+        {
+            if (IsV3InModeB()) return true;
+            Thread.Sleep(100);
+        } while (Environment.TickCount64 < deadline);
+        return false;
+    }
+
+    // True if any HID path is a v3 Magic Mouse in Mode A (col02 collection present in path).
+    static bool IsV3InModeA() =>
+        HidNative.EnumerateHidPaths().Any(p =>
+            IsV3Path(p) &&
+            p.Contains("col02", StringComparison.OrdinalIgnoreCase));
+
+    // True if a v3 Magic Mouse unified path exists (no split collections) and is accessible.
+    // Accessibility via CreateFile(0 access) confirms mouhid.sys has finished binding.
+    static bool IsV3InModeB()
+    {
+        var v3Paths = HidNative.EnumerateHidPaths()
+            .Where(IsV3Path)
+            .ToList();
+
+        if (v3Paths.Count == 0) return false;
+
+        // In Mode B all v3 HID paths are unified — no &col0x collection suffixes
+        if (v3Paths.Any(p => p.Contains("&col0", StringComparison.OrdinalIgnoreCase)))
+            return false;
+
+        // Confirm mouhid has bound by verifying the unified path is openable
+        var unifiedPath = v3Paths[0];
+        using var h = HidNative.CreateFile(unifiedPath, 0,
+            HidNative.FILE_SHARE_READ | HidNative.FILE_SHARE_WRITE,
+            IntPtr.Zero, HidNative.OPEN_EXISTING, 0, IntPtr.Zero);
+        return !h.IsInvalid;
+    }
+
+    // True if the HID device path belongs to a Magic Mouse v3 (BT or USB).
+    static bool IsV3Path(string path) =>
+        (path.Contains("0001004c", StringComparison.OrdinalIgnoreCase) &&
+         path.Contains("pid&0323", StringComparison.OrdinalIgnoreCase)) ||
+        (path.Contains("vid_05ac", StringComparison.OrdinalIgnoreCase) &&
+         path.Contains("pid_0323", StringComparison.OrdinalIgnoreCase));
 
     void RecordFailure(string reason)
     {
@@ -182,8 +300,7 @@ internal sealed class V3RecycleManager : IDisposable
 
         if (_consecutiveFailures >= ConsecutiveFailCap)
         {
-            Logger.Log($"V3RECYCLE {ConsecutiveFailCap} consecutive failures — pausing 2h");
-            // Don't auto-disable for consecutive failures; just slow down. Auto-disable only for daily cap.
+            Logger.Log($"V3RECYCLE {ConsecutiveFailCap} consecutive failures — pausing until next cadence interval");
             _consecutiveFailures = 0; // reset so next successful cycle clears the count
         }
 

--- a/MagicMouseTray/V3RecycleManager.cs
+++ b/MagicMouseTray/V3RecycleManager.cs
@@ -111,7 +111,19 @@ internal sealed class V3RecycleManager : IDisposable
     {
         Logger.Log("V3RECYCLE cycle start");
 
-        // Pre-check: device must be in Mode B before we start.
+        // Pre-check 1: BT stack health — BTHENUM parent must be DN_STARTED before we flip.
+        // If BTHENUM is not started, the wedge is pre-existing; flipping would fail and
+        // leave the device in an unknown state. Let SelfHealManager handle recovery.
+        bool btHealthy = await Task.Run(HidNative.IsV3BtStackHealthy, ct);
+        Logger.Log($"V3RECYCLE pre-check BTHENUM healthy={btHealthy}");
+        if (!btHealthy)
+        {
+            Logger.Log("V3RECYCLE pre-check: BTHENUM not DN_STARTED — skipping cycle, BT stack wedged");
+            RecordFailure("BTHENUM pre-flip not started");
+            return;
+        }
+
+        // Pre-check 2: device must be in Mode B before we start.
         // Mode A at entry means a prior cycle crashed mid-flip — skip and let SelfHealManager restore.
         bool preCheckModeA = await Task.Run(IsV3InModeA, ct);
         if (preCheckModeA)

--- a/MagicMouseTray/V3RecycleManager.cs
+++ b/MagicMouseTray/V3RecycleManager.cs
@@ -41,7 +41,7 @@ internal sealed class V3RecycleManager : IDisposable
     const int RetryDelayMs       = 500;
     const int MaxRetries         = 3;
     const int MaxRestoreAttempts = 3;      // FLIP:AppleFilter retries for Mode B restore
-    const int ModeAVerifyMs      = 2_000;  // poll budget for Mode A confirmation
+    const int ModeAVerifyMs      = 5_000;  // poll budget for Mode A + col02 DN_STARTED (empirical: ~16ms path + ~1000ms pipeline ready)
     const int ModeBVerifyMs      = 5_000;  // poll budget for Mode B confirmation (mouhid is slow)
     const int ConsecutiveFailCap = 3;
     const int DailyFailCap       = 10;    // >10 failures in 24h → auto-disable
@@ -118,8 +118,9 @@ internal sealed class V3RecycleManager : IDisposable
         Logger.Log($"V3RECYCLE pre-check BTHENUM healthy={btHealthy}");
         if (!btHealthy)
         {
+            // Pre-existing wedge — not caused by this manager. Do NOT count against
+            // the failure budget; SelfHealManager handles BTHENUM recovery.
             Logger.Log("V3RECYCLE pre-check: BTHENUM not DN_STARTED — skipping cycle, BT stack wedged");
-            RecordFailure("BTHENUM pre-flip not started");
             return;
         }
 
@@ -171,8 +172,15 @@ internal sealed class V3RecycleManager : IDisposable
                 if (v3 is not null)
                 {
                     deviceName = v3.DeviceName;
-                    pct = v3.GetBatteryPercent();
-                    Logger.Log($"V3RECYCLE battery read: device={deviceName} pct={pct} attempt={attempt}");
+                    // Retry within Mode A window: col02 DN_STARTED does not guarantee the
+                    // HID report pipeline is ready. Empirical: GLE=121 then GLE=21, success
+                    // at ~1000ms. 3 retries at 500ms avoids full flip-cycle retry overhead.
+                    for (int readTry = 1; readTry <= 3 && pct < 0; readTry++)
+                    {
+                        if (readTry > 1) Thread.Sleep(500);
+                        pct = v3.GetBatteryPercent();
+                        Logger.Log($"V3RECYCLE battery read: device={deviceName} pct={pct} attempt={attempt} readTry={readTry}");
+                    }
                 }
                 else
                 {

--- a/TEST-PLAN.md
+++ b/TEST-PLAN.md
@@ -203,7 +203,7 @@ on zero devices (default initialization bug from adversarial review).
 | Test ID | Component | Test Case | Command | Pass Criteria |
 |---------|-----------|-----------|---------|---------------|
 | T2-01 | Driver install | applewirelessmouse package installed | `pnputil /enum-drivers \| Select-String applewireless` | OEM slot visible with correct provider |
-| T2-02 | Driver binding | LowerFilters set on BTHENUM device | `Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Enum\BTHENUM\...\9&..." \| Select LowerFilters` | Value = `applewirelessmouse` |
+| T2-02 | Driver binding | LowerFilters set on BTHENUM Enum key | `(Get-PnpDevice -Class HIDClass \| Where-Object { $_.InstanceId -imatch '00001124.*0001004C.*0323' }).InstanceId \| ForEach-Object { (Get-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Enum\$_").LowerFilters }` | Value = `applewirelessmouse`. **Note**: reads BTHENUM Enum key, NOT HID Enum key — only the BTHENUM key has LowerFilters |
 | T2-03 | HID enumeration | COL01 and COL02 both Status OK | `Get-PnpDevice \| Where-Object { $_.InstanceId -match "0323" -and $_.Status -eq "OK" }` | Count = 2 |
 | T2-04 | Scheduled task | `MagicMouseTray-StartupRepair` registered | `Get-ScheduledTask -TaskName MagicMouseTray-StartupRepair` | Task exists, trigger = AtStartup, delay = PT30S, principal = SYSTEM |
 | T2-05 | Cert trust | MagicMouseFix in TrustedPublisher | `Get-ChildItem Cert:\LocalMachine\TrustedPublisher \| Where Subject -match MagicMouseFix` | Certificate present |
@@ -286,6 +286,42 @@ Same as T4-B but with Magic Mouse v1. Substitute PID 030d in all verification st
 **Note**: MM-V1 uses a different HID descriptor than MM-V3. Confirm startup-repair.ps1 detects
 the correct BTHENUM parent for PID 030d and that `MouseBatteryReader` matches the correct
 KnownMice entry.
+
+---
+
+## Tier 5 — V3RecycleManager Tests (M3)
+
+**Scope**: End-to-end recycle cycle validation — Mode B→A flip, battery read, Mode A→B restore.
+**Prerequisite**: Mouse paired and in Mode B (scroll works, battery not showing). MM-Dev-Cycle scheduled task active.
+**Test script**: `C:\mm-dev-queue\test-v3-state.ps1` (run as Administrator).
+
+### Mode B Detection Signals (authoritative, 2026-05-07)
+
+| Signal | Mode A | Mode B | Source |
+|--------|--------|--------|--------|
+| HID paths | col01 + col02 (split) | unified (no col suffix) | `Get-PnpDeviceInterface` |
+| LowerFilters (BTHENUM Enum key) | `(empty)` | `applewirelessmouse` | Registry: `HKLM:\...\Enum\BTHENUM\{00001124...}_VID&0001004C_PID&0323\9&...` |
+| DEVPKEY_Device_Stack | no `applewireless` entry | `applewireless` in list | `Get-PnpDeviceProperty -KeyName DEVPKEY_Device_Stack` |
+| MouseClass DN_STARTED | **True (false positive)** | True | NOT a discriminator — mouhid stays bound to col01 in Mode A |
+| Scroll | broken | works | Physical test |
+| Battery (RID=0x90 on col02) | readable | N/A (col02 not present) | `HidD_GetInputReport` |
+
+**MouseClass DN_STARTED must NOT be used as a Mode B indicator** — confirmed false positive 2026-05-07.
+
+### T5 Test Cases
+
+| Test ID | Test Case | Command | Pass Criteria |
+|---------|-----------|---------|---------------|
+| T5-01 | State check: device in Mode B | `.\test-v3-state.ps1 -StateCheckOnly` | Output: `State: MODE B` + `FilterInStack=True` + `LowerFilters=applewirelessmouse` |
+| T5-02 | Single recycle cycle (FLIP:NoFilter → Mode A → battery → FLIP:AppleFilter → Mode B) | `.\test-v3-state.ps1 -Runs 1` | `PASS: ModeA=True Battery=NN% Restored=True` |
+| T5-03 | Mode A confirmed via HID paths | Inspect T5-02 output | Two col paths visible: `...col01...` + `...col02...` in Mode A |
+| T5-04 | Mode B restored via DEVPKEY_Device_Stack | Inspect T5-02 output | `FilterInStack=True` in post-restore checkpoint |
+| T5-05 | WaitForModeB latency within budget | Inspect T5-02 timing | `[ModeB] confirmed at Nms` where N is 400–800ms |
+| T5-06 | Battery pipeline retry handled | Inspect T5-02 output | If GLE=121/GLE=21 on attempts 1-2, passes on attempt 3 or 4. No outer cycle retry triggered. |
+| T5-07 | BTHENUM parent healthy pre-flip | Inspect T5-02 output | `IsV3BtStackHealthy=True` in baseline |
+| T5-08 | No degradation after 1 cycle | Run mouse scroll after T5-02 | Scroll works normally post-restore |
+
+**Note**: Run T5 as a single cycle (`-Runs 1`) only. Multiple rapid cycles risk BT stack drift requiring re-pair.
 
 ---
 

--- a/docs/PRD-PATH-B-USERLAND-RECYCLER.md
+++ b/docs/PRD-PATH-B-USERLAND-RECYCLER.md
@@ -199,11 +199,12 @@ If recycle-to-Mode-A is non-deterministic at high frequency (e.g. <70% success),
 - **Exit criteria**: v2 battery reads correctly when paired
 
 ### M3 — v3 PnP recycler integration
-- [ ] Port C# prototype (commit e323df6 per PSN-0001 Session 10) into `V3RecycleManager.cs`
-- [ ] Wire to existing `MM-Dev-Cycle` scheduled task (`scripts/mm-task-runner.ps1`)
-- [ ] Add idle-detection (`GetLastInputInfo` Win32) — only recycle when idle ≥ 30 s
-- [ ] State machine implementation (Idle → Cycling → Reading → Recovering → Idle)
-- [ ] Cap recycle attempts (3 retries) with exponential backoff
+- [x] Port C# prototype (commit e323df6 per PSN-0001 Session 10) into `V3RecycleManager.cs`
+- [x] Wire to existing `MM-Dev-Cycle` scheduled task (`scripts/mm-task-runner.ps1`)
+- [x] Add idle-detection (`GetLastInputInfo` Win32) — only recycle when idle ≥ 30 s
+- [x] State machine implementation (Idle → Cycling → Reading → Recovering → Idle)
+- [x] Cap recycle attempts (3 retries) with retry delay
+- [x] **FIX (2026-05-07)**: Mode B detection false positive — replaced `IsV3MouseClassPresent()` with `IsApplewirelessmouseInStack()` (DEVPKEY_Device_Stack). Real WaitForModeB latency ~563ms. Battery read inner retry handles GLE=121/GLE=21 pipeline delay at col02 DN_STARTED.
 - **Exit criteria**: v3 battery readable in tray; scroll auto-recovers within 10 s of read complete
 
 ### M4 — Adaptive polling
@@ -295,6 +296,65 @@ If recycle-to-Mode-A is non-deterministic at high frequency (e.g. <70% success),
 
 ---
 
+## M3 Empirical Findings (2026-05-07)
+
+### Finding 1 — Mode B Detection False Positive (CLOSED)
+
+**Problem**: `IsV3InModeB()` used `IsV3MouseClassPresent()` (Mouse class device DN_STARTED) as the Mode B discriminator. This is a false positive: mouhid.sys stays bound to col01 and DN_STARTED remains True even when the device is in Mode A. All pre-fix test runs showed `WaitForModeB confirmed at 1–3ms` — which was the false signal.
+
+**Root cause**: After FLIP:NoFilter, the Mouse class device node persists with DN_STARTED; mouhid does not unbind. The only thing that changes is the HID path topology (col01+col02 split appears) and the BTHENUM Enum LowerFilters is cleared.
+
+**Fix applied**: Replaced `IsV3MouseClassPresent()` with `IsApplewirelessmouseInStack()` — queries `DEVPKEY_Device_Stack` on the BTHENUM devnode via `CM_Get_DevNode_PropertyW`. This property reflects what is actually loaded in the kernel stack. In Mode B, `applewirelessmouse.sys` appears in the list; in Mode A it does not. `IsV3MouseClassPresent()` is retained as dead code (per no-deletion policy) but not called.
+
+**Real WaitForModeB latency**: ~563ms (not 1–3ms). All prior passes were false positives from the MouseClass check.
+
+### Finding 2 — BTHENUM Enum Registry Path vs HID Enum Path (CLOSED)
+
+**Problem**: `LowerFilters` reads from the HID Enum path always returned empty (including in Mode B). `mm-state-flip.ps1` writes to the BTHENUM Enum path, not the HID Enum path.
+
+**BTHENUM Enum registry path** (where LowerFilters lives):
+```
+HKLM:\SYSTEM\CurrentControlSet\Enum\BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&0001004C_PID&0323\9&73B8B28&0&D0C050CC8C4D_C00000000
+```
+
+**HID Enum path** (WRONG — always empty):
+```
+HKLM:\SYSTEM\CurrentControlSet\Enum\HID\...
+```
+
+Resolution: test script now reads from BTHENUM Enum path via `Get-V3BthenumInstance`. C# uses DEVPKEY_Device_Stack (runtime) rather than registry LowerFilters, which avoids this ambiguity entirely.
+
+### Finding 3 — No PnP Event ID 410 on FLIP:AppleFilter (CLOSED)
+
+**Hypothesis**: Kernel-PnP/Configuration event ID 410 would fire after a successful FLIP:AppleFilter if `applewirelessmouse.sys` loaded. Absence of event 410 was briefly interpreted as the driver not loading.
+
+**Conclusion**: Event 410 only fires on full Bluetooth re-pair/device deletion level operations. A clean FLIP:AppleFilter (LowerFilters write + disable/enable) does not generate event 410 even when the driver loads correctly. DEVPKEY_Device_Stack confirms driver presence at 563ms without event 410.
+
+### Finding 4 — Battery Read Pipeline Latency (CLOSED)
+
+col02 `DN_STARTED` appears at 3–4ms post-flip, but the HID report pipeline is not ready. Observed sequence:
+
+- Attempt 1: GLE=121 (device busy) — immediate
+- Attempt 2: GLE=21 (pipe not ready)
+- Attempt 3: GLE=21
+- Attempt 4: `BATTERY OK: 18%` (~1000ms post col02 DN_STARTED)
+
+3-retry inner loop (500ms delay each) in `V3RecycleManager.cs` handles this reliably without triggering the outer cycle retry.
+
+### Verification Test Results (commit 55e9193)
+
+Test: `test-v3-state.ps1 -Runs 1` — 3× runs:
+
+| Run | Mode A | Battery | Mode B Restored | WaitForModeB actual |
+|-----|--------|---------|-----------------|---------------------|
+| 1 | True | 18% | True | 563ms |
+| 2 | True | 18% | True | ~1ms (false positive — pre-fix) |
+| 3 | True | 18% | True | ~1ms (false positive — pre-fix) |
+
+After fix: all runs use DEVPKEY_Device_Stack for Mode B confirmation with real ~563ms latency.
+
+---
+
 ## References
 
 - PSN-0001 hypothesis log: H-007 (battery-only without filter), H-009 (recycle reliability), H-010 revised (mode mutual exclusion)
@@ -303,3 +363,4 @@ If recycle-to-Mode-A is non-deterministic at high frequency (e.g. <70% success),
 - C# recycle prototype: commit `e323df6` (per PSN-0001 Session 10)
 - Magic Utilities cadence reference: 15 min poll interval, avoids 10–50 ms scroll stutter
 - Session 15 empirical results: `docs/SESSION-15-EMPIRICAL-TEST-RESULTS-2026-05-05.md`
+- M3 Mode B detection fix: commit on `ai/m3-v3-recycle-manager` branch (2026-05-07)

--- a/docs/SESSION-17-MODE-B-DETECTION-FIX-2026-05-07.md
+++ b/docs/SESSION-17-MODE-B-DETECTION-FIX-2026-05-07.md
@@ -1,0 +1,140 @@
+# Session 17 — Mode B Detection False Positive Fix
+
+**Date**: 2026-05-07
+**Branch**: `ai/m3-v3-recycle-manager`
+**Status**: CLOSED — root cause found and fixed in C# production code and test script
+**Hardware**: Magic Mouse v3 (PID 0x0323), MAC D0:C0:50:CC:8C:4D
+
+---
+
+## BLUF
+
+`IsV3InModeB()` was using `IsV3MouseClassPresent()` (Mouse class device DN_STARTED) as its
+Mode B discriminator — a false positive. mouhid.sys stays bound to col01 and DN_STARTED
+stays True even when the device is in Mode A. All prior WaitForModeB confirmations showing
+`1–3ms` were false. Real latency is ~563ms.
+
+Fix: replaced with `IsApplewirelessmouseInStack()` which queries `DEVPKEY_Device_Stack` on
+the BTHENUM devnode — reflects what is actually loaded in the kernel. Applewirelessmouse.sys
+only appears in this list after FLIP:AppleFilter + enable completes successfully.
+
+---
+
+## Root Cause Chain
+
+1. **Test script bug (precursor)**: `Get-HidLowerFilters` was reading from the HID Enum path.
+   `mm-state-flip.ps1` writes to the BTHENUM Enum path. HID Enum LowerFilters is always empty.
+   Fixed by `Get-BthenumLowerFilters` using `Get-V3BthenumInstance` to locate the correct key.
+
+2. **Core detection bug**: `Test-IsV3InModeB` called `[HidEnum]::IsV3MouseClassPresent()`.
+   mouhid.sys stays resident on col01 across both modes — DN_STARTED never goes False in Mode A.
+   The 1–3ms `[ModeB] confirmed` in prior runs was this false signal triggering immediately.
+
+3. **Consequence**: `V3RecycleManager.IsV3InModeB()` had the same bug in C# production code,
+   calling `HidNative.IsV3MouseClassPresent()`.
+
+---
+
+## Findings
+
+### Mode B latency (real)
+
+- WaitForModeB: **563ms** after FLIP:AppleFilter (one observed data point)
+- This is within the 5000ms `ModeBVerifyMs` budget — no timeout risk
+- Prior 1–3ms times were all false positives
+
+### No PnP event 410 on FLIP:AppleFilter
+
+`Microsoft-Windows-Kernel-PnP/Configuration` event ID 410 is only generated on full BT
+re-pair/device deletion, not on filter-add + disable/enable cycles. Absence of event 410
+does NOT mean the driver failed to load. DEVPKEY_Device_Stack is the authoritative signal.
+
+### BTHENUM Enum registry path (authoritative LowerFilters location)
+
+```
+HKLM:\SYSTEM\CurrentControlSet\Enum\BTHENUM\{00001124-0000-1000-8000-00805F9B34FB}_VID&0001004C_PID&0323\9&73B8B28&0&D0C050CC8C4D_C00000000
+```
+
+The HID Enum path (`HKLM:\...\Enum\HID\...`) does NOT contain LowerFilters for this device.
+
+### Battery pipeline latency post-col02-DN_STARTED
+
+col02 DN_STARTED appears at ~3ms but the HID report pipeline is not ready:
+
+| Attempt | GLE | Wait from DN_STARTED |
+|---------|-----|---------------------|
+| 1 | 121 (device busy) | 0ms |
+| 2 | 21 (pipe not ready) | ~500ms |
+| 3 | 21 | ~1000ms |
+| 4 | 0 (SUCCESS) 18% | ~1500ms |
+
+3-retry inner loop in `ExecuteRecycleCycle` (500ms × 3) handles this without triggering
+the outer cycle retry. No code change needed.
+
+---
+
+## Changes Made
+
+### `MagicMouseTray/HidNative.cs`
+
+Added:
+- `CM_Get_DevNode_Property` P/Invoke (`CM_Get_DevNode_PropertyW` entry point)
+- `DEVPROPKEY` struct
+- `s_devpkeyStack` static field — DEVPKEY_Device_Stack `{a45c254e-df1c-4efd-8020-67d146a850e0}` pid=14
+- `IsApplewirelessmouseInStack()` — finds v3 BTHENUM devnode, queries DEVPKEY_Device_Stack,
+  parses UTF-16 multi-string, returns true if any entry matches `applewireless`
+
+`IsV3MouseClassPresent()` retained (not deleted per policy) but no longer called.
+
+### `MagicMouseTray/V3RecycleManager.cs`
+
+`IsV3InModeB()`:
+- Was: `return HidNative.IsV3MouseClassPresent();`
+- Now: `return HidNative.IsApplewirelessmouseInStack();`
+- Updated comment to document the false positive and real 563ms latency
+
+`WaitForModeB()` comment updated with empirical latency.
+
+### `C:\mm-dev-queue\test-v3-state.ps1`
+
+- `Test-IsV3InModeB`: replaced `[HidEnum]::IsV3MouseClassPresent()` with `Get-BthenumFilterInStack`
+  which calls `Get-PnpDeviceProperty -KeyName DEVPKEY_Device_Stack`
+- Added `Get-V3BthenumInstance`: finds BTHENUM device via `Get-PnpDevice -Class HIDClass`
+  matching `{00001124}` + VID `0001004c` + PID `0323`
+- Added `Get-BthenumLowerFilters`: reads from BTHENUM Enum registry path (not HID Enum path)
+- Added `Get-BthenumFilterInStack`: reads DEVPKEY_Device_Stack from BTHENUM devnode
+- Added auto-restore on Mode A baseline: FLIP:AppleFilter before test if device found in Mode A
+- Fixed self-relaunch arg forwarding: explicit `$passArgs` from `$PSBoundParameters`
+- Changed default `$Runs` from 3 to 1 (rapid cycling causes BT stack drift)
+- Fixed `return if ($lf)` syntax (invalid PS 5.x) → `if ($lf) { return ... } else { return ... }`
+- Added `-StateCheckOnly` summary: Mode A/B/Unknown, FilterInStack, LowerFilters, BTHENUM health
+
+---
+
+## Test Results (post-fix)
+
+Test log: `C:\mm-dev-queue\test-log-20260507-093013.txt`
+
+```
+ Run 1: PASS   ModeA=True  Battery=18%  Restored=True  time=25.2s
+ Run 2: PASS   ModeA=True  Battery=18%  Restored=True  time=17s
+ Run 3: PASS   ModeA=True  Battery=18%  Restored=True  time=17s
+ ALL RUNS PASSED  total=59.3s
+```
+
+Note: Runs 2 and 3 still showed 1ms WaitForModeB — these were run against commit 55e9193 before
+the production C# fix. The test script fix was in place; the C# code fix was applied in this
+session after the test run.
+
+---
+
+## Discrimination Table (updated)
+
+| Signal | Mode A | Mode B |
+|--------|--------|--------|
+| HID paths | col01 + col02 split | unified (no col suffix) |
+| LowerFilters (BTHENUM Enum key) | `(empty)` | `applewirelessmouse` |
+| DEVPKEY_Device_Stack | no `applewireless` | contains `applewireless` |
+| MouseClass DN_STARTED | **True** (false positive) | True |
+| scroll | broken | works |
+| battery (RID=0x90 col02) | readable | N/A |


### PR DESCRIPTION
## Summary

- **Root cause fixed**: `IsV3InModeB()` was using `IsV3MouseClassPresent()` (Mouse class device DN_STARTED) to detect Mode B. mouhid.sys stays bound to col01 and DN_STARTED stays True even in Mode A — a false positive. All prior `WaitForModeB confirmed at 1–3ms` readings were this signal firing immediately.
- **Fix**: `HidNative.IsApplewirelessmouseInStack()` — queries `DEVPKEY_Device_Stack` on the v3 BTHENUM devnode via `CM_Get_DevNode_PropertyW`. Applewirelessmouse.sys only appears in the stack after FLIP:AppleFilter + enable completes. Real WaitForModeB latency: 226–563ms.
- **Build**: 0 warnings, 0 errors (`dotnet build -c Debug`)
- **Live test**: 1/1 PASS — Mode A correct (FilterInStack=False), Mode B correct (FilterInStack=True, 226ms), battery=17%, full cycle 19.9s

## Changes

| File | Change |
|------|--------|
| `MagicMouseTray/HidNative.cs` | Added `IsApplewirelessmouseInStack()`, `CM_Get_DevNode_PropertyW` P/Invoke, `DEVPROPKEY` struct |
| `MagicMouseTray/V3RecycleManager.cs` | `IsV3InModeB()` now calls `IsApplewirelessmouseInStack()` instead of `IsV3MouseClassPresent()` |
| `TEST-PLAN.md` | New Tier 5 — V3RecycleManager tests with Mode B discrimination table |
| `docs/PRD-PATH-B-USERLAND-RECYCLER.md` | M3 empirical findings section (4 closed findings) |
| `docs/SESSION-17-MODE-B-DETECTION-FIX-2026-05-07.md` | Root cause analysis + discrimination signal table |

## Mode B Discrimination (updated)

| Signal | Mode A | Mode B |
|--------|--------|--------|
| HID paths | col01 + col02 split | unified (no col suffix) |
| LowerFilters (BTHENUM Enum key) | `(empty)` | `applewirelessmouse` |
| **DEVPKEY_Device_Stack** | no `applewireless` | **contains `applewireless`** ← authoritative |
| MouseClass DN_STARTED | **True (false positive)** | True — NOT a discriminator |

## Pre-merge note

Full M3 peer review (V3RecycleManager + SelfHealManager interaction, failure caps, multi-device scaffolding) is a prerequisite before the v1.1.0 release tag. This PR fixes the detection bug; the full milestone review is a separate gate.

## Test plan

- [x] `dotnet build -c Debug` — 0 warnings, 0 errors
- [x] Live hardware test via `MM-TestRun-M3` SYSTEM task: `Run 1: PASS ModeA=True Battery=17% Restored=True FilterInStack=True time=19.9s`
- [x] Mode A checkpoint: `LowerFilters=(empty)` + `FilterInStack=False` — correct negative
- [x] Mode B checkpoint: `LowerFilters=applewirelessmouse` + `FilterInStack=True` at 226ms — correct positive
- [ ] Full M3 peer review before release tag

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
