### PR TITLE
feat(devices): Magic Trackpad 1/2/3, more keyboards, v2 USB; gated Logitech (experimental)

### DIFF
--- a/MagicMouseTray/AdaptivePoller.cs
+++ b/MagicMouseTray/AdaptivePoller.cs
@@ -90,7 +90,7 @@ internal sealed class AdaptivePoller : IDisposable
             var interval = LastInterval;
             try
             {
-                var devices = DeviceRegistry.Discover();
+                var devices = DeviceRegistry.Discover(_config.EnableThirdParty);
 
                 int lowestPct = -1;
                 string lowestDevice = string.Empty;

--- a/MagicMouseTray/Config.cs
+++ b/MagicMouseTray/Config.cs
@@ -19,6 +19,7 @@ internal sealed class Config
     internal int Threshold { get; private set; } = 20;
     internal bool StartWithWindows { get; private set; }
     internal bool EnableV3Recycle { get; private set; } = true;
+    internal bool EnableThirdParty { get; private set; } = false;
 
     internal static Config Load()
     {
@@ -38,6 +39,8 @@ internal sealed class Config
                 cfg.StartWithWindows = s;
             else if (key == "enable_v3_recycle" && bool.TryParse(val, out bool r))
                 cfg.EnableV3Recycle = r;
+            else if (key == "enable_third_party" && bool.TryParse(val, out bool tp))
+                cfg.EnableThirdParty = tp;
         }
         return cfg;
     }
@@ -65,6 +68,13 @@ internal sealed class Config
         Logger.Log($"CONFIG enable_v3_recycle={value}");
     }
 
+    internal void SetEnableThirdParty(bool value)
+    {
+        EnableThirdParty = value;
+        Persist();
+        Logger.Log($"CONFIG enable_third_party={value}");
+    }
+
     static bool IsValid(int t) => t is 10 or 15 or 20 or 25;
 
     void Persist()
@@ -75,7 +85,8 @@ internal sealed class Config
             File.WriteAllLines(ConfigPath, [
                 $"threshold={Threshold}",
                 $"start_with_windows={StartWithWindows.ToString().ToLower()}",
-                $"enable_v3_recycle={EnableV3Recycle.ToString().ToLower()}"
+                $"enable_v3_recycle={EnableV3Recycle.ToString().ToLower()}",
+                $"enable_third_party={EnableThirdParty.ToString().ToLower()}"
             ]);
         }
         catch { }

--- a/MagicMouseTray/DeviceRegistry.cs
+++ b/MagicMouseTray/DeviceRegistry.cs
@@ -9,13 +9,13 @@ internal static class DeviceRegistry
     /// Scans all present HID interfaces and returns one IBatteryDevice per matched Apple device.
     /// Matching priority: mouse VID/PID checked first, then keyboard VID/PID.
     /// </summary>
-    public static IReadOnlyList<IBatteryDevice> Discover()
+    public static IReadOnlyList<IBatteryDevice> Discover(bool enableThirdParty = false)
     {
         var results = new List<IBatteryDevice>();
 
         foreach (var path in HidNative.EnumerateHidPaths())
         {
-            var device = TryClassify(path);
+            var device = TryClassify(path, enableThirdParty);
             if (device is not null)
                 results.Add(device);
         }
@@ -23,7 +23,7 @@ internal static class DeviceRegistry
         return results;
     }
 
-    static IBatteryDevice? TryClassify(string path)
+    static IBatteryDevice? TryClassify(string path, bool enableThirdParty)
     {
         // Magic Mouse — check all variants
         foreach (var entry in MouseBatteryDevice.KnownMice)
@@ -32,6 +32,17 @@ internal static class DeviceRegistry
                 path.Contains(entry.PidPattern, StringComparison.OrdinalIgnoreCase))
                 return new MouseBatteryDevice(path, entry.DisplayName, entry.Kind);
         }
+
+        // B2 (experimental, flag-gated): directly-connected Logitech HID++ devices ONLY.
+        // Checked BEFORE the keyboard col02 gate below: Logitech HID paths have no col02
+        // collection, so gating on col02 first would make this branch unreachable. The
+        // VID 046d match keeps it from interfering with Apple-keyboard classification.
+        // Unifying/Bolt RECEIVERS are intentionally excluded — they require per-device-index
+        // (1-6) addressing, not 0xFF; reading them is out of scope.
+        if (enableThirdParty
+            && path.Contains("vid_046d", StringComparison.OrdinalIgnoreCase)
+            && !IsLogitechReceiver(path))
+            return new LogitechBatteryDevice(path);
 
         // Magic Keyboard — col02 only (col01=keyboard, col03=consumer+vendor; battery cap is on col02).
         // Filtering here prevents 3 instances per physical keyboard (one per collection).
