### PR TITLE
feat(ui+ship): per-device driver/capability matrix + shippability polish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: release
+
+# Build, test, publish, optionally sign, and attach the single-file exe on a v* tag.
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Restore
+        run: dotnet restore MagicMouseTray/MagicMouseTray.csproj
+
+      - name: Build
+        run: dotnet build MagicMouseTray/MagicMouseTray.csproj -c Release --no-restore
+
+      # Unit tests target net8.0-windows and require the windows-latest runner (cannot run on Linux).
+      - name: Test
+        run: dotnet test MagicMouseTray.Tests/MagicMouseTray.Tests.csproj -c Release
+
+      - name: Publish (single-file, self-contained win-x64)
+        run: dotnet publish MagicMouseTray/MagicMouseTray.csproj -c Release -o publish
+
+      # Optional Authenticode signing — only runs if the cert secrets are present.
+      - name: Sign (optional)
+        if: ${{ env.SIGN_PFX_BASE64 != '' }}
+        env:
+          SIGN_PFX_BASE64: ${{ secrets.SIGN_PFX_BASE64 }}
+          SIGN_PFX_PASSWORD: ${{ secrets.SIGN_PFX_PASSWORD }}
+        shell: pwsh
+        run: |
+          [IO.File]::WriteAllBytes("$env:RUNNER_TEMP\cert.pfx", [Convert]::FromBase64String($env:SIGN_PFX_BASE64))
+          ./scripts/sign-app.ps1 -Exe publish/MagicMouseTray.exe -PfxPath "$env:RUNNER_TEMP\cert.pfx" -PfxPassword $env:SIGN_PFX_PASSWORD
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "${{ github.ref_name }}" "publish/MagicMouseTray.exe" --generate-notes

