### PR TITLE
m4(kbd-driver): add MagicKbDesc.vcxproj + .sln

### DIFF
--- a/driver-keyboard/MagicKbDesc.sln
+++ b/driver-keyboard/MagicKbDesc.sln
@@ -1,0 +1,23 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.32104.313
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "MagicKbDesc", "MagicKbDesc.vcxproj", "{B2C3D4E5-F607-8901-BCDE-F23456789012}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B2C3D4E5-F607-8901-BCDE-F23456789012}.Debug|x64.ActiveCfg = Debug|x64
+		{B2C3D4E5-F607-8901-BCDE-F23456789012}.Debug|x64.Build.0 = Debug|x64
+		{B2C3D4E5-F607-8901-BCDE-F23456789012}.Debug|x64.Deploy.0 = Debug|x64
+		{B2C3D4E5-F607-8901-BCDE-F23456789012}.Release|x64.ActiveCfg = Release|x64
+		{B2C3D4E5-F607-8901-BCDE-F23456789012}.Release|x64.Build.0 = Release|x64
+		{B2C3D4E5-F607-8901-BCDE-F23456789012}.Release|x64.Deploy.0 = Release|x64
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/driver-keyboard/MagicKbDesc.vcxproj
+++ b/driver-keyboard/MagicKbDesc.vcxproj
@@ -1,0 +1,90 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  MagicKbDesc.vcxproj — KMDF lower filter for Apple keyboard descriptor patching.
+  Cloned from sibling driver/MagicMouseDriver.vcxproj 2026-05-08; same EWDK +
+  WDK target, just renamed and pointed at this directory's source files.
+-->
+<Project DefaultTargets="Build" ToolsVersion="15.0"
+         xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{B2C3D4E5-F607-8901-BCDE-F23456789012}</ProjectGuid>
+    <TargetName>MagicKbDesc</TargetName>
+    <TargetExt>.sys</TargetExt>
+    <DriverType>KMDF</DriverType>
+    <KmdfVersionMajor>1</KmdfVersionMajor>
+    <KmdfVersionMinor>33</KmdfVersionMinor>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Driver</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <TargetVersion>Windows10</TargetVersion>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Driver</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
+    <TargetVersion>Windows10</TargetVersion>
+    <DriverTargetPlatform>Universal</DriverTargetPlatform>
+  </PropertyGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <WarningLevel>Level4</WarningLevel>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+    <Link>
+      <SubSystem>Native</SubSystem>
+      <Driver>WDM</Driver>
+      <AdditionalDependencies>wdmguid.lib;hidclass.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+
+  <ItemGroup>
+    <ClCompile Include="Driver.c" />
+    <ClCompile Include="Descriptor.c" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ClInclude Include="MagicKbDesc.h" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Inf Include="MagicKbDesc.inx" />
+  </ItemGroup>
+
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <Import Project="$(WDKContentRoot)\build\WindowsDriver.targets"
+          Condition="Exists('$(WDKContentRoot)\build\WindowsDriver.targets')" />
+
+  <!-- Same SIGNTASK pre-backup workaround used by the M3 driver — see
+       sibling MagicMouseDriver.vcxproj for full rationale. -->
+  <Target Name="BackupPreSign" AfterTargets="Link">
+    <MakeDir Directories="C:\mm3-presign" />
+    <Copy SourceFiles="$(OutDir)$(TargetFileName)"
+          DestinationFiles="C:\mm3-presign\$(TargetFileName)"
+          Condition="Exists('$(OutDir)$(TargetFileName)')" />
+    <Message Text="*** BackupPreSign: $(TargetFileName) -&gt; C:\mm3-presign\ ***" Importance="High" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
## Summary
Adds the MSBuild project + solution wrappers so the `driver-keyboard/` sources from PR #38 can compile via the existing M12 EWDK pipeline.

Cloned from sibling `driver/MagicMouseDriver.vcxproj` — same KMDF 1.33, `PlatformToolset=WindowsKernelModeDriver10.0`, and the same `BackupPreSign` `AfterTargets="Link"` target that works around the SIGNTASK `/fd sha256` issue. Differences:
- `TargetName=MagicKbDesc`, fresh `ProjectGuid`
- Source files: `Driver.c`, `Descriptor.c` (no InputHandler/HidDescriptor)
- INF: `MagicKbDesc.inx`
- `AdditionalDependencies` adds `hidclass.lib` for HID-class symbols

## Test plan (full pipeline tonight)
After merge:
- [ ] `pwsh \\wsl.localhost\Ubuntu\home\lesley\.claude\worktrees\<runtime>\driver-keyboard\build.ps1` — invokes `mm-task-runner.ps1 BUILD` route via the existing M12 SYSTEM scheduled task
- [ ] `pwsh ...\sign.ps1` — production-signs with M12 cert
- [ ] `pwsh ...\install.ps1` — `pnputil /add-driver MagicKbDesc.inf /install /force`
- [ ] Toggle BT off/on → re-enumeration binds the new lower filter
- [ ] Modify the existing `Test-HidD-GetFeature-0x09.ps1` to use RID `0x47` on Col02 → re-run → expect `*** SUCCESS *** bytes: [47 NN]` where NN is battery percent
