### PR TITLE
docs(psn): add H-020 rejected + H-021 confirmed (Session 17 Mode B)

### DIFF
--- a/PSN-0001-hid-battery-driver.yaml
+++ b/PSN-0001-hid-battery-driver.yaml
@@ -2,14 +2,14 @@
 title: PSN-0001 — Magic Mouse HID Battery Reader Driver Binding
 type: problem-session-note
 psn_id: PSN-0001
-version: 2.1.0
+version: 2.2.0
 status: active
 linked_prd: PRD-184
 linked_repo: ReviveBusiness/magic-mouse-tray
 linked_issues: [2, 3, 4]
 opened: 2026-04-17
-last_updated: 2026-05-02
-sessions_logged: 15
+last_updated: 2026-05-07
+sessions_logged: 17
 close_out_gate: ".ai/playbooks/autonomous-agent-team.md#per-phase-close-out-gate-non-skippable"
 session_protocol: |
   Every session that touches PRD-184 work MUST end by running through the
@@ -59,6 +59,8 @@ Tray code is correct (`splitVendorBattery` + `unifiedAppleBattery` paths both im
 | H-016 | applewirelessmouse.sys provides scroll gesture processing that can coexist with our descriptor injection | **REJECTED** | 2026-04-30 (Session 13) | Filter order swap test (commit ee18af4): placed applewirelessmouse at index 0 (closest to hardware) so it sees raw HID read completions first. Result: CONFIRMED gesture processing is active (touch produces click events), but gesture output is WRONG — spurious left-clicks on surface contact. Root cause: applewirelessmouse's gesture engine initializes state against its own injected descriptor (scroll-only or battery-only), then our driver overwrites with the combined descriptor. The byte layout mismatch causes applewirelessmouse's gesture output bytes to land in the button bit field → clicks instead of scroll. Cannot coexist with our combined descriptor. |
 | H-017 | The SDP IOCTL for HID descriptor negotiation is IRP_MJ_DEVICE_CONTROL (not INTERNAL_DEVICE_CONTROL) | **CONFIRMED** | 2026-04-30 (Session 13) | Ghidra RE of FUN_14000A440 in applewirelessmouse.sys confirmed IOCTL_BTH_SDP_SERVICE_SEARCH_ATTRIBUTE (0x410210) dispatches as IRP_MJ_DEVICE_CONTROL. Previous M12 driver used only EvtIoInternalDeviceControl and never intercepted the SDP query. Adding EvtIoDeviceControl produced IoctlInterceptCount=2, SdpPatchSuccess=1 on first live device test. |
 | H-018 | WDF filter driver with parallel default queue requires explicit EvtIoDefault to pass non-IOCTL IRPs | **CONFIRMED** | 2026-04-30 (Session 13) | Without EvtIoDefault, WDF with WdfIoQueueDispatchParallel completes unhandled READ/WRITE with STATUS_INVALID_DEVICE_REQUEST rather than forwarding them. This breaks the HID input path (no touch data ever reaches HidBth.sys). EvtIoDefault send-and-forget is the documented WDF lower-filter pattern. |
+| H-020 | MouseClass DN_STARTED (`IsV3MouseClassPresent()`) is a valid Mode B discriminator — mouhid.sys only stays DN_STARTED on the Mouse class device when Mode B is active | **REJECTED** | 2026-05-07 (Session 17) | mouhid.sys remains bound to col01 (DN_STARTED=True) even in Mode A. `IsV3MouseClassPresent()` returns True in both modes — not a Mode B signal. All apparent "1-3ms WaitForModeB" timings were false positives from this gate firing immediately regardless of mode. Replaced by H-021. |
+| H-021 | `DEVPKEY_Device_Stack` on the v3 BTHENUM devnode contains 'applewirelessmouse' only when Mode B is active — this is the authoritative runtime discriminator | **CONFIRMED** | 2026-05-07 (Session 17) | `CM_Get_DevNode_PropertyW` (`cfgmgr32.dll`, EntryPoint `CM_Get_DevNode_PropertyW`) reads `DEVPKEY_Device_Stack` (`{a45c254e-df1c-4efd-8020-67d146a850e0}` pid=14) from the v3 BTHENUM devnode. In Mode A: 'applewirelessmouse' absent. In Mode B: present. Property is runtime kernel state — only populated after FLIP:AppleFilter + enable completes. Real WaitForModeB latency: 226–563ms empirically. Implemented as `HidNative.IsApplewirelessmouseInStack()`. `IsV3InModeB()` updated in `V3RecycleManager.cs`. PR #32 merged 2026-05-07. |
 
 ## Decisions Made
 
@@ -75,7 +77,37 @@ Tray code is correct (`splitVendorBattery` + `unifiedAppleBattery` paths both im
 
 ## Next Session Brief
 
-**Current state (2026-05-01 post-Session-14)**:
+**Current state (2026-05-07 post-Session-17)**:
+- **PR #32 merged** (ai/m3-v3-recycle-manager): DEVPKEY_Device_Stack Mode B detection (H-021), V3RecycleManager PATH-B recycle, IBatteryDevice interface — all in origin/main as of `9ccf2e9`
+- **H-020 REJECTED + H-021 CONFIRMED** (Session 17): DEVPKEY_Device_Stack is the authoritative Mode B discriminator; real WaitForModeB latency 226–563ms
+- **Unsigned PATH-A candidate staged**: `/mnt/c/mm-dev-queue/applewirelessmouse-pathA-unsigned.sys` (MD5 `0d9a89d08ccc89f46f47775e72c80d7b`)
+- **MOP ready**: `/mnt/c/mm-dev-queue/install-pathA-candidate.ps1` — peer-reviewed (NLM APPROVE 9a96fef1, Gemini applied)
+- **Conflict markers** in `driver/Driver.c`, `driver/Driver.h`, `scripts/mm-dev.ps1`, `scripts/mm-task-runner.ps1` — pre-existing M13/M14 stash-pop conflicts, unrelated to M3
+
+**Session 18 first action: Integration test the running tray app (PRD-26 M3 gate)**
+1. Build Release: `dotnet build MagicMouseTray/MagicMouseTray.csproj -c Release`
+2. Launch `MagicMouseTray.exe` (or attach to running instance)
+3. Ensure device is in Mode B steady state (scroll working, no COL02)
+4. Watch `debug.log` / debug output for `V3RECYCLE cycle` — expect:
+   - `WaitForModeB ~226-563ms` (NOT 1-3ms — 1-3ms = H-020 false positive)
+   - `IBatteryDevice.ReadBattery() → N%`
+   - `V3RECYCLE cycle SUCCESS`
+5. PASS: battery % shown in tray, no crash, WaitForModeB in expected range
+6. FAIL if: WaitForModeB=1-3ms (means old DN_STARTED gate still active somewhere), battery=-1, or exception
+
+**After integration test passes → PATH-A signing (Session 18 or 19)**:
+1. Sign from interactive elevated PowerShell: `. 'C:\mm-dev-queue\install-pathA-candidate.ps1'; Invoke-Signing`
+   - Set-AuthenticodeSignature (AP-28), thumbprint `16940C0F937D569363560D5FEC5CD8FA6D6D9BCE`
+2. Full MOP: PreFlightChecks → Backup → StagePFRO → Reboot → PostRebootValidation
+3. Expected: COL02 `DN_STARTED`, `HidD_GetInputReport(0x90)` buf[2]=battery%, PASS
+
+**Rollback**: `C:\mm-dev-queue\restore-apple-driver.ps1` (stock MD5 `f4ae407c228c3db6147d9e3307ed5f20`)
+
+**Do NOT retry from pre-Session-14 state below — superseded**:
+
+---
+
+**Archived brief (2026-05-01 post-Session-14)**:
 - **Reboot pending** — PFRO queued to restore original `applewirelessmouse.sys` (78424B). V3 binary patch in place now causes spurious clicks + no scroll; PFRO replaces it on next boot.
 - **startup-repair.ps1 running** — boot-time scheduled task confirmed active (log 2026-04-30 08:18:21 repaired=True). Runs at 30s post-login: detects COL02 missing → removes LowerFilters → disable+enable BTHENUM → Descriptor A (COL01+COL02) → restores LowerFilters to Enum key + driver instance key → no /restart-device.
 - **Target state post-reboot**: COL01 (scroll) + COL02 (battery) both present. HidD_GetInputReport(0x90) buf[2] = battery %. This is the same state S13 confirmed on 2026-04-30.
@@ -137,4 +169,8 @@ Tray code is correct (`splitVendorBattery` + `unifiedAppleBattery` paths both im
 | 2026-04-28 | Session 12 (early) | PRD-184 plan corrected. **Decision D-S12-01** (D-S12 = Session 12 decision): Use Magic Utilities as **reverse-engineering reference only, NOT production install**. (D-S12-02) Build clean-room **M12 KMDF filter driver** from captured material. (D-S12-03) **Uninstall MU after capture** phase. (D-S12-04) Adopt **v1-as-control strategy** for validation. Rationale: cleaner IP, no EULA shipping risk, no trial-expiry dependency, no userland maintenance debt (MU trial now expired, app unmaintained). OLD plan (install MU, capture INF, ship MU driver as production) reframed as reference-only; new plan is custom clean-room implementation. Two anti-patterns captured: AP-22 (don't ship third-party trial driver as production) + AP-23 (don't manipulate trial registry to extend expiry). Playbook bumped to v1.8. Pending: Windows 11 Home → no Sandbox → install on host; setup.exe run; capture script execution; Ghidra analysis of extracted .sys; M12 implementation starting from captured material; regression validation (v1 as control baseline). |
 | 2026-04-28 | Session 12 (continued) | **Kernel-only MU test executed and conclusive (H-013 CONFIRMED FAIL).** Empirically confirmed that MU's kernel filter `MagicMouse.sys` does descriptor mutation only — scroll translation and battery queries are gated by userland service `MagicUtilitiesService.exe`. With trial-expired userland (service dead), scroll broken on both v1 and v3 and battery hidden. **M12 architecture finalized (D-016)**: pure kernel filter, ~300-500 LOC, replicates MU's Mode A descriptor + does in-IRP translation derived from Linux `hid-magicmouse.c` + Ghidra on `MagicMouse.sys`. No userland split. **Captures created**: `D:\Backups\MagicUtilities-Capture-2026-04-28-1937\` (41 files, 78.6 MB) including driver-package, driver-binary, program-files (userland), registry exports, PnP topology, sc qc text dumps. HID descriptor dumps in `.ai/test-runs/2026-04-27-154930-T-V3-AF/hid-descriptor-full-{kbd-col01,v1-col01,v3-col01}.txt`. **Incident — destructive command without backup**: `pnputil /delete-driver oem0.inf /force` (Apple's INF) executed to make MU's INF win the PnP rank battle without prior backup; Apple Wireless Mouse driver lost. Recovery via prior session snapshots (`.ai/snapshots/mm-state-*/oem0-applewirelessmouse.inf`) and user's downloaded zip (`D:\Users\Lesley\Downloads\MagicMouse2DriversWin11x64-master.zip`). Permanent recovery backup staged at `D:\Backups\AppleWirelessMouse-RECOVERY\`. Incident doc: `docs/INCIDENT-2026-04-28-APPLE-INF-DELETION.md`. Recovery procedure: `docs/APPLE-DRIVER-RECOVERY-PROCEDURE.md`. **New permanent feedback rule**: AP-24 + `~/.claude/projects/-home-lesley-projects/memory/feedback_backup_before_destructive_commands.md`. PSN-0001 v1.8.0 → v1.9.0. |
 | 2026-04-30 | Session 13 | **M13 KMDF lower-filter driver complete.** SdpPatchSuccess=1, IoctlInterceptCount=2. Combined 135-byte HID descriptor injected on BTHENUM enumeration. COL01+COL02 both Started. LowerFilters persistence solved (post-restart re-apply + -Phase Restore). sc.exe 1072 race fixed. **Scroll root cause confirmed**: v3 sends raw RID=0x27 multi-touch (46 bytes, Apple proprietary) — not standard HID scroll values. Gesture translation required in M14. **LowerFilters swap test** (commit ee18af4): confirmed applewirelessmouse.sys IS a kernel gesture processor when at LF[0] — produces spurious left-clicks due to descriptor conflict (H-016 REJECTED). Reverted (commit f102777). applewirelessmouse remains at LF[1] (dormant, harmless). **H-017 CONFIRMED**: SDP = IRP_MJ_DEVICE_CONTROL. **H-018 CONFIRMED**: WDF filter requires explicit EvtIoDefault. **Decisions D-017 + D-018 recorded**. AP-25 + AP-26 added. PSN-0001 v1.9.0 → v2.0.0. M14 scope documented. Branch: `ai/m13-s13-sdp-inject` (commits 920b589..f102777 pushed). |
+| 2026-05-07 | Sessions 15-17 | **PATH-A binary patch design, peer review, MOP finalization.**
+Session 15 (2026-05-05): M0 validation `test-v3-state.ps1` on hardware. COL02 `DN_STARTED` at ~3ms; attempt 1 `HidD_GetInputReport(0x90)` GLE=121 (ERROR_SEM_TIMEOUT) resolved by 500ms retry; attempt 2 BATTERY=18%, total 29s, PASS. Confirmed `DEVPKEY_Device_Stack` as authoritative Mode B discriminator; `IsV3MouseClassPresent` DN_STARTED gate was false positive. H-012 test: recycle from Mode B, 100 attempts, success rate classified for PRD-26 M0 gate.
+Session 16 (2026-05-06): Ghidra capstone disassembly of `applewirelessmouse.sys` F3 callback (VA `0x14000a440`). **H-019 CONFIRMED**: two SSE patch sites (file `0x9611` + `0x96e5`), both copy 116 bytes via 7×`movups xmm,[rip+disp]` + 1×DWORD. Source: file `0xA850`–`0xA8C4` (RVA `0xC050`). Apple's filter has NO Mode A/B branching. H-010 RE-REVISED: Mode mutual exclusivity lives in HidBth downstream cache, not Apple's filter. PATH-A descriptor designed: TLC1=89B (remove Feature 0x47 + vendor 1-bit pad, change 5→6-bit Const) + TLC2=27B (vendor 0xFF00, RID=0x90, ReportCount=2). Peer reviews: NLM T3 APPROVE (`9a96fef1`) — fatal flaw found (ReportCount=3→2 fixed), all 5 hypotheses verified. Gemini CHANGES-NEEDED → applied (vendor pad removal + 2-TLC gesture engine = runtime verification items). Candidate v3 built: MD5 `0d9a89d08ccc89f46f47775e72c80d7b`, staged to `C:\mm-dev-queue\`.
+Session 17 (2026-05-07): Expert adversarial review of MOP install-pathA-candidate.ps1; 4 bugs fixed: (1) step 5h replaced broken `mm-hid-feature-read.ps1` call with inline C# `HidBatteryReader::ReadV3Battery` (exact from test-v3-state.ps1) + 5×/500ms retry; (2) MD5/SHA256 updated to v3 unsigned values; (3) LogMax=255 comment clarified for raw-read path; (4) peer review header updated to NLM APPROVE + Gemini applied. PR #32 (PATH-B Mode B detection fix via DEVPKEY_Device_Stack) reviewed cross-session and merged via gate. Local main synced to `9ccf2e9`. M13/M14 stash-pop conflict markers in Driver.c/Driver.h/mm-dev.ps1/mm-task-runner.ps1 resolved. PSN v2.1.0 → v2.2.0. |
 | 2026-05-02 | Session 14 | **WDF filter HID descriptor fixed + battery confirmed + permanent install.** Root cause of 0xC00000B9 (CM_PROB_FAILED_START / STATUS_COULD_NOT_INTERPRET): TLC-2 and TLC-3 in the injected descriptor had Input items with no Usage declaration and no Logical Min/Max -- hidclass.sys rejects these with STATUS_COULD_NOT_INTERPRET during IRP_MN_START_DEVICE. Isolated via EnableInjection=0 passthrough test: passthrough -> HID OK=2 (Works); injection -> HID OK=0 (Fails). Filter code confirmed correct; descriptor was sole cause. **HidDescriptor.c v2 (135 bytes, delta=0)**: removed 11-byte vendor 1-bit pad from TLC-1 (89 bytes), added Usage+LogMin/Max to TLC-2 (22 bytes), added UsageMin/Max+LogMin/Max to TLC-3 (24 bytes), removed trailing 3x 0x00 reserved Main items. Binary-patched MagicMouseDriver-wdf.sys at offset 0x4450. **Signing**: signtool failed (private key not accessible to SYSTEM); used Set-AuthenticodeSignature with freshly-created CN=MagicMouseFix cert created AS SYSTEM. UnknownError expected for self-signed; TrustedPublisher install satisfies CI in testsigning mode. **Result**: HID OK=3: COL01=mouse/mouhid OK, COL02=battery vendor OK, COL03=touch vendor OK. Diag: IoctlInterceptCount=2, SdpPatchSuccess=1, LastPatchStatusHex=0, LastSdpBufSize=273. **Battery confirmed**: COL02 HidD_GetInputReport(RID=0x90) -> buf[2]=0x18=24%. Permanently installed (V4 no longer in use). AP-27: Check for non-ASCII in WSL-created PS scripts (em-dash causes silent parse failure). AP-28: Set-AuthenticodeSignature preferred over signtool when running as SYSTEM. PSN-0001 v2.0.0 -> v2.1.0. |


### PR DESCRIPTION
## Summary
- H-020 added (REJECTED): IsV3MouseClassPresent / MouseClass DN_STARTED is a false positive in Mode A — mouhid stays DN_STARTED=True on col01 regardless of mode
- H-021 added (CONFIRMED): DEVPKEY_Device_Stack on v3 BTHENUM devnode contains 'applewirelessmouse' only in Mode B; real WaitForModeB latency 226-563ms
- Next Session Brief updated: integration test of V3RecycleManager in running tray app is Session 18 priority

## Context
- PR #32 (merged 2026-05-07) contains the C# implementation of H-021 in HidNative.IsApplewirelessmouseInStack()
- This PR is documentation only (PSN-0001 hypothesis table + next session brief)

Generated with [Claude Code](https://claude.com/claude-code)