--- a/MagicMouseTray.Tests/DeviceCapabilityTests.cs
+++ b/MagicMouseTray.Tests/DeviceCapabilityTests.cs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+using MagicMouseTray;
+using Xunit;
+
+namespace MagicMouseTray.Tests;
+
+public class DeviceCapabilityTests
+{
+    static readonly DriverStatus[] AllDriverStates =
+    {
+        DriverStatus.Ok, DriverStatus.NotInstalled,
+        DriverStatus.NotBound, DriverStatus.UnknownAppleMouse,
+    };
+
+    static readonly int[] AllSentinels = { 75, 0, -2, -1 }; // >=0, edge 0, blocked, absent
+
+    // The remediation URLs the matrix is expected to point at, per DriverStatus. These are the
+    // SAME URLs used by TrayApp.BuildMenu. We assert URL-equality only — labels intentionally
+    // differ (BuildMenu prefixes "⚠ " and uses capital "Driver"); do NOT assert label equality.
+    static string ScrollFixUrl(DriverStatus d) => d switch
+    {
+        DriverStatus.UnknownAppleMouse => "https://github.com/ReviveBusiness/magic-mouse-tray/releases",
+        DriverStatus.NotBound          => "https://github.com/ReviveBusiness/magic-mouse-tray#scroll-not-working",
+        _                              => "https://github.com/tealtadpole/MagicMouse2DriversWin11x64",
+    };
+
+    [Fact]
+    public void Describe_CoversEveryCombination_WithoutThrowing()
+    {
+        foreach (DeviceKind kind in Enum.GetValues(typeof(DeviceKind)))
+            foreach (var pct in AllSentinels)
+                foreach (var drv in AllDriverStates)
+                {
+                    var row = DeviceCapability.Describe(kind, pct, drv);
+                    Assert.False(string.IsNullOrWhiteSpace(row.ReadMethod));
+                    Assert.False(string.IsNullOrWhiteSpace(row.Status));
+                    // An action with a label may or may not carry a URL (null URL = in-app action).
+                    if (row.ActionUrl is not null)
+                        Assert.NotNull(row.ActionLabel);
+                }
+    }
+
+    [Theory]
+    [InlineData(DeviceKind.MagicMouseV1)]
+    [InlineData(DeviceKind.MagicMouseV2)]
+    public void V1V2_BatteryStatus_DrivenByLastPct_NeverBlockedWhenReadable(DeviceKind kind)
+    {
+        // A readable battery (>=0) must never be reported as blocked/unreadable, regardless of driver.
+        foreach (var drv in AllDriverStates)
+        {
+            var ok = DeviceCapability.Describe(kind, 50, drv);
+            Assert.StartsWith("Battery OK", ok.Status);
+
+            // When the driver is non-Ok, the action is a SCROLL fix whose URL matches BuildMenu's.
+            if (drv != DriverStatus.Ok)
+            {
+                Assert.NotNull(ok.ActionUrl);
+                Assert.Equal(ScrollFixUrl(drv), ok.ActionUrl);
+            }
+            else
+            {
+                Assert.Null(ok.ActionUrl);
+            }
+        }
+    }
+
+    [Fact]
+    public void V3_ModeB_OffersInAppReadAction_WithNullUrl()
+    {
+        var row = DeviceCapability.Describe(DeviceKind.MagicMouseV3, -2, DriverStatus.Ok);
+        Assert.Equal("Read Battery Now", row.ActionLabel);
+        Assert.Null(row.ActionUrl); // in-app action, not a link
+    }
+
+    [Fact]
+    public void V3_ReadOk_HasNoAction()
+    {
+        var row = DeviceCapability.Describe(DeviceKind.MagicMouseV3, 88, DriverStatus.Ok);
+        Assert.Null(row.ActionLabel);
+        Assert.Null(row.ActionUrl);
+    }
+
+    [Fact]
+    public void Keyboard_Unpatched_LinksToPatchDoc()
+    {
+        var row = DeviceCapability.Describe(DeviceKind.MagicKeyboard, -2, DriverStatus.Ok);
+        Assert.Equal("Needs SDP-cache patch", row.Status);
+        Assert.Equal("https://github.com/ReviveBusiness/magic-mouse-tray#keyboard-battery-patch", row.ActionUrl);
+    }
+
+    [Fact]
+    public void Keyboard_Patched_IsOk_NoAction()
+    {
+        var row = DeviceCapability.Describe(DeviceKind.MagicKeyboard, 60, DriverStatus.Ok);
+        Assert.Equal("OK", row.Status);
+        Assert.Null(row.ActionLabel);
+    }
+
+    [Fact]
+    public void Mouse_NonOkDriver_ActionUrl_MatchesBuildMenuUrls()
+    {
+        // URL parity with the top-level driver warning, asserted for v1/v2 Mode-A reads.
+        foreach (var drv in new[] { DriverStatus.NotInstalled, DriverStatus.NotBound, DriverStatus.UnknownAppleMouse })
+        {
+            var row = DeviceCapability.Describe(DeviceKind.MagicMouseV1, -1, drv);
+            Assert.Equal(ScrollFixUrl(drv), row.ActionUrl);
+        }
+    }
+}

