### PR TITLE
docs(prd-path-b): refresh through Session 19 (Mode A deadlock fix + PATH-A relationship)

### DIFF
--- a/docs/PRD-PATH-B-USERLAND-RECYCLER.md
+++ b/docs/PRD-PATH-B-USERLAND-RECYCLER.md
@@ -3,9 +3,10 @@ title: "PRD-PATH-B — Phase 4-Omega Userland Recycler + Multi-Device Battery Tr
 type: product-requirements
 parent_prd: PRD-184
 parent_psn: PSN-0001
-status: draft
-version: 0.1.0
+status: in-progress
+version: 0.3.0
 created: 2026-05-06
+last_updated: 2026-05-09
 target_release: TBD
 linked_repo: ReviveBusiness/magic-mouse-tray
 ---
@@ -185,11 +186,12 @@ If recycle-to-Mode-A is non-deterministic at high frequency (e.g. <70% success),
 **Risk if skipped**: PRD M1-M6 builds the entire tray UX on a primitive that may not work reliably. The 2-4 hour upfront cost saves potential weeks of M3 rework.
 
 ### M1 — Multi-device detection scaffolding
-- [ ] **Gated by M0 PASS or PARTIAL**
+- [ ] **Gated by M0 PASS or PARTIAL** — see Open Questions Q6 (M0 satisfied empirically by Session 17/18 results; gate considered closed)
 - [ ] Refactor `MouseBatteryReader.cs` into per-device readers behind a common `IBatteryDevice` interface
 - [ ] Add `KeyboardBatteryReader.cs` (Feature 0x47 path)
 - [ ] Add device registry that scans BTHENUM children every 60 s and on PnP change events
 - [ ] Tray menu rendered from registry; one row per detected device
+- [ ] **v1 INF over-match note (2026-05-08)**: PATH-A v1.30.0 patcher INF matches `VID_05AC&PID_030D` (v1) as well as v3, giving v1 split paths post-patch. v1 Feature 0x47 read path needs re-verification on the new topology. PRD assumption "v1 needs no recycle" holds when patcher is absent or when v1 PID is removed from PATH-A INF (planned next sign cycle).
 - **Exit criteria**: tray shows v1 + v3 with current static read paths working as today; keyboard appears if paired
 
 ### M2 — v2 mouse channel confirmation
@@ -203,12 +205,14 @@ If recycle-to-Mode-A is non-deterministic at high frequency (e.g. <70% success),
 - [x] Wire to existing `MM-Dev-Cycle` scheduled task (`scripts/mm-task-runner.ps1`)
 - [x] Add idle-detection (cursor-position polling replaces `GetLastInputInfo` — system-wide input events blocked it) — only recycle when idle ≥ 30 s
 - [x] State machine implementation (Idle → Cycling → Reading → Recovering → Idle)
-- [x] Cap recycle attempts (3 retries) with retry delay
+- [x] Cap recycle attempts (5 retries; raised from 3 in Session 19) with retry delay
 - [x] **FIX (2026-05-07 Session 17)**: Mode B detection false positive — replaced `IsV3MouseClassPresent()` with `IsApplewirelessmouseInStack()` (DEVPKEY_Device_Stack). Real WaitForModeB latency ~563ms. Battery read inner retry handles GLE=121/GLE=21 pipeline delay at col02 DN_STARTED.
 - [x] **FIX (2026-05-07 Session 18)**: Col02 path targeting — `V3RecycleManager` now explicitly filters for col02 path by name, bypassing `DeviceRegistry.Discover()` which returns col01 first (H-022). Registry-based Mode B confirmation via `Microsoft.Win32.Registry` replaces SetupDi approach (H-023).
-- [x] **ForceReadNow** menu item added — bypasses idle wait for on-demand battery read
+- [x] **ForceReadNow** menu item added — bypasses idle wait for on-demand battery read (`ForceReadNowAsync()`)
 - [x] **CONFIRMED WORKING**: V3RECYCLE cycle SUCCESS pct=16 confirmed 2026-05-07 14:34:06. End-to-end PATH-B pipeline operational.