@@ -45,4 +56,11 @@ internal static class DeviceRegistry
 
         return null;
     }
+
+    // Known Logitech receiver PIDs (Unifying / Bolt / nano variants). Receivers are excluded
+    // from B2 because battery must be queried per paired device index, not at 0xFF.
+    static readonly string[] LogitechReceiverPids = ["c52b", "c548", "c531", "c52f", "c534"];
+
+    static bool IsLogitechReceiver(string path) =>
+        Array.Exists(LogitechReceiverPids, pid => path.Contains(pid, StringComparison.OrdinalIgnoreCase));
 }

--- a/MagicMouseTray/DriverHealthChecker.cs
+++ b/MagicMouseTray/DriverHealthChecker.cs
@@ -35,6 +35,18 @@ internal static class DriverHealthChecker
     // If Apple ships a new model, its PID won't be here — we surface that as UnknownAppleMouse.
     static readonly string[] KnownPids = ["030d", "0310", "0269", "0323"];
 
+    // Apple BT-HID devices matched by the same VID/UUID scan but that do NOT use the
+    // applewirelessmouse scroll filter (trackpads + keyboards). Excluded from BOTH the
+    // UnknownAppleMouse and the NotBound verdicts — otherwise the tray shows a false warning.
+    // PIDs are numeric facts only (hid-ids.h, GPL) — no kernel code/comments copied.
+    static readonly string[] NonScrollApplePids =
+    [
+        "030e", "0265", "0324",                                       // trackpads (v1, v2, v3)
+        "0239", "023a", "023b", "024f", "0250", "0267", "026c",       // existing keyboard rows (latent fix)
+        "029c", "029a", "029f", "0320", "0321", "0322",               // Magic Keyboards 2021/2024
+        "0255", "0256", "0257",                                       // Apple Wireless Keyboard 2011 (true)
+    ];
+
     internal static DriverStatus GetStatus()
     {
         try
@@ -72,6 +84,14 @@ internal static class DriverHealthChecker
                 int pidIdx = subkeyName.LastIndexOf("_PID&", StringComparison.OrdinalIgnoreCase);
                 if (pidIdx < 0 || pidIdx + 9 > subkeyName.Length) continue;
                 var pid = subkeyName.Substring(pidIdx + 5, 4).ToLowerInvariant();
+
+                // Non-scroll Apple device (trackpad/keyboard): no scroll filter expected.
+                // Skip so it triggers neither UnknownAppleMouse nor NotBound.
+                if (Array.Exists(NonScrollApplePids, p => p == pid))
+                {
+                    Logger.Log($"DRIVER_CHECK skip_non_scroll_apple pid=0x{pid.ToUpper()}");
+                    continue;
+                }
 
                 using var deviceKey = btEnumKey.OpenSubKey(subkeyName, writable: false);
                 if (deviceKey == null) continue;

--- a/MagicMouseTray/HidNative.cs
+++ b/MagicMouseTray/HidNative.cs
@@ -58,6 +58,13 @@ internal static class HidNative
     internal static extern bool HidD_GetFeature(SafeFileHandle HidDeviceObject,
         byte[] ReportBuffer, int ReportBufferLength);
 
+    // B2 (experimental, flag-gated): HID++ negotiation for directly-connected third-party devices.
+    [DllImport("hid.dll", SetLastError = true)]
+    internal static extern bool HidD_GetAttributes(SafeFileHandle HidDeviceObject, ref HIDD_ATTRIBUTES Attributes);
+
+    [DllImport("hid.dll", SetLastError = true)]
+    internal static extern bool HidD_SetOutputReport(SafeFileHandle HidDeviceObject, byte[] ReportBuffer, int ReportBufferLength);
+
     [DllImport("hid.dll")]
     internal static extern bool HidD_GetPreparsedData(SafeFileHandle HidDeviceObject,
         out IntPtr PreparsedData);
@@ -342,6 +349,9 @@ internal static class HidNative
         [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 512)]
         public string DevicePath;
     }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal struct HIDD_ATTRIBUTES { public int Size; public ushort VendorID, ProductID, VersionNumber; }
 
     [StructLayout(LayoutKind.Sequential)]
     internal struct HIDP_CAPS

