### PR TITLE
docs(m4-v3): salvage V3 Magic Mouse macOS HCI capture findings

### DIFF
--- a/docs/M4-MAC-CAPTURE-FINDINGS-2026-05-08.md
+++ b/docs/M4-MAC-CAPTURE-FINDINGS-2026-05-08.md
@@ -1,0 +1,426 @@
+# M4 Keyboard — macOS Bluetooth Capture Findings (2026-05-08)
+
+> **Status update (HCI capture):** As of the second pass with the Apple
+> Bluetooth Debug Logging Profile installed, we have **byte-exact wire
+> traces** in `/Users/lesley/Documents/BT_Keyboard_Trace.pklg`. The bytes
+> overturn the original "Hypothesis C′" plan — macOS uses **undocumented
+> Report IDs** that don't appear in the public HID descriptor, so Windows
+> `HidD_*` APIs (which validate against the descriptor) cannot replicate
+> the wire flow. See "Byte-exact findings" below. The earlier sections
+> ("Two-tier architecture", "Connect-time init sequence", etc.) are
+> correct in shape but list the wrong RID for the init Set Feature; treat
+> the Byte-exact section as canonical.
+
+
+## Goal
+
+Apple Wireless Keyboard (PID `0x0239`) battery is read successfully by macOS but
+[KeyboardBatteryDevice.cs](../MagicMouseTray/KeyboardBatteryDevice.cs) documents
+that all active read paths on Windows fail (`HidD_GetInputReport` err=87 for
+all 255 RIDs, `HidD_GetFeature` empty/err=1, etc.). We captured macOS BT
+subsystem behaviour to determine **how** macOS gets the value and whether the
+Windows code can be made to do the same.
+
+## Setup
+
+- Mac: Apple Silicon, BT chipset BCM\_4388C2 (PCIe transport), macOS 26 (Sequoia).
+- Keyboard: `Lesley's Keyboard`, BD\_ADDR `E8:06:88:4B:07:41`, VID `0x05AC` PID `0x0239`,
+  Bluetooth Classic (BR/EDR), HID profile only — no BLE counterpart.
+- Tools (no kernel debug profile required):
+  - [scripts/kbd-mac-battery-capture-trigger.sh](../scripts/kbd-mac-battery-capture-trigger.sh) — disconnect/reconnect via `blueutil`.
+  - [scripts/kbd-mac-battery-logstream.sh](../scripts/kbd-mac-battery-logstream.sh) — `sudo log stream` of `com.apple.bluetooth` subsystem around the reconnect.
+- Capture artifact: [docs/kbd-mac-logstream.txt](kbd-mac-logstream.txt) (~9k lines, ~1.6 MB).
+
+## Confirmed: HID descriptor matches the existing Windows finding
+
+Dumped from `ioreg -l -w0 -r -c AppleBluetoothHIDKeyboard`. The
+`ReportDescriptor` is identical to what the Windows side parsed:
+
+- **Report ID `0x47` (71)** — Input, 1-byte payload, Generic Device Controls / Battery
+  Strength, lives in **Collection 2** (= Windows `col02`).
+- **Report ID `0x09`** — Feature, 1 data byte + 2 const padding bytes (4 bytes total
+  including RID), Vendor page `0xFF01` Usage `0x0B`, lives in **Collection 3**
+  (= Windows `col03`). This is the only Feature report on the device.
+- `MaxFeatureReportSize = 4`, `MaxInputReportSize = 9`, `SetReportTimeoutMS = 3500`.
+
+So the descriptor is not the missing piece. The wire protocol is.
+
+## Connect-time init sequence (two steps)
+
+A second capture at 00:31:43–.44 with `log config --mode 'private_data:on'`
+revealed that the SCO Link State Set Report is preceded by a **Set Protocol**
+transaction. **The RIDs and types in this table were corrected after the HCI
+capture — see "Byte-exact findings" for the actual wire bytes:**
+
+| Step | Originator | Transaction | Size | Notes |
+|---|---|---|---|---|
+| 1 | **Kernel** (`enqueueKernelSpaceHIDDataForDevice`) | `0x07` Set Protocol | 1 byte | Wire: `71` = Set Protocol, Protocol bit=1 (Report mode). Windows' HID class driver issues this automatically; **not** the missing piece. |
+| 2 | **Userspace** (`enqueueUserSpaceHIDDataForDevice`, `bluetoothd`) | `0x05` Set Report | 3 bytes | Wire: `53 4A 03` = SET_REPORT Feature, **RID `0x4A` (undocumented)**, value `0x03`. Apple-specific. **This is the step Windows can't replicate via `HidD_*`.** |
+| 3 | (60 s later, kernel) | `0x04` Get Report | 2 bytes | Wire: `43 47` = GET_REPORT **Feature**, RID `0x47`. Response `A3 47 ??` where `??` is battery percent. |
+
+The split between kernel and userspace originators matters: it tells us
+exactly which step is Apple's vendor logic (step 2) versus standard HID
+behaviour the Windows HID stack already replicates (step 1).
+
+## Note on un-redaction
+
+Running `sudo log config --mode 'private_data:on'` before the capture
+**partially** un-redacts: BD addresses and string fields that were `<private>`
+become visible, but raw HID payload arrays are still suppressed. macOS marks
+byte arrays under a separate redaction class that this toggle does not affect.
+
+To obtain the **exact wire bytes** for the SCO Link State Set Report, two
+options remain:
+
+1. Install Apple's **Bluetooth Debug Logging Profile** (gated behind Apple
+   Developer login, reboot required), then capture HCI in PacketLogger.
+2. Pair the keyboard to a Linux box / VM and use `btmon` from BlueZ
+   (re-pairing un-pairs the keyboard from the Mac).
+
+Both yield the same data. Recommendation: **defer until the Windows-side
+hypothesis-C′ test fails**. The inferred init payload `[0x09, 0x03, 0x00,
+0x00]` is constrained tightly enough by the descriptor (RID 0x09 is the
+only Feature; report length is 1 data + 2 const padding = 3 bytes) and the
+log (`packetDataSize = 3`, "SCO Link State: 3" = `0x03`) that there's
+little room for it to be wrong.
+
+## Original finding: macOS sends an init Set Report, then polls Get Report
+
+Reconstructed from the `bluetoothd` log around the reconnect:
+
+| Time (UTC-7) | What happened |
+|---|---|
+| 00:05:57.242 | "Received outgoing connection attempt for HID Host profile on E8:06:88:4B:07:41" |
+| 00:05:57.405 | "Received connection result for HID Host profile … result was 0" |
+| 00:05:57.432 | "Received all connection results for device" |
+| **00:05:57.436** | **`enqueueUserSpaceHIDDataForDevice … transactionType = 0x05 (Set Report), HID_Host_Handle = 0x7808, packetDataSize = 3`** — userspace `bluetoothd` injects a vendor "SCO Link State" Set Report (sniff-interval coordination) on the **HID Control L2CAP channel** of the new connection. |
+| 00:05:57.445 | Keyboard ACKs with `HID Handshake` (transType `0x00`). |
+| 00:05:57.464 | Second `HID Handshake` from keyboard. |
+| **00:06:57.446** (≈60 s later) | **`enqueueKernelSpaceHIDDataForDevice … transactionType = 0x04 (Get Report), HID_Host_Handle = 0x7808, dataSize = 2`** — the macOS *kernel* (not bluetoothd) sends a 2-byte HID Get Report PDU. The 2 bytes are `[THdr=0x41, RID=0x47]` ("Get Report, type=Input, RID=0x47"). |
+| **00:06:57.474** (28 ms later) | **Keyboard responds: `HIDShimIncomingControlData … type 0x0A (HID DATA) and length 2`** — payload `[0x47, battery_byte]`. |
+| 00:06:57.474 | Kernel immediately issues another Get Report (same shape) — pattern is "poll, ack, poll." |
+
+Key observations:
+
+1. **macOS does send HID Get Report and the keyboard firmware responds** —
+   directly contradicting the Windows-side conclusion that the firmware refuses
+   GET_REPORT. The previous Windows tests must have hit a different barrier.
+2. The kernel issues the Get Report from `enqueueKernelSpaceHIDDataForDevice`,
+   not from `bluetoothd` userspace — i.e. it's the AppleBluetoothHIDKeyboard.kext
+   driving it, not an app.
+3. The first Get Report fires **\~60 seconds after HID Host connect**, suggesting
+   a periodic poll cadence (60 s would be the steady-state battery refresh on
+   macOS — consistent with Apple's Bluetooth menulet showing battery without
+   manual refresh). Not a single connect-time push as the Windows code assumes.
+4. **A vendor Set Report (transType 0x05, 3-byte payload) is sent immediately
+   after HID Host profile connect**, on the same L2CAP handle that later carries
+   the Get Report. The bluetoothd subsystem labels this
+   `setSniffIntervalForOneSniffAttemptAppleHID … SCO Link State: 3`. This
+   maps to **RID `0x09` Feature** (the only Feature RID in the descriptor),
+   payload byte = `0x03`, padded to 3 bytes.
+
+## Two-tier architecture observed
+
+The `bluetoothd` log shows a clear two-layer split between **how often macOS
+*reports* battery to apps** and **how often it actually *asks the device*** over
+the air:
+
+| Layer | Cadence (observed) | What it does | Crosses BT? |
+|---|---|---|---|
+| App / menu-bar UI | every **2–3 s** | Calls `IOBluetoothDevice batteryPercent` → bluetoothd `getBatteryLevel` → reads bluetoothd's in-memory cache | No |
+| `bluetoothd` cache | served on demand | Returns the last cached value (`status 0x0` if fresh, `status 0x1` if invalid) | No |
+| Kernel HID driver | every **~60 s** | Issues HID `Get Report` over L2CAP to refresh the cache | **Yes** |
+
+Evidence in [docs/kbd-mac-logstream.txt](kbd-mac-logstream.txt):
+
+- Bursts of `getBatteryLevel - battery fetch beginning` lines from multiple
+  bluetoothd worker threads (`22a354`, `22a356`, `229a58`, `2238de`) every
+  2–3 seconds whether the keyboard is connected or not. All cached reads;
+  none touch the wire.
+- Exactly **one** `enqueueKernelSpaceHIDDataForDevice transactionType = 0x04
+  (Get Report)` 60 seconds after the HID Host profile finishes connecting.
+  This is the only event that produced a wire round-trip in our window.
+
+**Caveat:** with only one wire poll observed, we cannot distinguish whether the
+kernel polls **autonomously every 60 s** or only **lazily on cache expiry when
+userspace asks**. Both produce the same observed cadence under the constant
+userspace polling that's always happening on macOS. A 5-minute capture (see
+"Open questions" below) would resolve it.
+
+## Hypotheses for why GET_REPORT failed on Windows
+
+**C′ (most likely): firmware requires the SCO Link State Set Feature as a prerequisite.**
+macOS sends Set Feature RID `0x09` `[0x03, 0x00, 0x00]` immediately on connect.
+Windows opens col02/col03 and goes straight to `HidD_GetInputReport` —
+keyboard silently drops the request, Windows times out and surfaces err=87.
+Easy to test: send the Set Feature first on col03, then call
+`HidD_GetInputReport(0x47)` on col02.
+
+**C″: Windows HID stack rewrites the GET_REPORT PDU encoding** in a way the
+firmware rejects, while macOS sends the raw `[0x41, 0x47]` directly via the
+kernel BT stack. Would need a raw L2CAP socket on PSM `0x11` to confirm —
+much heavier; defer until C′ is ruled out.
+
+**A/B (now eliminated):** the previous "macOS just receives the connect-time
+push and caches it" story does not hold up. The capture proves macOS actively
+polls.
+
+## ~~Implications for the Windows implementation~~ (SUPERSEDED)
+
+> **This section is wrong.** It was based on the inferred RID `0x09` from
+> redacted logs. The HCI capture proved the actual init RID is `0x4A`, which
+> is **not in the descriptor** — `HidD_SetFeature` will reject it before
+> sending. See "Byte-exact findings → What this means for Windows" below
+> for the correct guidance (raw L2CAP via `BTHPROTO_L2CAP`).
+
+## Open questions a longer Mac capture could answer
+
+Worth running if hypothesis C′ doesn't pan out on Windows, or before committing
+to a 60 s constant:
+
+1. **Is the 60 s wire poll autonomous or lazy?** Capture for 5 minutes with the
+   keyboard connected. If we see exactly 5 Get Reports at 60 s intervals
+   regardless of userspace activity → autonomous timer. If the cadence varies
+   with userspace polling load → lazy refresh on cache expiry.
+2. **Is the SCO Link State Set Report sent on every connect, or only the first
+   one in a session?** Disconnect/reconnect 3–4 times in the capture window
+   and check whether the `transactionType = 0x05, packetDataSize = 3` line
+   appears every time.
+3. **Does the keyboard ever push battery without being polled** (e.g., on a
+   significant level change)? Watch for `HIDShimIncomingControlData type 0x0A
+   (HID DATA), length 2` lines that are NOT preceded by an outbound
+   `transactionType = 0x04`. If yes, Windows could keep a `ReadFile` open as
+   a backup channel.
+4. **Actual byte payload of the request and response.** The current trace
+   shows `<private>` for HID data. Resolving this needs either the **Apple
+   Bluetooth Debug Logging Profile** (HCI capture in PacketLogger) or a
+   Linux box with `btmon`. Only required if C′ fails and we have to debug
+   the wire encoding.
+
+## Next step (SUPERSEDED — see Empirical update 2026-05-08 below)
+
+Run [scripts/kbd-setfeature-then-getinput-2026-05-08.ps1](../scripts/kbd-setfeature-then-getinput-2026-05-08.ps1)
+on the Windows machine with the keyboard paired and connected.
+
+## Empirical update — 2026-05-08
+
+Three rounds of probe iteration (PR #36 SO_RCVTIMEO, PR #37 dual-error
+capture, third run with `BluetoothSetServiceState(DISABLE)` + raw L2CAP)
+all produced the same result:
+
+```
+connect() returned: -1  (WSAGetLastError=0  Marshal.GetLastWin32Error=0)
+```
+
+Both Win32 error sources read 0 immediately after the failure — the
+kernel BT stack rejects the connect at a layer below Winsock's
+error-propagation surface, even with the HID profile administratively
+disabled. Userland `AF_BTH/BTHPROTO_L2CAP` to PSM `0x11` is **not a
+supported Windows path** while the device is paired as a HID device.
+
+But then a much smaller test changed the picture entirely. Calling
+`HidD_GetFeature(Col03, RID=0x09, len=4)` from userland **SUCCEEDED**
+with real bytes `[92 12 02 02]`:
+
+```
+[Col03 / RID 0x09 / declared Feature 4 bytes]
+  HidD_GetFeature(rid=0x09, len=4)...
+  *** SUCCESS *** bytes: [92 12 02 02]
+
+[Col02 / RID 0x47 / declared Input only / control test]
+  HidD_GetFeature(rid=0x47, len=2)...
+  FAILED (ok=False err=1) -- ERROR_INVALID_FUNCTION
+```
+
+This proves **Windows BT HID can issue Feature `GET_REPORT`s to this
+firmware over L2CAP without any userland L2CAP work, without a Set
+Feature init, and without driver replacement.** The keyboard responds
+on the first try.
+
+The only blocker for `HidD_GetFeature(Col02, RID=0x47)` is `hidclass.sys`
+descriptor validation: RID `0x47` is declared as Input only (`81 02`)
+in Apple's public descriptor, so the userland call is rejected before
+the bytes ever reach the L2CAP wire.
+
+### Implication: a 4-byte descriptor patch is the entire fix
+
+Insert `09 20 B1 02` immediately before the `c0 c0` closing Col02:
+
+```
+Original Col02 (31 bytes): ... 75 08 95 01 81 02         c0 c0
+Patched  Col02 (35 bytes): ... 75 08 95 01 81 02 09 20 B1 02 c0 c0
+                                                  ^^^^^^^^^^^
+                                                  re-emit Usage(Battery Strength)
+                                                  + Feature main item
+```
+
+Global items (Report Size 8, Count 1, Logical Min 0, Logical Max 255)
+carry across main items per HID 1.11 §6.2.2.7, so only the Usage (a
+local item) needs re-emitting. After the patch, `hidclass.sys` parses
+RID `0x47` as both Input and Feature; `HidD_GetFeature(0x47)` succeeds;
+kernel sends `43 47`; firmware responds `A3 47 NN`; userland gets the
+battery byte.
+
+### Why a kernel filter is still required
+
+Patching the descriptor from user-mode is impossible because
+`hidclass.sys` parses the descriptor once at attach time and caches the
+result. The patch must happen on the IRP path:
+
+- Lower filter on `BTHENUM\{...}_VID&05AC_PID&{Apple kb whitelist}`
+- Intercept `IOCTL_HID_GET_REPORT_DESCRIPTOR`
+- In the completion routine, locate Col02's tail by scanning for the
+  `85 47 ... 81 02 c0 c0` pattern
+- Insert the 4 patch bytes; update `Information` to the new size
+- Forward up the stack
+
+This is the entire driver. ~150-250 lines of KMDF C. No init injection,
+no L2CAP relay, no descriptor replacement, no `bcdedit /set testsigning on`
+at runtime — production-signed via the existing M12 `CN=MagicMouseFix`
+cert in TrustedPublisher.
+
+Scaffold: [`driver-keyboard/`](../driver-keyboard/) (this PR).
+
+## Byte-exact findings (HCI capture, 2026-05-08 second pass)
+
+Capture file: `/Users/lesley/Documents/BT_Keyboard_Trace.pklg` (PacketLogger,
+Apple BT Debug Profile installed). Decoded with `tshark` reading the `.pklg`
+directly. All traffic on **L2CAP HID Control** (PSM 0x11, dynamic CIDs
+0x0058 host→device, 0x0b08 device→host).
+
+### Connect-time init (t=570.467s → 570.495s)
+
+| Frame | Direction | L2CAP payload | Decoded |
+|---|---|---|---|
+| 4426 | host→kbd | `71` | SET_PROTOCOL, Protocol=Report (1 byte total — Wireshark labels this "Boot" but the bit value 1 means Report Protocol per BT HID 1.1 §7.4.6) |
+| 4429 | kbd→host | `00` | HANDSHAKE, Successful |
+| **4430** | **host→kbd** | **`53 4A 03`** | **SET_REPORT Feature, RID `0x4A`, value `0x03`** |
+| 4432 | kbd→host | `00` | HANDSHAKE, Successful |
+| 4435–4439 | host→kbd | (5×) DATA Output Keyboard LEDs | Standard HID LED state push |
+
+**Critical:** RID `0x4A` is **not present in the public HID descriptor**.
+Apple's `bluetoothd` injects it directly via raw L2CAP. The firmware accepts
+the Feature SET_REPORT for this undocumented RID; the descriptor
+advertises only `0x09` as a Feature.
+
+### Steady-state battery poll (t=630.485s → 631.408s, ~60 s after connect)
+
+| Frame | Direction | L2CAP payload | Decoded |
+|---|---|---|---|
+| **8022** | **host→kbd** | **`43 47`** | **GET_REPORT, type=Feature, RID `0x47`** |
+| **8026** | **kbd→host** | **`A3 47 64`** | **DATA Feature, RID `0x47`, value `0x64` = 100 = battery percent** |
+| 8027 | host→kbd | `41 30` | GET_REPORT, type=Input, RID `0x30` (PacketLogger label: `BATTERY LEVEL WARNING`) |
+| 8030 | kbd→host | `A1 30 00` | DATA Input, RID `0x30`, value `0x00` (PacketLogger label: `BATTERY STATUS OK`; non-zero presumably indicates a low-battery warning) |
+
+**Critical:** RID `0x47` is declared in the descriptor as **Input only**, yet
+the keyboard responds to a Feature GET_REPORT for it just fine — so the
+descriptor under-reports the device's capabilities. RID `0x30` is also
+absent from the descriptor.
+
+### What this means for Windows
+
+Windows' `HidD_GetFeature` / `HidD_SetFeature` / `HidD_GetInputReport`
+validate the requested RID against the parsed report descriptor before
+issuing the L2CAP transaction:
+
+- `HidD_GetFeature(col02, [0x47, …])` fails because col02's
+  `FeatureReportByteLength = 0` (RID 0x47 is declared Input there).
+- `HidD_SetFeature(col03, [0x4A, …])` would fail because RID `0x4A` is
+  not in any collection's descriptor at all.
+- This explains the "all 255 RIDs return err=87" observation in
+  [KeyboardBatteryDevice.cs:11-13](../MagicMouseTray/KeyboardBatteryDevice.cs):
+  the firmware *would* respond, but Windows refuses to send the bytes.
+
+The real fix is **raw L2CAP on PSM 0x11**, bypassing the HID class:
+
+1. `socket(AF_BTH, SOCK_STREAM, BTHPROTO_L2CAP)`
+2. Connect to keyboard BD addr, PSM `0x11`
+3. Send `53 4A 03` once on connect → wait for handshake `00`
+4. Every 60 s, send `43 47` → read response `A3 47 ??`; last byte is battery %
+
+Windows complication: by default the in-box HID Profile owns the HID L2CAP
+channels for a paired HID device, and a second userland L2CAP connection
+on PSM 0x11 is rejected. Two known workarounds:
+
+- **Disable the in-box HID profile for the device** before opening the
+  L2CAP socket (registry / `BluetoothSetServiceState`). Re-enable when
+  done. Will likely cause a brief HID disconnect.
+- **Kernel-mode HID filter driver** that intercepts and forwards traffic on
+  the existing channel. Heavier; a real shipping product needs this.
+
+For a probe / proof-of-concept, the first workaround is acceptable.
+
+## Note on the V3 Magic Mouse
+
+**The V3 Magic Mouse (PID `0x0323`) uses a different battery protocol entirely**
+— device-pushed Input on RID `0x90`, no `43 47` query, and a separate
+multi-touch RID `0x12`. See [`M4-V3-MOUSE-MAC-CAPTURE-FINDINGS-2026-05-10.md`](M4-V3-MOUSE-MAC-CAPTURE-FINDINGS-2026-05-10.md)
+for the byte-level analysis. The Windows reader code for V3 already exists
+in [`MouseBatteryReader.cs`](../MagicMouseTray/MouseBatteryReader.cs); the
+remaining V3 blocker is the HidBth descriptor cache issue tracked under M3/M13.
+
+## Cross-device confirmation: V1 Magic Mouse uses the same battery protocol
+
+Captured `magic-mouse -v1_battery_with_restart.pklg` against the V1 Magic
+Mouse (`04:F1:3E:EE:DE:10`, VID `0x05AC` / PID `0x030D`) with the BT Debug
+Profile installed. PacketLogger natively decodes the steady-state poll
+identically to the keyboard:
+
+| Time (relative) | Direction | Bytes | Decoded |
+|---|---|---|---|
+| 3979.216 | host→mouse | `43 47` | GET_REPORT Feature, RID `0x47` |
+| 3980.173 | mouse→host | `A3 47 0F` | DATA Feature — **`BATTERY LEVEL 15%`** |
+| 3980.173 | host→mouse | `41 30` | GET_REPORT Input, RID `0x30` |
+| 3980.196 | mouse→host | `A1 30 00` | DATA Input — **`BATTERY STATUS OK`** |
+
+So the **steady-state battery query bytes are universal** across the Apple
+BT HID family. Same `0x47` Feature and `0x30` Input RIDs respond on both
+the keyboard and the mouse.
+
+The connect-time init differs by device:
+
+| Device | Init transactions (host → device) |
+|---|---|
+| **Keyboard** (PID `0x0239`) | one Set Feature: `53 4A 03` |
+| **V1 Magic Mouse** (PID `0x030D`) | sequence of vendor Set Features at gesture/sensitivity RIDs: `53 C6 01 12 01 2C` *(rejected with HANDSHAKE Error: Invalid Report ID)*, then `53 F1 DB`, `53 F8 01 37`, `53 D7 01`. None of those address battery; the firmware happily answers `43 47` without any host-issued init. The first attempt being **rejected by the firmware** also implies the host is doing some auto-discovery rather than reading from a known table. |
+
+**Implication for the Windows port:** the same probe script
+([scripts/kbd-l2cap-with-hid-disable-2026-05-08.ps1](../scripts/kbd-l2cap-with-hid-disable-2026-05-08.ps1))
+covers both devices. It now accepts `-BdAddr` and `-Device <keyboard|mouse|none>`
+parameters; for the mouse, run with `-Device none` (or `-Device mouse` —
+currently equivalent — skip the keyboard's `53 4A 03` init).
+
+```powershell
+# keyboard (default)
+.\kbd-l2cap-with-hid-disable-2026-05-08.ps1
+
+# V1 magic mouse (skip init; battery query is universal)
+.\kbd-l2cap-with-hid-disable-2026-05-08.ps1 -BdAddr 04:F1:3E:EE:DE:10 -Device none
+```
+
+**Open question:** does the keyboard *actually* require the `53 4A 03`
+init for `43 47` to work, or is it incidental (e.g., sniff-interval
+coordination)? The mouse capture suggests the firmware doesn't strictly
+require any host-issued init — the auto-discovery probe failed and
+battery still works. If true, the Windows port can drop the keyboard
+init step entirely. Test by running `-BdAddr E8:06:88:4B:07:41 -Device none`
+on Windows and seeing whether `43 47` still gets a valid response.
+
+## Reproducibility
+
+To re-derive the macOS findings:
+
+```bash
+# in Terminal.app, with Bluetooth permission granted:
+brew install blueutil
+./scripts/kbd-mac-battery-logstream.sh   # follow the keyboard wake prompt
+
+# the resulting docs/kbd-mac-logstream.txt should contain:
+grep "transactionType = 0x04 (Get Report)" docs/kbd-mac-logstream.txt
+grep "HIDShimIncomingControlData: Received incoming control data of type 0x0A" \
+     docs/kbd-mac-logstream.txt
+```
+
+The `setSniffIntervalForOneSniffAttemptAppleHID` log line — and the matching
+`Set Report, packetDataSize = 3` enqueue — appears whenever an Apple HID
+reconnects.

--- a/docs/M4-V3-MOUSE-MAC-CAPTURE-FINDINGS-2026-05-10.md
+++ b/docs/M4-V3-MOUSE-MAC-CAPTURE-FINDINGS-2026-05-10.md
@@ -1,0 +1,205 @@
+# V3 Magic Mouse — macOS HCI Capture Findings (2026-05-10)
+
+> **Companion to:** [`M4-MAC-CAPTURE-FINDINGS-2026-05-08.md`](M4-MAC-CAPTURE-FINDINGS-2026-05-08.md)
+> (Apple keyboard + V1 Magic Mouse). The V3 mouse uses a **different**
+> battery protocol from the keyboard / V1 mouse, so it gets its own write-up.
+>
+> **Companion to:** [`M13-V3-BATTERY-AUDIT-2026-04-30.md`](M13-V3-BATTERY-AUDIT-2026-04-30.md)
+> (Windows-side V3 battery audit). The macOS HCI bytes here corroborate the
+> existing Windows analysis — same RID, same byte layout, same percent in
+> `buf[2]`. No new wire protocol; what's new is the device-side push pattern,
+> the multi-touch RID confirmation, and the cross-OS reconciliation.
+
+## TL;DR
+
+| What | V3 Magic Mouse (PID `0x0323`) | Keyboard / V1 Mouse (for contrast) |
+|---|---|---|
+| Battery protocol | **Device-pushed** Input report on **RID `0x90`** | Host-issued GET_REPORT Feature on RID `0x47` |
+| Battery wire bytes | `a1 90 04 NN` (3-byte HID payload after THdr) | `43 47` query → `A3 47 NN` response |
+| `buf[2]` value | battery percent (0–100) | battery percent (0–100) |
+| Pushed when | At every reconnect; ~6 times in a 19-min capture spanning 3 reconnects | N/A — query-driven, ~60 s cadence |
+| Multi-touch / pointer | **RID `0x12`** (Linux: `MOUSE2_REPORT_ID`) | N/A — keyboard has its own RIDs |
+| Windows blocker | HidBth descriptor cache non-determinism (M3/M13 territory) | HidD_* RID validation against missing descriptor entries (M4 territory; raw L2CAP fix in PR #35) |
+
+**The Windows-side reader code in [`MouseBatteryReader.cs`](../MagicMouseTray/MouseBatteryReader.cs)
+is already correct.** This capture confirms it — `buf[2]` is the battery
+percent for V3, exactly as the existing code assumes.
+
+## Source capture
+
+- **File:** `/Users/lesley/Documents/Magic_mouse_v3.pklg` (PacketLogger, ~2 MB,
+  43,786 frames, ~19 min span). Not committed (contains BD addresses of
+  unrelated nearby devices).
+- **Tool:** PacketLogger.app with the Apple Bluetooth Debug Logging Profile
+  installed (see prior M4 doc for install instructions).
+- **Mouse:** "Magic Mouse", BD addr `D0:C0:50:CC:8C:4D`, VID `0x004C` /
+  PID `0x0323`, firmware `3.1.4`. Note the OUI: VID `0x004C` (newer Apple
+  range) vs the V1 mouse's `0x05AC` and the keyboard's `0x05AC`.
+- **Decoder:** `tshark` (Wireshark CLI), reads `.pklg` directly.
+
+## Full HID RID inventory observed
+
+### Input reports (THdr `0xa1` — device → host)
+
+| RID | Count | Sample wire bytes (HID payload) | Identity |
+|---|---|---|---|
+| **`0x12`** | **27,669** | `a1 12 00 f2 ff 2b 00` (length 7), `a1 12 00 00 00 00 00 …` (length 7–15) | **Multi-touch / pointer** (Linux `MOUSE2_REPORT_ID`). Variable-length per-touch encoding decoded in `magicmouse_raw_event()`. |
+| `0xf0` | 6 | `a1 f0 90 04 2a` | Vendor channel **wrapping** a RID-`0x90` battery payload. Identical battery byte (`buf[2]`) inside. |
+| `0x90` | 6 | `a1 90 04 2a` | **Battery push.** Layout: `[RID][flags?][pct]`. Pushed twice per reconnect in our capture (3 reconnects × 2 = 6). |
+| `0x60` | 3 | `a1 60 02` | One per reconnect — likely a wake/state notify. Single payload byte `0x02`. |
+| `0x13` | 1 | (variant of `0x12`) | Possibly extended-touch report; only one observed. |
+
+### Feature responses (THdr `0xa3` — answers to host `43 ??` queries)
+
+| RID | Count | Sample wire bytes | Notes |
+|---|---|---|---|
+| `0xf0` | 36 | `a3 f0 BB 01 00 20 04`, `a3 f0 34 03 14 03 d0`, `a3 f0 e0 00 00 00 00`, `a3 f0 14 22`, `a3 f0 c5 01`, `a3 f0 b8 48 00`, `a3 f0 bc 02 00` | Multiplexed vendor channel. Sub-command set first via `53 ff <subcmd>`, then read with `43 f0`. The first byte after the RID echoes the sub-command index. **None match a 0–100 battery shape.** |
+| `0xf1` | 9 | `a3 f1 00 01`, `a3 f1 01 db 00 3c 00`, `a3 f1 db 01 02 00 d1` | Vendor configuration / acks. |
+| `0x4a` | 3 | `a3 4a 01 01` | 2-byte status flags. Seen 3 times, identical bytes — likely a static device-info field. |
+
+### Connect-time host transactions observed (THdr `0x53`/`0x43`/`0x71` etc., host → device)
+
+These are host-issued vendor configuration. **None of them match the
+keyboard's `53 4A 03` init or the keyboard/V1's `43 47` battery query.**
+The V3 protocol family is entirely separate.
+
+```
+71                       SET_PROTOCOL Report mode (universal across Apple BT HID)
+53 c6 01 12 02 2c        SET_REPORT Feature, vendor configuration A
+53 c6 01 18 02 20        SET_REPORT Feature, vendor configuration A (variant)
+53 ff <subcmd>           SET_REPORT Feature, multiplexed vendor sub-command
+                         observed sub-cmds: 00 01 14 34 90 b8 bb bc c5 db e0
+43 f0                    GET_REPORT Feature, multiplexed vendor read
+43 f1                    GET_REPORT Feature, vendor config
+43 4a                    GET_REPORT Feature, 2-byte status
+41 f0                    GET_REPORT Input,   vendor read (Input variant)
+53 f1 06 01 37           SET_REPORT Feature, RID 0xF1 sub-write
+53 f1 02 01              SET_REPORT Feature, RID 0xF1 sub-write
+53 f1 01 db              SET_REPORT Feature, RID 0xF1 sub-write
+```
+
+## Battery report — byte layout (cross-OS confirmation)
+
+The 3-byte RID-`0x90` battery report has been observed identically in
+three independent contexts:
+
+| Source | Bytes | `buf[2]` (decoded) |
+|---|---|---|
+| Repo audit, 2026-04-29 ([`M13-V3-BATTERY-AUDIT-2026-04-30.md`](M13-V3-BATTERY-AUDIT-2026-04-30.md)) | `90 04 22` | `0x22` = **34 %** |
+| This Mac PacketLogger capture (2026-05-10) | `a1 90 04 2a` | `0x2a` = **42 %** |
+| Windows `HidD_GetInputReport(0x90)` probe (this session) | `90 04 28 00 00 00 00 00` | `0x28` = **40 %** |
+| Repo `mm3-pre-validation-baseline-2026-04-26.md:60` | `90 04 31` | `0x31` = **49 %** |
+
+```
+buf[0] = 0x90    Report ID (always)
+buf[1] = 0x04    constant — observed in EVERY capture across both OSes
+buf[2] = pct     battery 0–100 (0x00–0x64)
+buf[3..N] = 0    zero pad when caller's buffer > 3 bytes
+```
+
+The "8-byte buffer" form on Windows (`90 04 28 00 00 00 00 00`) is just
+`MaxInputReportSize` zero-padding — col02 has other RIDs that need 8 bytes,
+so HID class returns 8 even for the 3-byte RID `0x90`.
+
+## Open question: what is `buf[1] = 0x04`?
+
+**Status:** unresolved. `mm3-pre-validation-baseline-2026-04-26.md:63`
+labels it "(flags)" but no capture has shown it taking any other value.
+
+**Evidence so far:**
+
+- Repo's 2026-04-29 probe: `0x04` (mouse at 34 %)
+- Repo's 2026-04-26 baseline: `0x04` (mouse at 49 %)
+- Mac capture, 2026-05-10: `0x04` (mouse at 42 %)
+- Windows probe, 2026-05-10: `0x04` (mouse at 40 %)
+
+Two independent OSes, four different battery percentages, weeks apart — same
+constant `0x04`. Most likely explanations:
+
+1. **Static format/version byte** — `0x04` is the "this is a battery v1
+   payload" marker. Easy to imagine Apple firmware re-using a stable
+   identifier here.
+2. **Status flags byte where every observed state has bit 2 set** — would
+   require seeing it flip during a state we haven't captured (charging,
+   critical-low, paired-but-asleep) to know the bit-meanings.
+
+**Cheap experiment that would close this question:** capture a fresh RID
+`0x90` push while the mouse is charging via USB-C. If `buf[1]` flips, it's
+flags; if it stays `0x04`, it's a constant. Worth one minute next time the
+mouse is being charged anyway.
+
+For now, **the safe call in [`MouseBatteryReader.cs`](../MagicMouseTray/MouseBatteryReader.cs)
+is to ignore `buf[1]` and use `buf[2]` directly as the battery percent**,
+which is what the existing code does. If `buf[1]` later turns out to encode
+a charging flag, that becomes a UI enhancement, not a correctness fix.
+
+## Multi-touch RID `0x12` — what's in it
+
+Linux `drivers/hid/hid-magicmouse.c` (`magicmouse_raw_event()`) decodes
+RID `0x12` byte-by-byte. Summary of the per-frame structure:
+
+- **Length:** variable, 7–15 bytes depending on touch count.
+- **Byte 0:** number of active touches (0 = pointer-only, 1+ = trackpad-style).
+- **Subsequent bytes:** mouse motion (`dx`, `dy` as signed shorts) when no
+  touches; or per-touch (finger ID, X, Y, pressure, contact size encoded
+  across multiple bytes per touch) when 1+ touches.
+
+For the V3 (USB-C, PID `0x0323`), the report layout is the same as the
+V2 `MOUSE2_REPORT_ID = 0x12` — Linux added the V3 PID under the existing
+device-ID table and reuses the V2 parsing path:
+
+```
+USB_DEVICE_ID_APPLE_MAGICMOUSE2_USBC → MOUSE2_REPORT_ID (0x12)
+```
+
+This is the canonical reference. Anyone porting multi-touch handling on
+Windows should mirror Linux's `magicmouse_emit_touch()` decoding.
+
+## Implications for the Windows port
+
+| Concern | Status |
+|---|---|
+| Battery byte layout | **Solved.** `buf[2]` = pct, confirmed across OSes and probes. Existing [`MouseBatteryReader.cs:178-204`](../MagicMouseTray/MouseBatteryReader.cs) reads it correctly when col02 is enumerated. |
+| `HidD_GetInputReport(0x90)` works | **Conditional.** Works under Descriptor A (col02 enumerates the vendor TLC); fails under Descriptor B (col02 orphaned). See [`v3-BATTERY-EMPIRICAL-PROOF-AND-PATHS.md`](v3-BATTERY-EMPIRICAL-PROOF-AND-PATHS.md). |
+| Windows blocker | **Descriptor-cache non-determinism in HidBth.** Not a wire-protocol problem — purely a Windows kernel-layer issue. M3/M13 territory; tracked in those docs. |
+| Multi-touch port | Out of scope for the M4 battery work. RID `0x12` decoded by Linux source — straightforward to port if/when needed. |
+| Charging-flag UI | Open question pending the `buf[1]` experiment. Low-priority enhancement. |
+
+**Net:** the V3 work doesn't need a new mac-side investigation. The remaining
+problem is on the Windows kernel side and is being tracked under M3/M13.
+
+## Reproducibility
+
+To re-derive the V3 macOS findings on a different machine:
+
+```bash
+# Mac side: install the Bluetooth Debug Logging Profile from Apple Developer,
+# reboot, then with a paired V3 mouse:
+#  1. Open PacketLogger.app, hit the red Start button.
+#  2. Disconnect/reconnect the mouse via blueutil to capture init + push:
+brew install blueutil
+KBD=d0-c0-50-cc-8c-4d
+blueutil --disconnect $KBD; sleep 4; blueutil --connect $KBD; sleep 30
+#  3. PacketLogger > File > Stop, Save As ~/Documents/v3.pklg
+
+# Then dissect:
+brew install wireshark
+FILE=~/Documents/v3.pklg
+
+# Battery push (RID 0x90):
+tshark -r "$FILE" -Y "bthid && bthid.transaction_type == 0xa" -x \
+  | grep -E '^0000' | grep ' a1 90 ' | head
+
+# Multi-touch (RID 0x12):
+tshark -r "$FILE" -Y "bthid && bthid.transaction_type == 0xa" -x \
+  | grep -E '^0000' | grep ' a1 12 ' | head
+
+# Full RID histogram:
+tshark -r "$FILE" -Y "bthid && bthid.transaction_type == 0xa" -x \
+  | grep -E '^0000' | awk '$11=="a1"{c[$12]++} END{for(r in c)printf "RID 0x%s %d\n",r,c[r]}' \
+  | sort -k3 -rn
+```
+
+Expected: `a1 90 04 NN` somewhere in the output, where `NN` is the current
+battery percent in hex; tens of thousands of `a1 12 …` multi-touch frames
+if the mouse was being used during the capture.


### PR DESCRIPTION
## Summary

- Recovers two documentation files that were committed to the now-stale `claude/m4-mouse-protocol-confirm` worktree (commit `5ff2543`) but never made it into `main`
- PR #42 was merged before this commit was added; the docs were orphaned

## What's in here

- `docs/M4-V3-MOUSE-MAC-CAPTURE-FINDINGS-2026-05-10.md` — full RID inventory for V3 Magic Mouse, byte-layout table for the RID 0x90 battery report, cross-OS reconciliation table (Mac + Windows captures), open question on `buf[1]=0x04`
- `docs/M4-MAC-CAPTURE-FINDINGS-2026-05-08.md` — adds a V3 callout pointing to the new doc

No code changes. Pure documentation recovery.

## Test plan
- [ ] Both files present and readable
- [ ] No conflicts with main

🤖 Generated with [Claude Code](https://claude.com/claude-code)