### PR TITLE
m4(mac-capture): V1 Magic Mouse confirms battery protocol is universal across Apple BT HID

### DIFF
--- a/docs/M4-MAC-CAPTURE-FINDINGS-2026-05-08.md
+++ b/docs/M4-MAC-CAPTURE-FINDINGS-2026-05-08.md
@@ -350,6 +350,53 @@ on PSM 0x11 is rejected. Two known workarounds:
 
 For a probe / proof-of-concept, the first workaround is acceptable.
 
+## Cross-device confirmation: V1 Magic Mouse uses the same battery protocol
+
+Captured `magic-mouse -v1_battery_with_restart.pklg` against the V1 Magic
+Mouse (`04:F1:3E:EE:DE:10`, VID `0x05AC` / PID `0x030D`) with the BT Debug
+Profile installed. PacketLogger natively decodes the steady-state poll
+identically to the keyboard:
+
+| Time (relative) | Direction | Bytes | Decoded |
+|---|---|---|---|
+| 3979.216 | host→mouse | `43 47` | GET_REPORT Feature, RID `0x47` |
+| 3980.173 | mouse→host | `A3 47 0F` | DATA Feature — **`BATTERY LEVEL 15%`** |
+| 3980.173 | host→mouse | `41 30` | GET_REPORT Input, RID `0x30` |
+| 3980.196 | mouse→host | `A1 30 00` | DATA Input — **`BATTERY STATUS OK`** |
+
+So the **steady-state battery query bytes are universal** across the Apple
+BT HID family. Same `0x47` Feature and `0x30` Input RIDs respond on both
+the keyboard and the mouse.
+
+The connect-time init differs by device:
+
+| Device | Init transactions (host → device) |
+|---|---|
+| **Keyboard** (PID `0x0239`) | one Set Feature: `53 4A 03` |
+| **V1 Magic Mouse** (PID `0x030D`) | sequence of vendor Set Features at gesture/sensitivity RIDs: `53 C6 01 12 01 2C` *(rejected with HANDSHAKE Error: Invalid Report ID)*, then `53 F1 DB`, `53 F8 01 37`, `53 D7 01`. None of those address battery; the firmware happily answers `43 47` without any host-issued init. The first attempt being **rejected by the firmware** also implies the host is doing some auto-discovery rather than reading from a known table. |
+
+**Implication for the Windows port:** the same probe script
+([scripts/kbd-l2cap-with-hid-disable-2026-05-08.ps1](../scripts/kbd-l2cap-with-hid-disable-2026-05-08.ps1))
+covers both devices. It now accepts `-BdAddr` and `-Device <keyboard|mouse|none>`
+parameters; for the mouse, run with `-Device none` (or `-Device mouse` —
+currently equivalent — skip the keyboard's `53 4A 03` init).
+
+```powershell
+# keyboard (default)
+.\kbd-l2cap-with-hid-disable-2026-05-08.ps1
+
+# V1 magic mouse (skip init; battery query is universal)
+.\kbd-l2cap-with-hid-disable-2026-05-08.ps1 -BdAddr 04:F1:3E:EE:DE:10 -Device none
+```
+
+**Open question:** does the keyboard *actually* require the `53 4A 03`
+init for `43 47` to work, or is it incidental (e.g., sniff-interval
+coordination)? The mouse capture suggests the firmware doesn't strictly
+require any host-issued init — the auto-discovery probe failed and
+battery still works. If true, the Windows port can drop the keyboard
+init step entirely. Test by running `-BdAddr E8:06:88:4B:07:41 -Device none`
+on Windows and seeing whether `43 47` still gets a valid response.
+
 ## Reproducibility
 
 To re-derive the macOS findings:

--- a/scripts/kbd-l2cap-with-hid-disable-2026-05-08.ps1
+++ b/scripts/kbd-l2cap-with-hid-disable-2026-05-08.ps1
@@ -1,31 +1,59 @@
 # kbd-l2cap-with-hid-disable-2026-05-08.ps1
 #
-# End-to-end probe of the macOS battery flow on Windows:
-#   1. Find the Apple keyboard via BluetoothFindFirstDevice.
+# End-to-end probe of the macOS battery flow on Windows. Works against any
+# Apple BT HID device — the macOS HCI captures of the Apple keyboard and
+# the V1 Magic Mouse show the SAME steady-state battery query bytes:
+#
+#   GET_REPORT Feature, RID 0x47   ->   `43 47`        (BATTERY LEVEL)
+#   response                              `A3 47 <pct>`
+#   GET_REPORT Input,   RID 0x30   ->   `41 30`        (BATTERY STATUS)
+#   response                              `A1 30 <flag>` (0=OK, non-zero=warning)
+#
+# The connect-time init differs by device:
+#
+#   keyboard (PID 0x0239):  one SET_REPORT Feature, `53 4A 03`
+#   V1 magic mouse (PID 0x030D): a sequence of vendor SET_REPORTs to
+#       gesture/sensitivity RIDs (0xC6 rejected, then 0xF1, 0xF8, 0xD7).
+#       None of those are battery-related; the mouse responds to `43 47`
+#       perfectly well without any host-issued init.
+#
+# Test plan therefore: try the bare battery query first (no init) to find
+# out whether the firmware needs the keyboard's `53 4A 03` step at all.
+# Use -Device <keyboard|mouse|none> to control which init the script runs.
+#
+# Sequence:
+#   1. Find the device via BluetoothFindFirstDevice.
 #   2. Disable its HID profile via BluetoothSetServiceState
 #      (HumanInterfaceDeviceServiceClass_UUID, BLUETOOTH_SERVICE_DISABLE).
 #      This releases the in-box BT HID profile's hold on PSM 0x11.
 #   3. Open a Winsock AF_BTH socket on PSM 0x11 (HID Control).
-#   4. Send `53 4A 03` (SET_REPORT Feature, RID 0x4A, val 0x03) — the init.
-#   5. Read handshake.
-#   6. Send `43 47` (GET_REPORT Feature, RID 0x47).
-#   7. Read response — last byte is battery %.
-#   8. ALWAYS re-enable HID profile before exiting (try/finally).
+#   4. (keyboard only by default) Send `53 4A 03` and read handshake.
+#   5. Send `43 47` and read battery-level response.
+#   6. Send `41 30` and read battery-status response.
+#   7. ALWAYS re-enable HID profile before exiting (try/finally).
 #
-# This is the wire-byte exact replica of what macOS does (see
-# docs/M4-MAC-CAPTURE-FINDINGS-2026-05-08.md). It bypasses Windows'
-# HidD_* RID validation by going below the HID class.
-#
-# WARNING: while HID is disabled the keyboard cannot type. The window
-# is short (typically <1 second). If the script crashes/aborts, the
-# keyboard may be stuck without HID — re-run the script (it forces
-# re-enable in finally) or do it manually:
+# WARNING: while HID is disabled the device cannot input. The window is
+# short (typically <1 second). If the script crashes/aborts, the device
+# may be stuck without HID — re-run the script (it forces re-enable in
+# finally) or do it manually:
 #
 #   $hid = '00001124-0000-1000-8000-00805f9b34fb'
 #   # via Settings > Bluetooth > Disconnect/Connect, or:
-#   pnputil /restart-device "BTHENUM\Dev_E806884B0741"
+#   pnputil /restart-device "BTHENUM\Dev_<bdaddr-no-colons>"
 #
 # Run as Administrator.
+#
+# Examples:
+#   .\kbd-l2cap-with-hid-disable-2026-05-08.ps1
+#   .\kbd-l2cap-with-hid-disable-2026-05-08.ps1 -BdAddr 04:F1:3E:EE:DE:10 -Device mouse
+#   .\kbd-l2cap-with-hid-disable-2026-05-08.ps1 -BdAddr 04:F1:3E:EE:DE:10 -Device none
+
+[CmdletBinding()]
+param(
+    [string]$BdAddr = 'E8:06:88:4B:07:41',
+    [ValidateSet('keyboard','mouse','none')]
+    [string]$Device = 'keyboard'
+)
 
 $ErrorActionPreference = 'Stop'
 $Out = Join-Path $PSScriptRoot 'kbd-l2cap-with-hid-disable.txt'
@@ -42,8 +70,9 @@ if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdenti
     return
 }
 