--- a/MagicMouseTray/IBatteryDevice.cs
+++ b/MagicMouseTray/IBatteryDevice.cs
@@ -6,6 +6,10 @@ public enum DeviceKind
     MagicMouseV2,
     MagicMouseV3,
     MagicKeyboard,
+    MagicTrackpadV1,
+    MagicTrackpadV2,
+    MagicTrackpadV3,
+    LogitechMouse,
 }
 
 public interface IBatteryDevice

--- a/MagicMouseTray/KeyboardBatteryDevice.cs
+++ b/MagicMouseTray/KeyboardBatteryDevice.cs
@@ -40,6 +40,23 @@ internal sealed class KeyboardBatteryDevice : IBatteryDevice
         // Magic Keyboard with Touch ID (A2449, 2021+)
         new("000205AC", "PID&0267", "Magic Keyboard with Touch ID"),
         new("000205AC", "PID&026C", "Magic Keyboard with Touch ID ISO"),
+        // PIDs below: numeric facts only from hid-ids.h (GPL) — no kernel code/comments copied.
+        // Magic Keyboard 2021/2024 (BLE company-id 0x004C or BT-classic 0x05AC)
+        new("0001004C", "PID&029C", "Magic Keyboard (2021)"),
+        new("000205AC", "PID&029C", "Magic Keyboard (2021)"),
+        new("0001004C", "PID&029A", "Magic Keyboard with Touch ID (2021)"),
+        new("000205AC", "PID&029A", "Magic Keyboard with Touch ID (2021)"),
+        new("0001004C", "PID&029F", "Magic Keyboard with Numeric Keypad (2021)"),
+        new("000205AC", "PID&029F", "Magic Keyboard with Numeric Keypad (2021)"),
+        new("0001004C", "PID&0320", "Magic Keyboard (2024)"),
+        new("000205AC", "PID&0320", "Magic Keyboard (2024)"),
+        new("0001004C", "PID&0321", "Magic Keyboard with Touch ID (2024)"),
+        new("000205AC", "PID&0321", "Magic Keyboard with Touch ID (2024)"),
+        new("0001004C", "PID&0322", "Magic Keyboard with Numeric Keypad (2024)"),
+        new("000205AC", "PID&0322", "Magic Keyboard with Numeric Keypad (2024)"),
+        new("000205AC", "PID&0255", "Apple Wireless Keyboard (2011 ANSI)"),
+        new("000205AC", "PID&0256", "Apple Wireless Keyboard (2011 ISO)"),
+        new("000205AC", "PID&0257", "Apple Wireless Keyboard (2011 JIS)"),
     ];
 
     // Battery Strength on Generic Device Controls page — readable as a Feature after the patch.