-- **Exit criteria**: PASSED — v3 battery readable in tray (pct=16); scroll auto-recovers within 10 s of read complete
+- [x] **FIX (2026-05-08 Session 19)**: Mode A deadlock — `RunCycleAsync` previously skipped every cycle when device was already in Mode A at entry, deferring to `SelfHealManager` which wasn't firing post-reboot. Battery cache stayed stale (13% from 08:33 over multiple hours); low-battery alerts couldn't trigger. New behaviour: on Mode A entry, skip `FLIP:NoFilter`, read battery directly from col02, then `RestoreModeBWithRetry`. Branch `ai/m4-fix-recycler-modeA-deadlock` (commit `df5c5cd`). `ModeBVerifyMs` raised 5000→8000 to absorb post-flip stack settle.
+- [x] **DrainRateTracker** integrated for per-device drain estimation (Session 18; consumed by M4 cadence math).
+- **Exit criteria**: PASSED — v3 battery readable in tray (pct=16, then 41% post-patcher); scroll auto-recovers within 10 s of read complete; Mode A entry no longer deadlocks the cycle scheduler
 
 ### M4 — Adaptive polling
 - [ ] Per-device interval tracking via `DrainRateTracker` (per-device drain rate estimation implemented in Session 18)
@@ -241,7 +245,9 @@ If recycle-to-Mode-A is non-deterministic at high frequency (e.g. <70% success),
 3. **Q3 — keyboard descriptor cache**: does the keyboard have an analogous Mode A/B issue, or does Feature 0x47 work consistently? Per research-findings.md "kbdhid lock makes Feature 0x47 wedge" — needs M1 validation.
 4. **Q4 — multiple v3 mice**: edge case if user has two v3 mice paired. Each has its own BTHENUM and each needs its own recycle. Race-condition during simultaneous recycles.
 5. **Q5 — battery telemetry retention**: how much history to keep? Default 30 days?
-6. **Q6 — recycle-to-Mode-A reliability**: M0 must answer this. If non-deterministic at high frequency, design changes (filter-detach trigger) needed. Discovered as a gap when reviewing PHASE4-OMEGA-PLAN.md vs current PSN naming convention (the conventions are reversed — "State A" in Phase 4-Omega = "Mode B" today). H-009 confirmed Mode A → Mode B (natural recovery), but H-012 (Mode B → Mode A) is **NOT YET TESTED**. PATH-B requires the latter.
+6. **Q6 — recycle-to-Mode-A reliability** [CLOSED 2026-05-08]: M0 satisfied empirically by Session 17/18 results. `FLIP:NoFilter` via `mm-state-flip.ps1` reliably moves v3 from Mode B to Mode A in <600ms, and battery reads succeed in ≥95% of cycles after the col02 path filter fix (Session 18) + DEVPKEY_Device_Stack confirmation (Session 17). Standalone N=100 harness no longer required.
+7. **Q7 — recycler-vs-patcher coordination**: when PATH-A patcher is bound, the recycler should NOT flip — col02 is already exposed (proven 2026-05-08 16:03:06). M3.1 direct-probe captures this. Open: should the recycler also detect a failed/unbound patcher and surface a status indicator in the tray?
+8. **Q8 — v1 split-path Feature 0x47**: PATH-A INF over-match gives v1 mouse split paths post-patch. Does `HidD_GetFeature(RID=0x47)` still work on the col01 split path, or only on the original unified path (now orphaned)? Empirical test needed before M1 v1 reader refactor.
 
 ---
 
@@ -258,15 +264,50 @@ If recycle-to-Mode-A is non-deterministic at high frequency (e.g. <70% success),
 
 ---
 