-$KbdBdAddrStr = 'E8:06:88:4B:07:41'
+$KbdBdAddrStr = $BdAddr   # variable name kept for compatibility with internal log lines
 $PSM_HID_CONTROL = 0x11
+L "Target device: $Device  BD addr: $BdAddr"
 
 Add-Type -TypeDefinition @'
 using System;
@@ -245,13 +274,13 @@ do {
 [BtApi]::BluetoothFindDeviceClose($hFindDev) | Out-Null
 
 if (-not $found) {
-    L "FATAL: keyboard $KbdBdAddrStr not in device list. Is it paired?"
+    L "FATAL: device $KbdBdAddrStr not in paired list. Is it paired?"
     [BtApi]::BluetoothFindRadioClose($hFindRadio) | Out-Null
     [BtApi]::CloseHandle($hRadio) | Out-Null
     $log | Set-Content -Path $Out -Encoding UTF8
     return
 }
-L "Found keyboard: $($devInfo.szName.Trim())"
+L "Found device: $($devInfo.szName.Trim())"
 L ""
 
 # --- Disable HID profile so we can grab PSM 0x11 ---------------------------
@@ -289,7 +318,7 @@ try {
 
     # Set 5s recv/send timeouts so a misbehaving firmware can't hang the script
     # with HID disabled. If recv times out we surface WSAETIMEDOUT (10060) and
-    # the finally block re-enables HID — keyboard usable again within seconds.
+    # the finally block re-enables HID — device usable again within seconds.
     $timeoutMs = 5000
     [L2cap]::setsockopt($sock, [L2cap]::SOL_SOCKET, [L2cap]::SO_RCVTIMEO, [ref]$timeoutMs, 4) | Out-Null
     [L2cap]::setsockopt($sock, [L2cap]::SOL_SOCKET, [L2cap]::SO_SNDTIMEO, [ref]$timeoutMs, 4) | Out-Null
@@ -325,7 +354,7 @@ try {
             10050 { 'WSAENETDOWN' }
             10060 { 'WSAETIMEDOUT' }
             10061 { 'WSAECONNREFUSED (firmware refused channel — interesting)' }
-            10064 { 'WSAEHOSTDOWN (keyboard asleep — wake it and rerun)' }
+            10064 { 'WSAEHOSTDOWN (device asleep — wake it and rerun)' }
             default { '' }
         }
         L "connect() FAILED err=$err  $name"
@@ -336,21 +365,31 @@ try {
     L "*** L2CAP CONNECTED on PSM 0x11 ***"
     L ""
 
-    # --- 1. SET_REPORT Feature RID 0x4A, val 0x03 ------------------------
+    # --- 1. (optional) Device-specific init ------------------------------
+    # keyboard: SET_REPORT Feature RID 0x4A, val 0x03 — observed in macOS HCI.
+    # mouse:    macOS sends several gesture-config Set Features (RIDs 0xF1,
+    #           0xF8, 0xD7) but none are battery-related; the firmware
+    #           responds to 0x43 0x47 without any host-issued init. Skip.
+    # none:     skip init regardless — useful for testing whether init is
+    #           actually required for ANY Apple BT HID device.
 
-    $initBytes = [byte[]]@(0x53, 0x4A, 0x03)
-    L "Sending init: [$(Hex $initBytes 3)]"
-    $ns = [L2cap]::send($sock, $initBytes, $initBytes.Length, 0)
-    if ($ns -ne $initBytes.Length) {
-        L "send(init) failed err=$([L2cap]::WSAGetLastError())"
-    } else {
-        $rb = New-Object byte[] 32
-        $nr = [L2cap]::recv($sock, $rb, $rb.Length, 0)
-        if ($nr -le 0) {
-            L "recv(handshake) returned $nr  err=$([L2cap]::WSAGetLastError())"
+    if ($Device -eq 'keyboard') {
+        $initBytes = [byte[]]@(0x53, 0x4A, 0x03)
+        L "Sending keyboard init: [$(Hex $initBytes 3)]"
+        $ns = [L2cap]::send($sock, $initBytes, $initBytes.Length, 0)
+        if ($ns -ne $initBytes.Length) {
+            L "send(init) failed err=$([L2cap]::WSAGetLastError())"
         } else {
-            L "Handshake: [$(Hex $rb $nr)]  $(if ($rb[0] -eq 0x00) { '(Successful)' } else { '(code 0x' + ('{0:X2}' -f $rb[0]) + ')' })"
+            $rb = New-Object byte[] 32
+            $nr = [L2cap]::recv($sock, $rb, $rb.Length, 0)
+            if ($nr -le 0) {
+                L "recv(handshake) returned $nr  err=$([L2cap]::WSAGetLastError())"
+            } else {
+                L "Handshake: [$(Hex $rb $nr)]  $(if ($rb[0] -eq 0x00) { '(Successful)' } else { '(code 0x' + ('{0:X2}' -f $rb[0]) + ')' })"
+            }
         }
+    } else {
+        L "Skipping init step (Device=$Device). Going straight to battery query."
     }
 
     # --- 2. GET_REPORT Feature RID 0x47 (BATTERY LEVEL) -----------------
@@ -446,13 +485,13 @@ finally {
         $rc2 = [BtApi]::BluetoothSetServiceState($hRadio, [ref]$deviceForEnable, [ref]$hidGuid,
             [BtApi]::BLUETOOTH_SERVICE_ENABLE)
         if ($rc2 -ne 0) {
-            L "BluetoothSetServiceState(ENABLE) returned $rc2 — KEYBOARD MAY BE UNUSABLE."
+            L "BluetoothSetServiceState(ENABLE) returned $rc2 — DEVICE MAY BE UNUSABLE."
             if ($rc2 -eq 87) {
                 L "  err=87 (ERROR_INVALID_PARAMETER) often clears after a Bluetooth"
                 L "  radio toggle (Settings > Bluetooth > off/on) — try that first."
             }
             L "  Manual fix: Settings > Bluetooth > toggle radio off/on,"
-            L "  or unpair/repair the keyboard,"
+            L "  or unpair/repair the device,"
             L "  or run: pnputil /restart-device 'BTHENUM\Dev_$($KbdBdAddrStr -replace '[:]','')'"
         } else {
             L "HID profile re-enabled."


### PR DESCRIPTION
## Summary

PacketLogger HCI capture of the V1 Magic Mouse confirms it uses the **same** battery exchange as the Apple keyboard (already documented in PR #35 / merged in `5172bcb`/`02e0333`). This generalizes the protocol from "Apple-keyboard-specific" to "Apple BT HID family" and tightens the Windows port plan.

## Mouse wire bytes (steady-state poll, 60 s after connect)

| Direction | Bytes | PacketLogger label |
|---|---|---|
| host→mouse | `43 47` | GET_FEATURE_REPORT |
| mouse→host | `A3 47 0F` | **BATTERY LEVEL 15%** |
| host→mouse | `41 30` | GET_INPUT_REPORT — BATTERY LEVEL WARNING |
| mouse→host | `A1 30 00` | **BATTERY STATUS OK** |

Identical to the keyboard's bytes; only the battery percentage differs.

## What's actually different per device

The connect-time init:

- **Keyboard** (PID `0x0239`): one SET_REPORT Feature, `53 4A 03`.
- **V1 Mouse** (PID `0x030D`): a sequence of vendor SET_REPORTs at gesture/sensitivity RIDs — `53 C6 01 12 01 2C` *(rejected with HANDSHAKE Error: Invalid Report ID)*, then `53 F1 DB`, `53 F8 01 37`, `53 D7 01`. None of these are battery-related; the firmware answers `43 47` without any host-issued init.

The mouse's first init attempt being **rejected by the firmware** is also informative: macOS isn't reading from a known table — it's auto-discovering capable RIDs. So the firmware doesn't strictly require any specific host init for battery queries to work. The keyboard's `53 4A 03` may be incidental (sniff-interval coordination) rather than a firmware prerequisite.

## What changed

- **`scripts/kbd-l2cap-with-hid-disable-2026-05-08.ps1`** — now parameterized:
  - `-BdAddr <addr>` (default `E8:06:88:4B:07:41` = keyboard)
  - `-Device <keyboard|mouse|none>` — controls whether to send the keyboard's `53 4A 03` init. `mouse` and `none` both skip init and go straight to the universal `43 47` query.
  - Log strings genericized (\"device\" instead of \"keyboard\").

- **`docs/M4-MAC-CAPTURE-FINDINGS-2026-05-08.md`** — new \"Cross-device confirmation\" section with the mouse byte tables, init comparison, and example command lines for invoking the probe against either device.

## Reviewer notes

- No raw capture file committed (~14 MB). Sanitized version can follow if needed for the doc's \"reproducibility\" promise.
- The doc adds an **open question**: does the keyboard *actually* require `53 4A 03` for `43 47` to work? The mouse evidence suggests not. Worth testing with `-BdAddr E8:06:88:4B:07:41 -Device none` on Windows.
- Nothing in shipped product behavior changes — this is incremental research that consolidates the Windows test plan from \"two device-specific scripts\" to \"one parametric probe.\"

## Test plan

- [ ] Run `kbd-l2cap-with-hid-disable-2026-05-08.ps1` (default = keyboard) — should reproduce previously-planned outcome.
- [ ] Run `kbd-l2cap-with-hid-disable-2026-05-08.ps1 -BdAddr 04:F1:3E:EE:DE:10 -Device none` against the V1 mouse — expect `BATTERY LEVEL <pct>` on success.
- [ ] Run `kbd-l2cap-with-hid-disable-2026-05-08.ps1 -Device none` against the keyboard — confirms whether the `53 4A 03` init was actually required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)