--- a/MagicMouseTray/LogitechBatteryDevice.cs
+++ b/MagicMouseTray/LogitechBatteryDevice.cs
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+// IBatteryDevice implementation for directly-connected (BT/USB) Logitech HID++ 2.0 devices.
+//
+// EXPERIMENTAL — flag-gated behind Config.EnableThirdParty (default off). No Logitech hardware
+// was available to verify this path; it is concrete, buildable scaffolding only.
+//
+// The HID++ 2.0 negotiation TECHNIQUE (Root feature lookup, then BatteryStatus/UnifiedBattery
+// query) is reimplemented from the MIT-licensed project Ithilias/logitray. No source was copied;
+// this is an independent C# implementation. See THIRD-PARTY-NOTICES.md.
+//
+// SCOPE: directly-connected devices only (deviceIndex 0xFF addresses the device itself).
+// Unifying/Bolt receivers are out of scope (they require per-paired-device index 1-6) and are
+// excluded at discovery time (DeviceRegistry.IsLogitechReceiver).
+using System.Runtime.InteropServices;
+using Microsoft.Win32.SafeHandles;
+
+namespace MagicMouseTray;
+
+internal sealed class LogitechBatteryDevice : IBatteryDevice
+{
+    const ushort UP_VENDOR = 0xFF00;   // HID++ vendor-defined collection
+    const byte DEV_INDEX   = 0xFF;     // direct-connect: addresses the device itself
+    const byte SW_ID       = 0x05;     // arbitrary software id (low nibble of byte3)
+    const byte SHORT_ID    = 0x10;     // short report: 7 bytes total
+    const byte LONG_ID     = 0x11;     // long report: 20 bytes total
+    const int  TIMEOUT_MS  = 600;      // mirrors the per-read budget elsewhere in the app
+
+    readonly string _path;
+
+    public string DeviceName { get; } = "Logitech Mouse"; // provisional; name query out of scope
+    public DeviceKind Kind => DeviceKind.LogitechMouse;
+
+    internal LogitechBatteryDevice(string path) => _path = path;
+
+    public int GetBatteryPercent()
+    {
+        using var handle = HidNative.CreateFile(
+            _path,
+            HidNative.GENERIC_READ | 0x40000000u /* GENERIC_WRITE */,
+            HidNative.FILE_SHARE_READ | HidNative.FILE_SHARE_WRITE,
+            IntPtr.Zero,
+            HidNative.OPEN_EXISTING,
+            HidNative.FILE_FLAG_OVERLAPPED,
+            IntPtr.Zero);
+
+        if (handle.IsInvalid)
+        {
+            Logger.Log($"LOGI_OPEN_FAILED path={_path} err={Marshal.GetLastWin32Error()}");
+            return -1;
+        }
+
+        // Confirm vendor collection and pick short vs long report length from OutputReportByteLength.
+        int reportLen;
+        byte reportId;
+        if (!HidNative.HidD_GetPreparsedData(handle, out var preparsed)) return -1;
+        try
+        {
+            var caps = new HidNative.HIDP_CAPS();
+            if (HidNative.HidP_GetCaps(preparsed, ref caps) != HidNative.HIDP_STATUS_SUCCESS) return -1;
+            if (caps.UsagePage != UP_VENDOR) { Logger.Log($"LOGI_NOT_VENDOR up=0x{caps.UsagePage:X4}"); return -1; }
+            if (caps.OutputReportByteLength >= 20) { reportId = LONG_ID; reportLen = 20; }
+            else                                   { reportId = SHORT_ID; reportLen = 7; }
+        }
+        finally { HidNative.HidD_FreePreparsedData(preparsed); }
+
+        // Prefer BatteryStatus (0x1000, fn0 = % directly); fall back to UnifiedBattery (0x1004, fn1).
+        int pct = ReadFeatureBattery(handle, reportId, reportLen, 0x1000, funcIndex: 0);
+        if (pct < 0)
+            pct = ReadFeatureBattery(handle, reportId, reportLen, 0x1004, funcIndex: 1);
+
+        if (pct >= 0) Logger.Log($"LOGI_BATTERY_OK device={DeviceName} pct={pct}%");
+        return pct;
+    }
+
+    // Resolves a HID++ 2.0 feature via Root (0x0000) GetFeature, then queries it for battery %.
+    int ReadFeatureBattery(SafeFileHandle handle, byte reportId, int reportLen, ushort featureId, byte funcIndex)
+    {
+        // Root.GetFeature(featureId): byte3 = 0x00 | swId (function 0 on the Root feature).
+        var rootReq = NewReport(reportId, reportLen, featureIndex: 0x00,
+            funcByte: (byte)(0x00 | SW_ID), arg0: (byte)(featureId >> 8), arg1: (byte)(featureId & 0xFF));
+        var rootResp = SendReceive(handle, rootReq, reportLen);
+        if (rootResp is null) return -1;
+        byte featureIndex = rootResp[4];
+        if (featureIndex == 0) return -1; // feature absent on this device
+
+        // Query the feature: byte3 = (funcIndex << 4) | swId.
+        var req = NewReport(reportId, reportLen, featureIndex,
+            funcByte: (byte)((funcIndex << 4) | SW_ID), arg0: 0, arg1: 0);
+        var resp = SendReceive(handle, req, reportLen);
+        if (resp is null) return -1;
+
+        int pct = resp[4]; // % at offset 4 for both 0x1000 GetBatteryLevelStatus and 0x1004 GetStatus
+        return pct is >= 0 and <= 100 ? pct : -1;
+    }
+
+    static byte[] NewReport(byte reportId, int len, byte featureIndex, byte funcByte, byte arg0, byte arg1)
+    {
+        var b = new byte[len];
+        b[0] = reportId;
+        b[1] = DEV_INDEX;
+        b[2] = featureIndex;
+        b[3] = funcByte;
+        b[4] = arg0;
+        b[5] = arg1;
+        return b;
+    }
+
+    // Writes the HID++ request and waits (overlapped) for the matching response, reusing the
+    // same event/wait helpers KeyboardBatteryDevice-era code uses for timed HID reads.
+    static byte[]? SendReceive(SafeFileHandle handle, byte[] req, int reportLen)
+    {
+        if (!HidNative.HidD_SetOutputReport(handle, req, req.Length))
+            return null;
+
+        IntPtr evt = HidNative.CreateEvent(IntPtr.Zero, true, false, IntPtr.Zero);
+        try
+        {
+            var buf = new byte[reportLen];
+            var ov = new HidNative.OVERLAPPED { hEvent = evt };
+            if (!HidNative.ReadFile(handle, buf, (uint)buf.Length, IntPtr.Zero, ref ov))
+            {
+                if ((uint)Marshal.GetLastWin32Error() != HidNative.ERROR_IO_PENDING) return null;
+                if (HidNative.WaitForSingleObject(evt, TIMEOUT_MS) != HidNative.WAIT_OBJECT_0)
+                {
+                    HidNative.CancelIo(handle);
+                    return null;
+                }
+            }
+            if (!HidNative.GetOverlappedResult(handle, ref ov, out uint got, false) || got == 0)
+                return null;
+
+            // Match the response to our request (same feature index + swId).
+            if (buf[0] != req[0] || buf[2] != req[2]) return null;
+            return buf;
+        }
+        finally { HidNative.CloseHandle(evt); }
+    }
+}