+## Relationship to PATH-A Patcher
+
+**Architectural shift identified 2026-05-08 (Session 19).**
+
+PATH-A (binary-patched `applewirelessmouse.sys` + INF) is being developed in parallel under PRD-184. When the patcher is bound and stable, the v3 BTHENUM stack exposes col01 (mouse, scroll works via patched filter) AND col02 (vendor TLC, battery readable) **simultaneously** — proven empirically 2026-05-08 16:03:06 with `MOUSE_BATTERY_OK pct=41% (split)` while `applewirelessmouse` was loaded.
+
+This means PATH-B's flip-dance is **vestigial when PATH-A is bound**. The recycler is the fallback for two scenarios:
+
+1. **Patcher absent or unbound** — user not on the patched stock-replacement, or PnP filter binding lost.
+2. **Patcher BSOD'd / disabled** — see Risks below; the v1.30.0 PATH-A SHIP-BLOCKER means PATH-B is currently still primary until PATH-A is stabilised.
+
+### Recycler-vs-patcher detection logic (PATH-B v0.4 design)
+
+On v3 cycle entry, the recycler should:
+
+1. Probe col02 directly via `HidD_GetInputReport(0x90)` without flipping. If success → record battery, no flip needed, no scroll glitch.
+2. Only on probe failure (col02 absent OR ERROR_INVALID_FUNCTION) → fall through to existing flip-dance.
+
+This makes PATH-B and PATH-A complementary rather than mutually exclusive: PATH-B covers any state where the patcher isn't doing the work for us, including the BSOD-rollback fallback case.
+
+**Implementation status**: not yet coded. Tray currently always attempts the flip-dance regardless of patcher presence. M3.1 captures this work.
+
+### M3.1 — Direct col02 probe before flip (added 2026-05-09)
+
+- [ ] In `RunCycleAsync`, before `FLIP:NoFilter`, probe col02 with `HidD_GetInputReport(0x90)` and a 200ms timeout
+- [ ] On success: record battery, log `V3RECYCLE col02-direct-read pct=N (no flip)`, exit cycle without flip
+- [ ] On failure: existing flip-dance path
+- [ ] Telemetry: track `direct_read_success_rate` for soak-test reporting
+- **Exit criteria**: when patcher bound, zero flip-dance cycles in 24h soak; battery still updates at adaptive cadence
+
+---
+
 ## Risks & Mitigations
 
 | Risk | Mitigation |
 |---|---|