--- a/MagicMouseTray.Tests/KindForNameTests.cs
+++ b/MagicMouseTray.Tests/KindForNameTests.cs
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+using System.Linq;
+using MagicMouseTray;
+using Xunit;
+
+namespace MagicMouseTray.Tests;
+
+public class KindForNameTests
+{
+    [Fact]
+    public void AllKnownMouseNames_ResolveToTheirKind()
+    {
+        foreach (var m in MouseBatteryDevice.KnownMice)
+            Assert.Equal(m.Kind, DeviceCapability.KindForName(m.DisplayName));
+    }
+
+    [Fact]
+    public void AllKnownKeyboardNames_ResolveToMagicKeyboard()
+    {
+        foreach (var k in KeyboardBatteryDevice.KnownKeyboards)
+            Assert.Equal(DeviceKind.MagicKeyboard, DeviceCapability.KindForName(k.DisplayName));
+    }
+
+    [Fact]
+    public void TenDistinctDisplayNames_AllResolve()
+    {
+        // 4 mouse entries (two "Magic Mouse 2024" share one name) + 7 keyboards = 10 distinct names.
+        var names = MouseBatteryDevice.KnownMice.Select(m => m.DisplayName)
+            .Concat(KeyboardBatteryDevice.KnownKeyboards.Select(k => k.DisplayName))
+            .Distinct(System.StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        Assert.Equal(10, names.Count);
+        Assert.All(names, n => Assert.NotNull(DeviceCapability.KindForName(n)));
+    }
+
+    [Fact]
+    public void UnknownName_ReturnsNull()
+    {
+        Assert.Null(DeviceCapability.KindForName("Logitech MX Master"));
+        Assert.Null(DeviceCapability.KindForName(""));
+    }
+}

--- a/MagicMouseTray.Tests/MagicMouseTray.Tests.csproj
+++ b/MagicMouseTray.Tests/MagicMouseTray.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Must match the referenced desktop project's TFM; runs on windows-latest in CI,
+         NOT on Linux/WSL (the app's desktop TFM precludes Linux execution). -->
+    <TargetFramework>net8.0-windows10.0.17763.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MagicMouseTray\MagicMouseTray.csproj" />
+  </ItemGroup>
+</Project>

--- a/MagicMouseTray/App.xaml.cs
+++ b/MagicMouseTray/App.xaml.cs
@@ -6,10 +6,24 @@ namespace MagicMouseTray;
 public partial class App
 {
     TrayApp? _trayApp;
+    static Mutex? _instanceMutex;
+    static bool _ownsMutex;
 
     protected override void OnStartup(StartupEventArgs e)
     {
         base.OnStartup(e);
+
+        // Single-instance guard: a second launch would create a competing V3RecycleManager
+        // racing on C:\mm-dev-queue\request.txt. Local\ scope is correct for a per-user tray app.
+        _instanceMutex = new Mutex(initiallyOwned: true, @"Local\MagicMouseTray.SingleInstance", out _ownsMutex);
+        if (!_ownsMutex)
+        {
+            _instanceMutex.Dispose();   // not owned — release handle, do NOT ReleaseMutex
+            _instanceMutex = null;
+            Shutdown();
+            return;                      // second instance exits silently
+        }
+
         ShutdownMode = ShutdownMode.OnExplicitShutdown;
         _trayApp = new TrayApp(Config.Load());
     }
@@ -17,6 +31,11 @@ public partial class App
     protected override void OnExit(ExitEventArgs e)
     {
         _trayApp?.Dispose();
+        if (_ownsMutex)                  // only the owner releases + disposes
+        {
+            _instanceMutex?.ReleaseMutex();
+            _instanceMutex?.Dispose();
+        }
         base.OnExit(e);
     }
 }

--- a/MagicMouseTray/DeviceCapability.cs
+++ b/MagicMouseTray/DeviceCapability.cs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+namespace MagicMouseTray;
+
+// Derives the per-device read-path + remediation row for the capability matrix.
+// Pure function of (Kind, last battery sentinel, driver status) — no I/O.
+// Read paths are deterministic per DeviceKind; the last reading distinguishes
+// "working" (>=0) from "present but blocked" (-2) from "not readable/absent" (-1).
+//
+// CAVEAT (RULE #1): DriverStatus from DriverHealthChecker.GetStatus() is a single
+// GLOBAL worst-state-wins value (DriverHealthChecker.cs:114-126), not per-device.
+// With multiple Apple mice paired, one device's worst state colors every mouse row.
+// Acceptable as a heuristic. The scroll filter governs SCROLL, not the v1/v2 split
+// battery read, so a non-Ok driver does NOT mean the v1/v2 battery is unreadable —
+// the action below is a scroll-fix, not a battery-fix.
+internal static class DeviceCapability
+{
+    internal readonly record struct Row(
+        string ReadMethod,    // e.g. "Split-vendor 0x90 (Mode A)"
+        string Status,        // e.g. "Battery OK", "Mode B — battery N/A", "Needs SDP-cache patch"
+        string? ActionLabel,  // null = no action; else a clickable menu-item label
+        string? ActionUrl);   // doc/remediation URL for ActionLabel (null = in-app action)
+
+    // Map a device display name back to its Kind without changing the event signature.
+    // NOTE: both "Magic Mouse 2024" KnownMice entries share one display name -> 10 distinct names.
+    internal static DeviceKind? KindForName(string name)
+    {
+        foreach (var m in MouseBatteryDevice.KnownMice)
+            if (string.Equals(m.DisplayName, name, StringComparison.OrdinalIgnoreCase))
+                return m.Kind;
+        foreach (var k in KeyboardBatteryDevice.KnownKeyboards)
+            if (string.Equals(k.DisplayName, name, StringComparison.OrdinalIgnoreCase))
+                return DeviceKind.MagicKeyboard;
+        return null;
+    }
+
+    // Scroll-driver remediation copy for the matrix dropdown. The URLs are kept identical
+    // to TrayApp.BuildMenu (:116-127) so the matrix and the top-level driver warning point
+    // at the SAME remediation target. Labels intentionally DIFFER from BuildMenu: the
+    // top-level item is "⚠ "-prefixed (e.g. "⚠ Install Apple Driver (scroll fix)") and uses
+    // a capital "Driver"; nested in the matrix the ⚠ glyph is dropped. Do NOT assert label
+    // equality between the two — only URL equality (see MagicMouseTray.Tests).
+    static (string Label, string Url) ScrollFix(DriverStatus d) => d switch
+    {
+        DriverStatus.UnknownAppleMouse =>
+            ("Unknown mouse model — check for app update",
+             "https://github.com/ReviveBusiness/magic-mouse-tray/releases"),
+        DriverStatus.NotBound =>
+            ("Driver not bound — scroll fix needed",
+             "https://github.com/ReviveBusiness/magic-mouse-tray#scroll-not-working"),
+        _ => // NotInstalled (and any non-Ok fallthrough)
+            ("Install Apple driver (scroll fix)",
+             "https://github.com/tealtadpole/MagicMouse2DriversWin11x64"),
+    };
+
+    const string KbPatchAnchor   = "https://github.com/ReviveBusiness/magic-mouse-tray#keyboard-battery-patch";
+    const string ScrollFixAnchor = "https://github.com/ReviveBusiness/magic-mouse-tray#scroll-not-working";
+
+    internal static Row Describe(DeviceKind kind, int lastPct, DriverStatus driver)
+    {
+        switch (kind)
+        {
+            case DeviceKind.MagicMouseV1:
+            case DeviceKind.MagicMouseV2:
+                // Split-vendor 0x90 read works in Mode A regardless of the scroll filter.
+                // Battery Status reflects the reading; any driver action is a SCROLL fix.
+                if (driver != DriverStatus.Ok)
+                {
+                    var (lbl, url) = ScrollFix(driver);
+                    return new("Split-vendor 0x90 (Mode A)",
+                               lastPct >= 0 ? "Battery OK — scroll driver needs attention"
+                                            : "No reading; scroll driver needs attention",
+                               lbl, url);
+                }
+                return new("Split-vendor 0x90 (Mode A)",
+                           lastPct >= 0 ? "Battery OK" : "No reading", null, null);
+
+            case DeviceKind.MagicMouseV3:
+                // v3 IS coupled to the filter: PATH-B recycle does FLIP:NoFilter -> read ->
+                // FLIP:AppleFilter, which needs applewirelessmouse present for Mode B restore.
+                if (lastPct >= 0)
+                    return new("Split-vendor 0x90 via PATH-B recycle",
+                               "Battery read OK (reverts to Mode B between reads)", null, null);
+                if (lastPct == -2)
+                {
+                    // Mode B: battery N/A until the next idle-gated recycle.
+                    if (driver != DriverStatus.Ok)
+                    {
+                        var (lbl, url) = ScrollFix(driver);
+                        return new("Unified Feature 0x47 (blocked by Apple driver)",
+                                   "Mode B — recycle needs the Apple scroll driver", lbl, url);
+                    }
+                    return new("Unified Feature 0x47 (blocked by Apple driver)",
+                               "Mode B — battery N/A until next read",
+                               "Read Battery Now", null); // in-app: V3RecycleManager.ForceReadNowAsync
+                }
+                return new("Split-vendor 0x90 via PATH-B recycle",
+                           "No reading — check driver/pairing", "Scroll/driver help", ScrollFixAnchor);
+
+            case DeviceKind.MagicKeyboard:
+                // ACTIVE-READ target: -2 means "present but Feature 0x47 cap absent"
+                // (unpatched or patch erased by re-pair) — KeyboardBatteryDevice.cs:122-127,138-139.
+                if (lastPct >= 0)
+                    return new("Feature 0x47 (after SDP-cache patch)", "OK", null, null);
+                if (lastPct == -2)
+                    return new("Feature 0x47 (Input-only until SDP-cache patch)",
+                               "Needs SDP-cache patch",
+                               "How to enable keyboard battery", KbPatchAnchor);
+                return new("Feature 0x47 (after SDP-cache patch)",
+                           "No reading (open/driver failure)", null, null);
+
+            default:
+                return new("Unknown", "Unsupported device", null, null);
+        }
+    }
+}

--- a/MagicMouseTray/KeyboardBatteryDevice.cs
+++ b/MagicMouseTray/KeyboardBatteryDevice.cs
@@ -18,7 +18,9 @@
 //   This is an active synchronous read on col02; DeviceRegistry.Discover() hands us the col02
 //   interface path and creates a fresh instance per poll, so no caching/monitor thread is needed.
 //   When the patch is absent (e.g. erased by a re-pair) the Feature cap is missing and we return
-//   -2 ("present but blocked") so the tray can trigger a re-patch (see M-KB3).
+//   -2 ("present but blocked"). The tray surfaces a how-to link to the patch instructions
+//   (DeviceCapability.KbPatchAnchor); auto-patch is NOT wired (the patch needs admin and there
+//   is no installed scheduled task for it, unlike MM-Dev-Cycle for the mouse flip).
 
 using System.Runtime.InteropServices;
 

--- a/MagicMouseTray/MagicMouseTray.csproj
+++ b/MagicMouseTray/MagicMouseTray.csproj
@@ -15,10 +15,12 @@
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <!-- Allows building on non-Windows (e.g. restoring packages) -->
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <Version>1.0.0</Version>
+    <AssemblyVersion>1.0.0.0</AssemblyVersion>
+    <FileVersion>1.0.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
-    <!-- HID device enumeration and handle management -->
-    <PackageReference Include="HidLibrary" Version="3.3.40" />
+    <InternalsVisibleTo Include="MagicMouseTray.Tests" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="magic-mouse.png" />

--- a/MagicMouseTray/TrayApp.cs
+++ b/MagicMouseTray/TrayApp.cs
@@ -32,7 +32,8 @@ internal sealed class TrayApp : IDisposable
     // Persistent critical alert shown at 1%; auto-closed when mouse unplugs.
     CriticalAlert? _criticalAlert;
 
-    readonly DriverStatus _driverStatus;
+    // Not readonly: recomputed on menu Opening so a just-applied driver fix shows without restart.
+    DriverStatus _driverStatus;
     readonly V3RecycleManager _recycleManager;
 
     Icon? _currentIcon;
@@ -75,6 +76,10 @@ internal sealed class TrayApp : IDisposable
         out ToolStripMenuItem startupItem)
     {
         var menu = new ContextMenuStrip();
+
+        // Recompute driver status + rebuild the matrix on every open so a just-applied
+        // driver fix shows without restart. GetStatus() is registry-only and fast.
+        menu.Opening += (_, _) => { _driverStatus = DriverHealthChecker.GetStatus(); UpdateDeviceMenuItems(); };
 
         // --- Device battery status (dynamically updated) ---
         _deviceSection = new ToolStripMenuItem("Devices") { Enabled = false };
@@ -152,29 +157,31 @@ internal sealed class TrayApp : IDisposable
         refresh.Click += (_, _) => _poller.RefreshNow();
         menu.Items.Add(refresh);
 
+        // --- Diagnostics (debug surface). The v3 "Read Battery Now" action is also
+        //     surfaced contextually in the per-device matrix dropdown. ---
+        var diagnostics = new ToolStripMenuItem("Diagnostics");
+
         var readNow = new ToolStripMenuItem("Read Battery Now");
         readNow.Click += (_, _) => _ = _recycleManager.ForceReadNowAsync();
-        menu.Items.Add(readNow);
+        diagnostics.DropDownItems.Add(readNow);
 
-        // --- Test Notification (debug only) ---
         var testToast = new ToolStripMenuItem("Test Notification");
         testToast.Click += (_, _) =>
         {
             var (name, pct) = _deviceBatteries.FirstOrDefault(kv => kv.Value >= 0);
             ToastNotifier.Show(pct >= 0 ? pct : 15, name?.Length > 0 ? name : "Magic Mouse");
         };
-        menu.Items.Add(testToast);
+        diagnostics.DropDownItems.Add(testToast);
 
-        menu.Items.Add(new ToolStripSeparator());
-
-        // --- Diagnostics ---
         var openLogs = new ToolStripMenuItem("Open Logs");
         openLogs.Click += (_, _) => OpenLogsInEditor();
-        menu.Items.Add(openLogs);
+        diagnostics.DropDownItems.Add(openLogs);
 
         var openDiagFolder = new ToolStripMenuItem("Open Diagnostics Folder");
         openDiagFolder.Click += (_, _) => OpenDiagnosticsFolder();
-        menu.Items.Add(openDiagFolder);
+        diagnostics.DropDownItems.Add(openDiagFolder);
+
+        menu.Items.Add(diagnostics);
 
         menu.Items.Add(new ToolStripSeparator());
 
@@ -372,8 +379,22 @@ internal sealed class TrayApp : IDisposable
         if (_deviceBatteries.Count == 0)
         {
             _deviceSection.Text = "No devices detected";
+            // Empty-state guidance (non-clickable child hint).
+            _deviceSection.Enabled = true; // enable so the hint dropdown is reachable
+            _deviceSection.DropDownItems.Clear();
+            _deviceSection.DropDownItems.Add(new ToolStripMenuItem(
+                "Pair a Magic Mouse/Keyboard via Bluetooth, then Refresh Now") { Enabled = false });
+            // Drop any stale per-device rows
+            foreach (var key in _deviceMenuItems.Keys.ToList())
+            {
+                _tray.ContextMenuStrip?.Items.Remove(_deviceMenuItems[key]);
+                _deviceMenuItems.Remove(key);
+            }
             return;
         }
+
+        _deviceSection.Enabled = false;
+        _deviceSection.DropDownItems.Clear();
 
         foreach (var kv in _deviceBatteries)
         {
@@ -389,7 +410,7 @@ internal sealed class TrayApp : IDisposable
 
             if (!_deviceMenuItems.TryGetValue(kv.Key, out var item))
             {
-                item = new ToolStripMenuItem(label) { Enabled = false };
+                item = new ToolStripMenuItem(label);   // enabled — carries the matrix dropdown
                 _deviceMenuItems[kv.Key] = item;
                 // Insert before the separator that follows the device section
                 var sepIdx = _tray.ContextMenuStrip!.Items.IndexOf(_deviceSection) + 1;
@@ -398,6 +419,34 @@ internal sealed class TrayApp : IDisposable
             else
             {
                 item.Text = label;
+            }
+
+            // Capability matrix dropdown for this device.
+            item.DropDownItems.Clear();
+            var knd = DeviceCapability.KindForName(kv.Key);
+            if (knd is { } k)
+            {
+                var row = DeviceCapability.Describe(k, kv.Value, _driverStatus);
+                item.DropDownItems.Add(new ToolStripMenuItem($"Read method: {row.ReadMethod}") { Enabled = false });
+                item.DropDownItems.Add(new ToolStripMenuItem($"Status: {row.Status}") { Enabled = false });
+                if (row.ActionLabel is { } al)
+                {
+                    var action = new ToolStripMenuItem(al) { ForeColor = System.Drawing.Color.OrangeRed };
+                    if (row.ActionUrl is { } url)
+                        action.Click += (_, _) => System.Diagnostics.Process.Start(
+                            new System.Diagnostics.ProcessStartInfo(url) { UseShellExecute = true });
+                    else // in-app action (today only v3 "Read Battery Now")
+                    {
+                        // ForceReadNowAsync runs the FLIP cycle unconditionally, so if Battery
+                        // Reads is Off or recycle auto-disabled it would no-op/RecordFailure
+                        // silently. Gate the action on the live recycle state.
+                        bool canRead = _config.EnableV3Recycle && !_recycleManager.AutoDisabled;
+                        action.Enabled = canRead;
+                        if (canRead) action.Click += (_, _) => _ = _recycleManager.ForceReadNowAsync();
+                        else action.Text = al + " (enable Battery Reads first)";
+                    }
+                    item.DropDownItems.Add(action);
+                }
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Apple Magic Mouse on Windows 11 has no native battery indicator. Magic Mouse Uti
 | Magic Mouse v1 (AA battery) | 0x030D | ✅ Confirmed |
 | Magic Mouse v2 | 0x0269 | ⚠ Included, not tested (device not available) |
 
+## Supported Keyboards
+
+Keyboard battery requires a one-time SDP-cache patch (see [Keyboard battery patch](#keyboard-battery-patch)).
+
+| Model | Bluetooth PID | Status |
+|-------|--------------|--------|
+| Apple Wireless Keyboard (2011, A1314) ANSI/ISO/JIS | 0x0239 / 0x023A / 0x023B | ✅ Confirmed |
+| Magic Keyboard (A1644) / ISO | 0x024F / 0x0250 | ⚠ Included, not tested (device not available) |
+| Magic Keyboard with Touch ID (A2449) / ISO | 0x0267 / 0x026C | ⚠ Included, not tested (device not available) |
+
 ## Install
 
 1. Download `MagicMouseTray.exe` from [Releases](../../releases)
@@ -69,14 +79,45 @@ bcdedit /set testsigning off
 ```
 > Note: re-enabling test signing is required if you ever need to reinstall the driver.
 
+### Magic Mouse 2024 (v3) — brief scroll interruption during battery reads
+
+The 2024 Magic Mouse exposes battery only through a unified Feature report that the Apple
+driver blocks (Mode B). To read it, the app momentarily flips the device to the legacy
+split-report mode (Mode A), reads, then flips back. Each scheduled read is **idle-gated** —
+the app waits for the cursor to be idle for ≥30 seconds before flipping — so the brief scroll
+interruption happens during the idle window, not mid-scroll. The exception is the manual
+**Diagnostics → Read Battery Now** (and the per-device matrix "Read Battery Now") action,
+which bypasses the idle wait and can therefore interrupt an active scroll.
+
+## Keyboard battery patch
+
+Apple wireless keyboards declare their battery report as Input-only in the native HID
+descriptor, so Windows cannot read it (the device only pushes on Bluetooth connect). The
+one-time fix patches the Bluetooth SDP cache (`HKLM\...\BTHPORT\Parameters\Devices\<MAC>`)
+to expose the battery report as a readable *Feature* report.
+
+**Fix** (one-time, requires admin):
+
+```powershell
+# Elevated PowerShell:
+.\scripts\kbd-patch-cachedservices.ps1
+```
+
+The script backs up the existing SDP blobs before modifying them. **Re-pairing the keyboard
+erases the patch** — re-run the script if you remove and re-add the keyboard. Until the patch
+is applied, the tray shows **Needs SDP-cache patch** in the keyboard's matrix dropdown, linking
+back to this section.
+
 ## Right-Click Menu
 
 | Item | What it does |
 |------|-------------|
+| Devices → *(per device)* | Each detected device expands to a capability matrix: read method, status, and a context action (e.g. "Read Battery Now" for a v3 in Mode B, "Needs SDP-cache patch" for an unpatched keyboard) |
 | Low Battery Threshold | Set alert level: 10 / 15 / 20 / 25% |
 | Start with Windows | Toggle auto-start on login |
+| Battery Reads [On/Off] | Toggle the v3 Mode-A recycle that reads the 2024 mouse battery |
 | Refresh Now | Force an immediate battery read |
-| Test Notification | Send a test toast (debug) |
+| Diagnostics | Submenu: Read Battery Now, Test Notification (debug toast), Open Logs, Open Diagnostics Folder |
 | ⚠ Install Apple Driver | Opens driver download (shown if driver missing) |
 | ⚠ Driver not bound — scroll fix needed | Opens this README's scroll fix section (driver installed but not bound) |
 | ⚠ Unknown mouse model — check for app update | Opens Releases page (future Apple mouse with unknown PID) |
@@ -114,6 +155,14 @@ Key log lines:
 - `DRIVER_CHECK unknown_apple_pid=0xXXXX` — future/unknown Apple mouse PID detected
 - `TOAST_SENT` — notification fired
 - `CRITICAL_ALERT_SHOWN` — 1% persistent window shown
+
+## Releases & versioning
+
+Releases are built by CI on a `v*` tag (`.github/workflows/release.yml`): the workflow builds,
+runs the unit tests on a `windows-latest` runner, publishes the single-file `win-x64` exe,
+optionally Authenticode-signs it (if cert secrets are configured), and attaches it to a GitHub
+release. The build stamps `FileVersion`/`AssemblyVersion` (currently `1.0.0.0`), visible via the
+exe's Properties → Details tab.
 
 ## License
 

--- a/scripts/sign-app.ps1
+++ b/scripts/sign-app.ps1
@@ -1,0 +1,22 @@
+#Requires -Version 5
+# Authenticode-sign the published MagicMouseTray.exe (post-publish step).
+# Honest note: a self-signed cert does NOT clear SmartScreen reputation — only a publicly
+# trusted OV/EV code-signing cert builds reputation. Until one is procured, signing reduces
+# but does not eliminate the SmartScreen prompt the README documents.
+param(
+    [Parameter(Mandatory)][string]$Exe,
+    [Parameter(Mandatory)][string]$PfxPath,
+    [Parameter(Mandatory)][string]$PfxPassword,
+    [string]$TimestampUrl = 'http://timestamp.digicert.com')
+
+# signtool.exe is NOT on PATH on windows-latest runners or typical shells — resolve it
+# explicitly from the Windows 10 SDK bin directory (newest version wins).
+$signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\signtool.exe" -ErrorAction SilentlyContinue |
+            Sort-Object FullName -Descending | Select-Object -First 1
+if (-not $signtool) { throw "signtool.exe not found — install the Windows 10 SDK (or add a setup step in CI)." }
+
+& $signtool.FullName sign /f $PfxPath /p $PfxPassword /fd SHA256 /tr $TimestampUrl /td SHA256 $Exe
+if ($LASTEXITCODE -ne 0) { throw "signtool sign failed ($LASTEXITCODE)" }
+
+& $signtool.FullName verify /pa $Exe
+if ($LASTEXITCODE -ne 0) { throw "signtool verify failed ($LASTEXITCODE)" }


### PR DESCRIPTION
Workstream A of the ship-prep effort. **Design peer-reviewed (2/3; lone objection was a label-equality nit, fixed) before implementation.**

## What
**Driver/capability matrix:** new `DeviceCapability.cs` maps `(DeviceKind, lastPct, DriverStatus)` → a per-device row describing the **read path + driver/remediation**, surfaced as enabled per-device dropdowns in the tray menu. Users can see which read-path/driver each device uses — Magic Mouse v1–v3 differ by installed driver; keyboard shows *'Needs SDP-cache patch'* vs *OK*. `menu.Opening` recomputes `DriverStatus` and rebuilds the matrix. Diagnostics actions demoted to a submenu; empty-state hint; v3 'Read Battery Now' gated.

**Shippability polish:**
- Single-instance `Mutex` (`Local\MagicMouseTray.SingleInstance`) with an `_ownsMutex` guard so a second instance never `ReleaseMutex()`es a non-owned handle (peer-review fix).
- Assembly `Version` 1.0.0; removed unused `HidLibrary` reference.
- `scripts/sign-app.ps1` resolves `signtool` from the Windows SDK glob (peer-review fix — not assumed on PATH).
- `.github/workflows/release.yml`: build → test → publish → optional sign → `gh release create` on `windows-latest`.
- README: supported-keyboards table, patch how-to, versioning notes.

**Driver-warning labels:** URLs kept identical to `TrayApp.BuildMenu`; labels intentionally differ (BuildMenu prefixes the warning glyph). Tests assert URL-equality only.

## Verification
- Build clean (0 / 0); new `MagicMouseTray.Tests` (net8.0-windows) — **12 pass**, covering the matrix across Kind × sentinel × DriverStatus and `KindForName`.
- **Live on hardware:** runs; mouse 62% + keyboard 14% surfaced; single-instance mutex + menu rebuild don't break startup.
- **Code-only:** v1/v2 mouse rows, Magic Keyboard variants, the `UnknownAppleMouse`/`NotBound`/`NotInstalled` mappings, Authenticode trust/SmartScreen reputation (needs OV/EV cert), and release.yml on a clean machine.

Installer intentionally out of scope (single-exe distribution). Branches off merged main (post v3-fix #55).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