--- a/MagicMouseTray/MouseBatteryDevice.cs
+++ b/MagicMouseTray/MouseBatteryDevice.cs
@@ -20,6 +20,13 @@ internal sealed class MouseBatteryDevice : IBatteryDevice
         new("VID_05AC",  "PID_0323", "Magic Mouse 2024", DeviceKind.MagicMouseV3), // USB v3
         new("000205AC", "PID&030D", "Magic Mouse v1",   DeviceKind.MagicMouseV1), // BT v1
         new("000205AC", "PID&0269", "Magic Mouse v2",   DeviceKind.MagicMouseV2), // BT v2 (M2 confirm pending)
+        // PIDs below: numeric facts only from hid-ids.h (GPL) — no kernel code/comments copied.
+        new("000205AC", "PID&0265", "Magic Trackpad 2",   DeviceKind.MagicTrackpadV2), // BT v2
+        new("VID_05AC",  "PID_0265", "Magic Trackpad 2",   DeviceKind.MagicTrackpadV2), // USB v2
+        new("000205AC", "PID&030E", "Magic Trackpad",     DeviceKind.MagicTrackpadV1), // BT v1
+        new("0001004C", "PID&0324", "Magic Trackpad 2024", DeviceKind.MagicTrackpadV3), // BLE v3
+        new("VID_05AC",  "PID_0324", "Magic Trackpad 2024", DeviceKind.MagicTrackpadV3), // USB v3
+        new("VID_05AC",  "PID_0269", "Magic Mouse v2",     DeviceKind.MagicMouseV2),    // USB v2
     ];
 
     const ushort UP_VENDOR_BATTERY     = 0xFF00;

--- a/MagicMouseTray/TrayApp.cs
+++ b/MagicMouseTray/TrayApp.cs
@@ -147,6 +147,20 @@ internal sealed class TrayApp : IDisposable
         };
         menu.Items.Add(battReadItem);
 
