### PR TITLE
feat(tray): Open Logs + Open Diagnostics Folder menu items

### DIFF
--- a/MagicMouseTray/Logger.cs
+++ b/MagicMouseTray/Logger.cs
@@ -8,9 +8,11 @@ namespace MagicMouseTray;
 // Never throws — all I/O errors are silently swallowed.
 internal static class Logger
 {
-    static readonly string LogPath = Path.Combine(
+    internal static readonly string LogPath = Path.Combine(
         Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
         "MagicMouseTray", "debug.log");
+
+    internal static string LogDir => Path.GetDirectoryName(LogPath)!;
 
     const long MaxBytes = 1024 * 1024; // 1 MB rotation threshold
     static readonly object Lock = new();

--- a/MagicMouseTray/TrayApp.cs
+++ b/MagicMouseTray/TrayApp.cs
@@ -163,6 +163,17 @@ internal sealed class TrayApp : IDisposable
 
         menu.Items.Add(new ToolStripSeparator());
 
+        // --- Diagnostics ---
+        var openLogs = new ToolStripMenuItem("Open Logs");
+        openLogs.Click += (_, _) => OpenLogsInEditor();
+        menu.Items.Add(openLogs);
+
+        var openDiagFolder = new ToolStripMenuItem("Open Diagnostics Folder");
+        openDiagFolder.Click += (_, _) => OpenDiagnosticsFolder();
+        menu.Items.Add(openDiagFolder);
+
+        menu.Items.Add(new ToolStripSeparator());
+
         // --- Quit ---
         var quit = new ToolStripMenuItem("Quit");
         quit.Click += (_, _) =>
@@ -180,6 +191,66 @@ internal sealed class TrayApp : IDisposable
         _config.SetThreshold(value);
         foreach (var item in _thresholdItems)
             item.Checked = (int)item.Tag! == _config.Threshold;
+    }
+
+    // Opens debug.log in Notepad++ if installed, falls back to notepad.exe.
+    // Notepad++ tail-follows the file (Settings > Misc > File Status Auto-Detection).
+    void OpenLogsInEditor()
+    {
+        var logPath = Logger.LogPath;
+        if (!System.IO.File.Exists(logPath))
+        {
+            System.IO.Directory.CreateDirectory(Logger.LogDir);
+            System.IO.File.WriteAllText(logPath, $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] Log file created on demand from tray.\r\n");
+        }
+
+        var npp = FindNotepadPlusPlus();
+        try
+        {
+            var psi = new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = npp ?? "notepad.exe",
+                Arguments = $"\"{logPath}\"",
+                UseShellExecute = true
+            };
+            System.Diagnostics.Process.Start(psi);
+            Logger.Log($"OPEN_LOGS editor={(npp ?? "notepad.exe")} path={logPath}");
+        }
+        catch (Exception ex)
+        {
+            Logger.Log($"OPEN_LOGS_FAIL err={ex.Message}");
+        }
+    }
+
+    void OpenDiagnosticsFolder()
+    {
+        try
+        {
+            System.IO.Directory.CreateDirectory(Logger.LogDir);
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = "explorer.exe",
+                Arguments = $"\"{Logger.LogDir}\"",
+                UseShellExecute = true
+            });
+            Logger.Log($"OPEN_DIAG_FOLDER path={Logger.LogDir}");
+        }
+        catch (Exception ex)
+        {
+            Logger.Log($"OPEN_DIAG_FOLDER_FAIL err={ex.Message}");
+        }
+    }
+
+    static string? FindNotepadPlusPlus()
+    {
+        string[] candidates =
+        {
+            @"C:\Program Files\Notepad++\notepad++.exe",
+            @"C:\Program Files (x86)\Notepad++\notepad++.exe",
+        };
+        foreach (var c in candidates)
+            if (System.IO.File.Exists(c)) return c;
+        return null;
     }
 
     void OnBatteryChanged(int pct, string name)

--- a/docs/PRD-PATH-B-USERLAND-RECYCLER.md
+++ b/docs/PRD-PATH-B-USERLAND-RECYCLER.md
@@ -234,6 +234,7 @@ If recycle-to-Mode-A is non-deterministic at high frequency (e.g. <70% success),
 - [ ] Settings dialog: enable/disable v3 recycle (default off until first user request); polling intervals; idle-time threshold
 - [ ] Per-device colour-coded battery indicator (green >50%, yellow 20-50%, red <20%)
 - [ ] Tooltip with last-poll timestamp + manual refresh option
+- [x] **Open Logs / Open Diagnostics Folder menu items (2026-05-09)**: tray context menu adds two diagnostics shortcuts. `Open Logs` launches Notepad++ (`C:\Program Files\Notepad++\notepad++.exe` or `(x86)` fallback) on `%APPDATA%\MagicMouseTray\debug.log`, falling back to `notepad.exe` if Notepad++ isn't installed. `Open Diagnostics Folder` opens `%APPDATA%\MagicMouseTray\` in Explorer. Both create the directory if missing. Implemented in `TrayApp.cs` (`OpenLogsInEditor`, `OpenDiagnosticsFolder`, `FindNotepadPlusPlus`); `Logger.LogPath` promoted from `private` to `internal` to allow tray access.
 - **Exit criteria**: settings persisted to `Config.cs`; user can disable v3 recycler if scroll glitch is unacceptable
 
 ---


### PR DESCRIPTION
## Summary

Adds two diagnostics shortcuts to the tray right-click menu:
- **Open Logs** — opens `%APPDATA%\MagicMouseTray\debug.log` in Notepad++ if installed (auto-detects standard install paths), falls back to `notepad.exe`
- **Open Diagnostics Folder** — opens `%APPDATA%\MagicMouseTray\` in Explorer

Both create the directory if missing. Tray-side log entries on click for traceability.

## Changes

- `MagicMouseTray/TrayApp.cs`: 2 new menu items + `OpenLogsInEditor()`, `OpenDiagnosticsFolder()`, `FindNotepadPlusPlus()` helpers
- `MagicMouseTray/Logger.cs`: `LogPath` promoted from `private static readonly` to `internal static readonly`; new `LogDir` getter
- `docs/PRD-PATH-B-USERLAND-RECYCLER.md`: M6 entry documenting the new menu items

## Test plan

- [x] Builds cleanly via `dotnet publish -c Release` (single-file self-contained, 186MB output at `C:\temp\mmtpub-new\MagicMouseTray.exe`)
- [ ] Menu items appear after `Test Notification` separator
- [ ] `Open Logs` launches Notepad++ if installed, falls back to Notepad otherwise
- [ ] `Open Diagnostics Folder` opens Explorer at `%APPDATA%\MagicMouseTray\`
- [ ] Both work when log directory doesn't yet exist (auto-creates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