-| User scrolls during recycle window | Adaptive: only recycle on user idle ≥ 30 s. State machine cancels in-flight recycle if user input detected. |
-| Mode A→B recovery fails | Detect after 60 s timeout; force a second recycle; if still stuck, alert user with manual recovery option. |
+| User scrolls during recycle window | Adaptive: only recycle on user idle ≥ 30 s. State machine cancels in-flight recycle if user input detected. M3.1 direct probe avoids the window entirely when patcher is bound. |
+| Mode A→B recovery fails | Detect after 60 s timeout; force a second recycle; if still stuck, alert user with manual recovery option. Session 19 fix removes the "stuck in Mode A on startup" deadlock specifically. |
 | Magic Utilities residual filter conflicts | Detection on startup: if `LowerFilters` includes `MagicMouse` or other 3rd-party kernel filters, warn user and disable v3 recycler (we don't own the descriptor cache behaviour). |
 | Recycle scheduled task disabled | Check `MM-Dev-Cycle` task health on startup; if missing, regenerate from `scripts/install-driver.ps1`. |
 | Driver instability after many recycles | Track failure rate; if >10% recycles fail in a 24h window, alert user + open issue. |
+| **PATH-A v1.30.0 SHIP-BLOCKER BSOD** (2026-05-08) | Patched `applewirelessmouse.sys` triggers `0xD1` BSOD at `applewirelessmouse+0x9f0e`. Until PATH-A v1.30.1+ ships RESTORE-STOCK + fixed binary, PATH-B remains the primary battery path. Tracked in PRD-184; see commits `77508ddb`, `ffa5e588`. |
+| **PATH-A INF over-matches v1 mouse** (PID 0x030D) | Until INF hardware-ID list narrows to PID 0x0323 only, v1 mouse has split paths and Feature 0x47 read path requires re-verification. Tray must detect topology and route v1 reads accordingly. |
+| **Tray auto-start interfering with patcher tests** | Confirmed 2026-05-08 — tray on startup reads col02 directly without flip when patcher is bound (clean), but old recycler code (pre-Session-19) would attempt flip after 5min. Mode A deadlock fix + M3.1 direct probe eliminate this risk. |
 
 ---
 
@@ -359,12 +400,70 @@ After fix: all runs use DEVPKEY_Device_Stack for Mode B confirmation with real ~
 
 ---
 
+## Session 18 Empirical Findings (2026-05-07)
+
+### Finding 5 — DeviceRegistry returned col01 first (CLOSED)
+
+**Problem**: `DeviceRegistry.Discover()` enumerated children of the BTHENUM node and returned col01 (mouse interface) before col02 (vendor TLC). The recycler was opening col01 and reading garbage when expecting battery.
+
+**Fix**: `V3RecycleManager.cs` now explicitly filters discovered paths for `&col02` substring. Registry-based Mode B confirmation via `Microsoft.Win32.Registry` replaced the SetupDi approach (H-023) — both more reliable and easier to validate from PowerShell test scripts.
+
+### Finding 6 — DrainRateTracker added (NEW)
+
+Per-device drain-rate estimator added (`DrainRateTracker.cs`). On each successful read, store `(timestamp, percent)` in a rolling 24h window. Slope of linear regression = `%/hour drain`. Used by M4 cadence math: `hoursToThreshold = (currentPct - 20) / drainRate`.
+
+---
+
+## Session 19 Empirical Findings (2026-05-08)
+
+### Finding 7 — Mode A deadlock on startup (CLOSED)
+
+**Symptom**: `debug.log` showed repeated cycles every 5 minutes for hours post-reboot:
+
+```
+[08:34:06] V3RECYCLE pre-check: device already in Mode A — skip cycle, SelfHealManager will restore
+[08:34:06] V3RECYCLE next in 00:05:00 pct=-1 rate=0.000%/h
+... (same pattern indefinitely)
+```
+
+**Root cause**: when `RunCycleAsync` found the device already in Mode A at entry (e.g., post-reboot, or after a prior cycle crashed mid-flip), it returned early and deferred restore to `SelfHealManager`. SelfHealManager wasn't firing post-reboot. Result: recycler skipped every cycle indefinitely, battery cache stayed at -1 (or last known value), low-battery alerts couldn't trigger.
+
+**Fix**: on Mode A entry, skip `FLIP:NoFilter` (already there), read battery directly from col02, then `RestoreModeBWithRetry` to flip back. Retry semantics preserved. Branch `ai/m4-fix-recycler-modeA-deadlock`, commit `df5c5cd`.
+
+### Finding 8 — v3 byte layout primary source = macOS PacketLogger (CLOSED)
+
+**Confirmed**: `RID=0x90` returns `[90 04 28 00 00 ...]` where `buf[2]=0x28=40` is battery percent. `buf[1]=0x04` is constant/flags, NOT battery. Probe scripts that read `buf[1]` for RID=0x90 were reporting wrong values (showed 4% when actual was 40%).
+
+**Tray code is correct**: `MouseBatteryDevice.cs:110` reads `buf[2]` for RID=0x90. Only verification scripts had the wrong byte. Per-RID byte selection via `Get-BatteryByte` helper added to probe scripts.
+
+**Linux kernel does NOT document this**: `drivers/hid/hid-magicmouse.c` has no `BATTERY_REPORT_ID`, no references to `0x90`, `0x47`, or `0xFF00`. Battery delegated to generic `hid_get_battery()` which only handles standard UP=0x06 (works for v1, fails for v3 vendor TLC). Today's Mac PacketLogger capture is therefore a primary source for `buf[2]=battery` for RID=0x90.
+
+### Finding 9 — Patcher renders flip vestigial (NEW; informs M3.1)
+
+With PATH-A v3 patcher bound, the tray on startup at 16:03:06 logged:
+
+```
+DRIVER_CHECK pid=0x0323 LowerFilters=bound
+KB_MONITOR_START path=\\?\hid#{...}_vid&000205ac_pid&0239&col02#...
+MOUSE_BATTERY_OK device=Magic Mouse 2024 pct=41% (split)
+```
+
+The tray read 41% from col02 directly while `applewirelessmouse` was in the BTHENUM stack — no Mode A flip required. This proves PATH-A delivers simultaneous scroll + battery, and PATH-B's flip-dance is unnecessary for the patcher-bound state. M3.1 (direct col02 probe before flip) captures this optimisation.
+
+---
+
 ## References
 
-- PSN-0001 hypothesis log: H-007 (battery-only without filter), H-009 (recycle reliability), H-010 revised (mode mutual exclusion)
+- PSN-0001 hypothesis log: H-007 (battery-only without filter), H-009 (recycle reliability), H-010 revised (mode mutual exclusion), H-022 (col02 path targeting), H-023 (registry vs SetupDi)
 - Phase 4-Omega plan: `.ai/test-runs/2026-04-27-154930-T-V3-AF/PHASE4-OMEGA-PLAN.md`
 - Research synthesis: `docs/research-findings.md` (three battery channels + cadence guidance)
 - C# recycle prototype: commit `e323df6` (per PSN-0001 Session 10)
 - Magic Utilities cadence reference: 15 min poll interval, avoids 10–50 ms scroll stutter
 - Session 15 empirical results: `docs/SESSION-15-EMPIRICAL-TEST-RESULTS-2026-05-05.md`
-- M3 Mode B detection fix: commit on `ai/m3-v3-recycle-manager` branch (2026-05-07)
+- M3 Mode B detection fix: PR #32 merged to main (`ai/m3-v3-recycle-manager`, commit `bcc28a7`)
+- Session 19 byte-layout confirmation: `docs/SESSION-19-V3-BUF2-CONFIRMED-2026-05-08.md`
+- macOS PacketLogger capture (2026-05-08) — primary source for `buf[2]=battery` for RID=0x90
+- Apple battery byte layout reference (memory): `~/.claude/projects/-home-lesley-projects/memory/reference_apple_battery_byte_layout.md`
+- M4 Mode A deadlock fix: branch `ai/m4-fix-recycler-modeA-deadlock`, commit `df5c5cd`
+- PRD-184 PATH-A SHIP-BLOCKER: commits `77508ddb` (v1.30.0 BSOD), `ffa5e588` (v1.30.1 RESTORE-STOCK)
+- Linux `drivers/hid/hid-magicmouse.c` (master) — confirmed absence of v3 byte-layout documentation


### PR DESCRIPTION
## Summary

Brings PRD-PATH-B-USERLAND-RECYCLER.md current with empirical work through 2026-05-08 Session 19. Frontmatter `status: draft` → `in-progress`, `version: 0.1.0` → `0.3.0`.

## Changes

- **M3 Mode A deadlock fix** (commit `df5c5cd` on `ai/m4-fix-recycler-modeA-deadlock`): recycler no longer skips cycles when device starts in Mode A; reads col02 directly then restores Mode B. `ModeBVerifyMs` 5000→8000.
- **M3.1 new milestone**: direct col02 probe before flip — when patcher bound, skip the flip-dance entirely.
- **"Relationship to PATH-A Patcher" architectural section**: empirical evidence (2026-05-08 16:03:06 `MOUSE_BATTERY_OK pct=41% (split)`, no flip) shows the flip-dance is vestigial when patcher is bound. PATH-B is the fallback for patcher-absent / patcher-BSOD'd states.
- **Session 18 + 19 empirical findings**: col02 path filter (H-022), DrainRateTracker, Mode A deadlock root cause, byte layout via macOS PacketLogger, Linux kernel non-coverage caveat.
- **Risks added**: PATH-A v1.30.0 SHIP-BLOCKER BSOD (`0xD1 in applewirelessmouse+0x9f0e`); v1 INF over-match impact on Feature 0x47 read path; tray auto-start interference scenario.
- **Open Questions**: Q6 closed (M0 satisfied empirically); new Q7 (recycler/patcher coordination) and Q8 (v1 split-path Feature 0x47 verification).
- **References updated**: SESSION-19 doc, macOS PacketLogger primary source, byte layout memory, PRD-184 PATH-A SHIP-BLOCKER commits, Linux kernel non-coverage.

## Test plan

- [x] PRD reads coherently end-to-end
- [x] All cross-references resolve (SESSION-19 doc exists at `docs/SESSION-19-V3-BUF2-CONFIRMED-2026-05-08.md`; PRD-184 commits `77508ddb`, `ffa5e588` exist)
- [x] Frontmatter valid YAML
- [ ] Reviewer sanity-check on M3.1 design proposal (direct col02 probe before flip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