+        // --- Third-party devices toggle (B2 experimental, default off) ---
+        var thirdPartyItem = new ToolStripMenuItem(
+            _config.EnableThirdParty ? "Third-party devices [On]" : "Third-party devices [Off]")
+        {
+            Checked = _config.EnableThirdParty
+        };
+        thirdPartyItem.Click += (_, _) =>
+        {
+            _config.SetEnableThirdParty(!_config.EnableThirdParty);
+            thirdPartyItem.Text = _config.EnableThirdParty ? "Third-party devices [On]" : "Third-party devices [Off]";
+            thirdPartyItem.Checked = _config.EnableThirdParty;
+        };
+        menu.Items.Add(thirdPartyItem);
+
         // --- Refresh Now ---
         var refresh = new ToolStripMenuItem("Refresh Now");
         refresh.Click += (_, _) => _poller.RefreshNow();

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1,0 +1,33 @@
+# Third-Party Notices
+
+MagicMouseTray is licensed under the MIT License (see `LICENSE`). This file credits
+third-party work whose *techniques* were studied and independently reimplemented in this
+project. No third-party source code was copied; only the documented protocol/technique was
+reused, and device IDs were used as numeric facts only.
+
+## HID++ 2.0 battery negotiation technique — Ithilias/logitray (MIT)
+
+The HID++ 2.0 feature-negotiation technique used by `LogitechBatteryDevice.cs` (Root feature
+lookup `0x0000`, then `BatteryStatus 0x1000` / `UnifiedBattery 0x1004` queries) was reimplemented
+in C# from the MIT-licensed project **Ithilias/logitray**. No source was copied.
+
+> NOTE (re-confirm-before-merge gate): `Ithilias/logitray` is not vendored into this repository.
+> Re-confirm its current upstream LICENSE is MIT before this B2 code is merged, and verify no
+> verbatim source comments or strings were introduced.
+
+## Device VID/PID identifiers — Linux kernel `hid-ids.h` (GPL-2.0)
+
+Apple Magic Mouse / Trackpad / Keyboard USB vendor/product IDs were taken as **numeric facts
+only** from the Linux kernel `hid-ids.h` recon catalog. Numeric identifiers are uncopyrightable
+facts (Feist v. Rural). **No kernel code, comments, macro names, or table selection/arrangement
+was copied.** All descriptor/read logic is original work or pre-existing in-repo code.
+
+## Excluded source
+
+- **gozaltech/mkBatteryChecker** — no license / all-rights-reserved. Not reusable; excluded. No
+  code or technique was taken from it.
+
+## MIT technique credits (battery read methods, host project remains MIT)
+
+- fixtan/MagicKeyBattery (MIT), hank1101444/WinMagicBattery (MIT) — Apple keyboard battery-read
+  approach informed the existing in-repo keyboard reader. Credited here per project policy.


### PR DESCRIPTION
Workstream B of the ship-prep effort. **Design peer-reviewed 3/3 before implementation.**

## What
**B1 (Apple, ship-first):** add Magic Trackpad v1/v2/v3 and Magic Mouse v2 (USB) to `KnownMice`; add 2021/2024 Magic Keyboards + true 2011 ALU PIDs to `KnownKeyboards`. Rows only — `GetBatteryPercent` is descriptor-driven, **no read-path change**. `DriverHealthChecker` now skips non-scroll Apple devices (trackpads/keyboards) so they no longer trip the false *'Unknown model' / 'scroll fix needed'* warnings (mouse `KnownPids` behavior unchanged).

**B2 (third-party, experimental, OFF by default):** `EnableThirdParty` config + tray toggle; `LogitechBatteryDevice` implements HID++ 2.0 GetStatus, reimplemented in C# from the MIT logitray technique. Receivers excluded. (Gated branch placed before the keyboard `col02` gate — Logitech paths have no `col02`, so it would otherwise be unreachable; fixed during review.)

## Licensing (peer-reviewed clean)
- Device IDs from GPL `hid-ids.h` used as **numeric facts only** (no kernel code/comments copied).
- MIT techniques (logitray / MagicKeyBattery / WinMagicBattery) reimplemented, not pasted.
- `THIRD-PARTY-NOTICES.md` added with credits + the GPL-facts-only / unlicensed-source posture.

## Verification
- Build clean (0 / 0).
- **Live on hardware:** runs; mouse 62% + keyboard 14% reads intact; `DRIVER_CHECK skip_non_scroll_apple pid=0x0239` fires and the keyboard is **no longer misflagged as an unknown Apple mouse** (the `⚠` driver warning disappears) — a real false-warning fix.
- **Code-only (no hardware):** trackpads 1/2/3, v1/v2 mice, all 2021/2024 keyboards, and all of B2 (Logitech). Additions are additive/fail-safe (a non-matching PID simply never classifies). Hardware verification pending — see THIRD-PARTY-NOTICES re-confirm gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)