### PR TITLE
m4(kbd-probe): add 5s SO_RCVTIMEO/SO_SNDTIMEO so firmware silence can't hang the probe

### DIFF
--- a/scripts/kbd-l2cap-with-hid-disable-2026-05-08.ps1
+++ b/scripts/kbd-l2cap-with-hid-disable-2026-05-08.ps1
@@ -80,6 +80,13 @@ public static class L2cap {
     public static extern int closesocket(IntPtr s);
     [DllImport("ws2_32.dll", SetLastError=true)]
     public static extern int WSAGetLastError();
+    [DllImport("ws2_32.dll", SetLastError=true)]
+    public static extern int setsockopt(IntPtr s, int level, int optname,
+        ref int optval, int optlen);
+
+    public const int SOL_SOCKET   = 0xFFFF;
+    public const int SO_RCVTIMEO  = 0x1006;
+    public const int SO_SNDTIMEO  = 0x1005;
 
     [StructLayout(LayoutKind.Sequential, CharSet=CharSet.Ansi)]
     public struct WSADATA {
@@ -271,6 +278,13 @@ try {
         [L2cap]::WSACleanup() | Out-Null
         return
     }
+
+    # Set 5s recv/send timeouts so a misbehaving firmware can't hang the script
+    # with HID disabled. If recv times out we surface WSAETIMEDOUT (10060) and
+    # the finally block re-enables HID — keyboard usable again within seconds.
+    $timeoutMs = 5000
+    [L2cap]::setsockopt($sock, [L2cap]::SOL_SOCKET, [L2cap]::SO_RCVTIMEO, [ref]$timeoutMs, 4) | Out-Null
+    [L2cap]::setsockopt($sock, [L2cap]::SOL_SOCKET, [L2cap]::SO_SNDTIMEO, [ref]$timeoutMs, 4) | Out-Null
 
     $sa = New-Object L2cap+SOCKADDR_BTH
     $sa.addressFamily  = [ushort][L2cap]::AF_BTH


### PR DESCRIPTION
## Summary
Single minimal change to `scripts/kbd-l2cap-with-hid-disable-2026-05-08.ps1` so the probe can be run safely.

Without a recv timeout, if the keyboard firmware silently drops a request — or the L2CAP socket is otherwise unresponsive — `recv()` blocks indefinitely **while HID is disabled**, leaving the keyboard unusable until the user kills the script with Ctrl+C and the `finally` block fires to re-enable HID.

5s is comfortable headroom over the observed macOS round-trip (~28 ms for the `GET_REPORT(0x47)` response per the HCI capture in `docs/M4-MAC-CAPTURE-FINDINGS-2026-05-08.md`). A timeout surfaces as `WSAETIMEDOUT (10060)`, which the existing error-name `switch` already identifies; the `finally` block then re-enables HID promptly.

## What changed
- Added `setsockopt` P/Invoke + `SOL_SOCKET`/`SO_RCVTIMEO`/`SO_SNDTIMEO` constants in the `L2cap` C# block.
- After socket creation, set 5000 ms timeout on both directions before `connect`.

14 lines added, 0 removed.

## Test plan
- [ ] Run `pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/kbd-l2cap-with-hid-disable-2026-05-08.ps1` as Admin with the keyboard paired and connected. Expect either:
  - `*** BATTERY LEVEL: NN% ***` → wire flow replicates; we're done
  - WSAETIMEDOUT after 5s → script exits cleanly, finally re-enables HID, keyboard usable again within ~5s of timeout
  - Other connect-time error → existing error table covers it; HID re-enabled in finally
- [ ] Verify keyboard usable within ~5s of any path (no indefinite hang)

## Out of scope (review polish, not "make this run")
The PR #35 review surfaced these — all production-future or polish, none block running:
- Parameterise `$KbdBdAddrStr`
- `return` → `exit N` for proper exit codes
- Streaming log writes
- L2CAP packet-boundary handling
- Passive `ReadFile` backup channel for unsolicited 0x47 emits
- Production-side: kernel HID filter (M7.c) — for shipping `KeyboardBatteryDevice.cs`, the `BluetoothSetServiceState(DISABLE)` round-trip would render the keyboard unusable for ~1s every poll cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
