### PR TITLE
feat(tray-ui): per-device v3 driver badge, scoped warning banner, conditional Battery Reads (#68)

### DIFF
--- a/.ai/validators/adr-number-check.py
+++ b/.ai/validators/adr-number-check.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""ADR numbering + index verifier (issue #78).
+
+Binary, dependency-free gate over ``design/adr/``. Exits non-zero unless every
+one of these holds:
+
+  1. **Unique numbers** — no two ADR files share an ``ADR-NNNN`` prefix.
+     (``main`` carried three files all claiming ``ADR-0004``; that is what this
+     check exists to stop recurring.)
+  2. **Well-formed names** — every ``.md`` in the directory except ``README.md``
+     matches ``ADR-NNNN-<slug>.md``.
+  3. **Header agrees with filename** — the file's first ``# ADR-NNNN`` heading
+     carries the same number as its filename. Catches a half-finished renumber.
+  4. **Listed in the index** — every ADR file is linked from the ``## Index``
+     table of ``design/adr/README.md``.
+  5. **No dangling index rows** — every file an index row links to exists.
+
+The root cause of #78 was that ADR numbers are allocated at authoring time on
+long-lived branches and reconciled "at merge" by a human step that never ran.
+This validator replaces that step: it is deterministic, so it can run in the
+pre-PR gate and simply refuse the collision.
+
+Usage:
+    python3 .ai/validators/adr-number-check.py                 # repo default dir
+    python3 .ai/validators/adr-number-check.py --adr-dir DIR
+    python3 .ai/validators/adr-number-check.py --next          # next free number
+
+Importable (hyphenated file — see tests/conftest.py):
+    errors = adr_number_check.check_adr_numbering(Path("design/adr"))  # [] == clean
+
+Exit codes: 0 = clean, 1 = one or more violations, 2 = usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# ``ADR-0004-resource-finops-governance.md``
+_FILENAME_RE = re.compile(r"^ADR-(\d{4})-(.+)\.md$")
+
+# First markdown H1 of an ADR: ``# ADR-0004 — Title``
+_HEADING_RE = re.compile(r"^#\s+ADR-(\d{4})\b", re.MULTILINE)
+
+# A markdown link in the index whose target is an ADR file:
+# ``[ADR-0004](ADR-0004-resource-finops-governance.md)``
+_INDEX_LINK_RE = re.compile(r"\]\((ADR-\d{4}-[^)]+\.md)\)")
+
+INDEX_FILENAME = "README.md"
+_INDEX_HEADING_RE = re.compile(r"^##+\s+Index\s*$", re.MULTILINE)
+
+
+def default_adr_dir() -> Path:
+    """``design/adr`` relative to the repo root that contains this validator."""
+    return Path(__file__).resolve().parents[2] / "design" / "adr"
+
+
+def adr_files(adr_dir: Path) -> list[Path]:
+    """Every ``ADR-NNNN-<slug>.md`` in ``adr_dir``, sorted by name."""
+    return sorted(
+        p
+        for p in adr_dir.glob("ADR-*.md")
+        if p.is_file() and _FILENAME_RE.match(p.name)
+    )
+
+
+def _index_section(adr_dir: Path) -> str | None:
+    """Text of the index README from its ``## Index`` heading onward.
+
+    Returns ``None`` when the README is absent — the caller turns that into a
+    fail-closed error rather than a silent pass. Falls back to the whole file
+    when there is no ``## Index`` heading, so a reformatted README degrades to a
+    weaker check instead of a false failure.
+    """
+    index = adr_dir / INDEX_FILENAME
+    if not index.is_file():
+        return None
+    text = index.read_text(encoding="utf-8")
+    match = _INDEX_HEADING_RE.search(text)
+    return text[match.start() :] if match else text
+
+
+def next_free_number(adr_dir: Path) -> int:
+    """Lowest number strictly greater than every number in use.
+
+    ADR numbers are append-only — gaps are history (a superseded or renumbered
+    ADR), never a free slot to recycle.
+    """
+    used = [int(m.group(1)) for p in adr_files(adr_dir) if (m := _FILENAME_RE.match(p.name))]
+    return max(used) + 1 if used else 1
+
+
+def check_adr_numbering(adr_dir: Path) -> list[str]:
+    """Return a list of violations; empty list means compliant."""
+    errors: list[str] = []
+
+    if not adr_dir.is_dir():
+        return [f"ADR directory not found: {adr_dir} — cannot verify, blocking"]
+
+    # (2) Well-formed filenames.
+    for path in sorted(adr_dir.glob("*.md")):
+        if path.name == INDEX_FILENAME:
+            continue
+        if not _FILENAME_RE.match(path.name):
+            errors.append(
+                f"{path.name}: malformed ADR filename — expected ADR-NNNN-<slug>.md"
+            )
+
+    files = adr_files(adr_dir)
+
+    # (1) Unique numbers.
+    by_number: dict[str, list[str]] = defaultdict(list)
+    for path in files:
+        match = _FILENAME_RE.match(path.name)
+        assert match is not None  # guaranteed by adr_files()
+        by_number[match.group(1)].append(path.name)
+    for number, names in sorted(by_number.items()):
+        if len(names) > 1:
+            errors.append(
+                f"duplicate ADR number ADR-{number} claimed by {len(names)} files: "
+                + ", ".join(sorted(names))
+                + " — renumber all but one to the next free number "
+                f"(ADR-{next_free_number(adr_dir):04d})"
+            )
+
+    # (3) Heading agrees with filename.
+    for path in files:
+        match = _FILENAME_RE.match(path.name)
+        assert match is not None
+        file_number = match.group(1)
+        heading = _HEADING_RE.search(path.read_text(encoding="utf-8"))
+        if heading is None:
+            errors.append(f"{path.name}: no '# ADR-NNNN ...' heading found")
+        elif heading.group(1) != file_number:
+            errors.append(
+                f"{path.name}: heading says ADR-{heading.group(1)} but the filename "
+                f"says ADR-{file_number} — half-finished renumber"
+            )
+
+    # (4)/(5) Index coverage, both directions.
+    index_text = _index_section(adr_dir)
+    if index_text is None:
+        errors.append(
+            f"ADR index missing at {adr_dir / INDEX_FILENAME} — cannot verify, blocking"
+        )
+        return errors
+
+    linked = set(_INDEX_LINK_RE.findall(index_text))
+    for path in files:
+        if path.name not in linked:
+            errors.append(
+                f"{path.name}: not listed in {INDEX_FILENAME} — add its row to the "
+                "## Index table in the same commit that adds the ADR"
+            )
+    for name in sorted(linked):
+        if not (adr_dir / name).is_file():
+            errors.append(
+                f"{INDEX_FILENAME}: index row links {name}, which does not exist"
+            )
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify ADR numbers are unique and the index is complete (#78)."
+    )
+    parser.add_argument(
+        "--adr-dir",
+        type=Path,
+        default=None,
+        help="ADR directory to check (default: <repo>/design/adr)",
+    )
+    parser.add_argument(
+        "--next",
+        action="store_true",
+        help="print the next free ADR number (e.g. ADR-0015) and exit 0",
+    )
+    args = parser.parse_args(argv)
+
+    adr_dir = args.adr_dir or default_adr_dir()
+
+    if args.next:
+        if not adr_dir.is_dir():
+            print(f"ERROR: ADR directory not found: {adr_dir}", file=sys.stderr)
+            return 2
+        print(f"ADR-{next_free_number(adr_dir):04d}")
+        return 0
+
+    errors = check_adr_numbering(adr_dir)
+    if errors:
+        print(f"FAIL: ADR numbering/index violations in {adr_dir} (#78):", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print(f"PASS: {len(adr_files(adr_dir))} ADRs, unique numbers, index complete")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.ai/validators/pr-admission-check.py
+++ b/.ai/validators/pr-admission-check.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Unfiled-admission gate for PR bodies (issue #38).
+
+Binary, dependency-free gate. Given a PR body (via ``--body-file`` or stdin),
+exits non-zero when the body **admits a defect but does not file it**.
+
+The failure this exists to stop
+------------------------------
+An agent discovers a real defect, writes it down in the PR body — "flagged, not
+fixed", "out of scope here", "reconciling the validator's scope is a follow-up"
+— and it never becomes a GitHub issue. The finding survives only as long as
+someone re-reads that PR body. Measured on this repo's own history, several
+genuine defects were disclosed exactly this way and were never tracked.
+
+The rule
+--------
+An admission phrase must be **accompanied by an issue reference** (``#NNN``)
+somewhere in its own markdown section. Section scope — not line scope — is
+deliberate: bodies legitimately write the admission as a bullet and the issue
+number a line or two away, and a line-scoped rule would cry wolf on every one of
+them. A gate that cries wolf gets disabled.
+
+What is deliberately NOT an admission
+-------------------------------------
+Tuned against the 75 real PR bodies in this repo (see ``## Tuning`` in the PR).
+These carve-outs are each an observed false positive, not speculation:
+
+* **Fenced code blocks** — a diff quoting a source ``# TODO`` is not a claim
+  about this PR. Line numbering is preserved when they are stripped.
+* **Headings** — ``## Follow-ups`` is structure, not a confession.
+* **Blockquotes** — quoted issue text or a quoted execution prompt.
+* **The plural "follow-ups"** — always the section name. The singular
+  ("is a follow-up") is the admission form.
+* **Negated forms** — "no known issue", "not prose TODOs", "none applicable".
+* **Deictic cross-references** — "filed as a follow-up **below**", "see above".
+  The body IS filing it; the number just lives in another section.
+
+Usage:
+    python3 .ai/validators/pr-admission-check.py --body-file pr-body.md
+    gh pr view N --json body -q .body | python3 .ai/validators/pr-admission-check.py
+
+Importable (hyphenated file — see tests/conftest.py):
+    errors = pr_admission_check.check_admissions(body)   # [] == compliant
+
+Exit codes: 0 = compliant, 1 = one or more unfiled admissions, 2 = usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+# The admission vocabulary. Every alternative here is a phrase an agent actually
+# uses when conceding a defect it is not fixing in this PR.
+#
+# ``follow[-\s]?up(?!s)`` — singular only. "Follow-ups" (plural) is the name of
+# the mandated PR-body section (pr-body-check.py check 5) and appears in
+# virtually every compliant body; matching it would flag nearly the whole repo.
+_ADMISSION_RE = re.compile(
+    r"""(
+        not\s+fixed
+      | out\s+of\s+scope
+      | left\s+alone
+      | known\s+(?:issue|bug|defect|problem)
+      | \bTODO\b
+      | follow[-\s]?up(?!s)
+      | separate\s+issue
+      | separately\s+tracked
+      | worth\s+a\s+look\s+separately
+    )""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_ISSUE_RE = re.compile(r"#\d+")
+
+# A negation immediately preceding the phrase inverts it: "no known issue",
+# "none applicable", "not prose TODOs". Bounded to 40 characters and to the same
+# sentence (no ``.`` in between) so it cannot swallow an unrelated earlier "not".
+_NEGATION_RE = re.compile(
+    r"\b(?:no|none|zero|not|never|without|nothing)\b[^.\n]{0,40}$",
+    re.IGNORECASE,
+)
+
+# "filed as a follow-up below", "see above", "tracked in §4" — the body is
+# pointing at where the reference lives, so the section-local rule would
+# misjudge it. Bounded to the 60 characters following the phrase.
+_DEICTIC_RE = re.compile(
+    r"^[^.\n]{0,60}?\b(?:below|above|see\s|§|section\b|listed\s+under)",
+    re.IGNORECASE,
+)
+
+_HEADING_RE = re.compile(r"\s*#{1,6}\s")
+
+
+def _strip_fences(body: str) -> str:
+    """Blank out fenced code blocks, preserving line count so numbers stay true."""
+    return re.sub(
+        r"```[^\n]*\n.*?```",
+        lambda m: "\n" * m.group(0).count("\n"),
+        body,
+        flags=re.DOTALL,
+    )
+
+
+def _sections(text: str) -> list[tuple[str, int]]:
+    """Split ``text`` at markdown headings. Returns [(section_text, first_lineno)]."""
+    out: list[tuple[str, int]] = []
+    current: list[str] = []
+    start = 1
+    for lineno, line in enumerate(text.split("\n"), start=1):
+        if _HEADING_RE.match(line) and current:
+            out.append(("\n".join(current), start))
+            current, start = [], lineno
+        current.append(line)
+    if current:
+        out.append(("\n".join(current), start))
+    return out
+
+
+def find_admissions(body: str) -> list[tuple[int, str, str]]:
+    """Every unfiled admission as ``(line_number, matched_phrase, line_text)``."""
+    found: list[tuple[int, str, str]] = []
+    text = _strip_fences(body)
+
+    for section, start in _sections(text):
+        # An issue reference anywhere in the section discharges the whole
+        # section: the finding is filed, and which line carries the number is
+        # a formatting choice, not a governance one.
+        if _ISSUE_RE.search(section):
+            continue
+        for offset, line in enumerate(section.split("\n")):
+            if _HEADING_RE.match(line) or line.lstrip().startswith(">"):
+                continue
+            for match in _ADMISSION_RE.finditer(line):
+                if _NEGATION_RE.search(line[: match.start()]):
+                    continue
+                if _DEICTIC_RE.match(line[match.end() :]):
+                    continue
+                found.append((start + offset, match.group(0), line.strip()))
+                break  # one report per line is enough to act on
+    return found
+
+
+def check_admissions(body: str) -> list[str]:
+    """Validate ``body``. Returns human-readable errors; empty list == compliant."""
+    errors: list[str] = []
+    for lineno, phrase, line in find_admissions(body):
+        snippet = line if len(line) <= 120 else line[:117] + "..."
+        errors.append(
+            f"line {lineno}: admits a defect (\"{phrase}\") with no issue "
+            f"reference in its section — {snippet}\n"
+            f"      Fix: file it (`python3 scripts/github.py create-issue "
+            f"--title ... --body-file ... --labels ...`) and cite `#NNN` here, "
+            f"or reword if it is not a defect."
+        )
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Fail a PR body that admits a defect without filing it (#38).",
+    )
+    parser.add_argument(
+        "--body-file",
+        help="Path to a file containing the PR body. Reads stdin if omitted.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.body_file:
+        try:
+            with open(args.body_file, encoding="utf-8") as handle:
+                body = handle.read()
+        except OSError as exc:  # pragma: no cover - usage error path
+            print(f"ERROR: cannot read --body-file: {exc}", file=sys.stderr)
+            return 2
+    else:
+        body = sys.stdin.read()
+
+    if not body.strip():
+        print("ERROR: empty PR body", file=sys.stderr)
+        return 2
+
+    errors = check_admissions(body)
+    if errors:
+        print("PR body admits defects that were never filed (#38):", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print("PR body OK — no unfiled admissions (#38).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.ai/validators/pr-body-check.py
+++ b/.ai/validators/pr-body-check.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Factory PR-body standard verifier (riley issue #6788).
+
+Binary, dependency-free gate. Given a PR body (via ``--body-file`` or stdin),
+exits non-zero unless the body carries every section the factory PR-body
+standard mandates:
+
+  1. At least one fenced ASCII diagram (box-drawing / arrow characters)
+  2. A ``Current State`` -> ``Future State`` pair
+  3. A ``Provenance`` block (produced by scripts/provenance.py, issue #6786)
+  4. A Documentation-confirmation line (names docs updated + which
+     doc-maintenance command was run, e.g. ``/prd update-decisions`` /
+     ``/prd update-progress``, or the literal ``none applicable``)
+  5. A ``Follow-ups`` section (linked issues, each carrying an execution prompt)
+  6. Issue-linkage discipline: a ``Closes #NNN`` (fully closing) or
+     ``Refs #NNN`` / ``Part of #NNN`` (partial) reference
+
+This validator is intentionally *additive* to ``_validate_pr_body`` in
+scripts/github.py (which enforces RULE-050 governing tickets and placeholder
+hygiene). It does not duplicate those checks.
+
+Usage:
+    python3 .ai/validators/pr-body-check.py --body-file pr-body.md
+    gh pr view N --json body -q .body | python3 .ai/validators/pr-body-check.py
+
+Importable:
+    from importlib import ...            # hyphenated file — see tests/conftest.py
+    errors = pr_body_check.check_pr_body(body_text)   # [] == compliant
+
+Exit codes: 0 = compliant, 1 = one or more sections missing, 2 = usage error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+
+# Characters that mark a block as an ASCII / box-drawing diagram. Unicode
+# box-drawing + arrows, plus common pure-ASCII diagram tokens.
+_BOX_DRAWING = "─│┌┐└┘├┤┬┴┼╭╮╰╯━┃╱╲╳→←↑↓↔⟶⟵▶◀▲▼"
+_ASCII_ARROWS = ("-->", "<--", "->", "<-", "==>", "|--", "+--", "--+", "+---", "___")
+
+
+def _fenced_blocks(body: str) -> list[str]:
+    """Return the inner text of every fenced (```-delimited) code block."""
+    # Non-greedy match of ```...``` including an optional info string line.
+    return re.findall(r"```[^\n]*\n(.*?)```", body, flags=re.DOTALL)
+
+
+def _has_ascii_diagram(body: str) -> bool:
+    for block in _fenced_blocks(body):
+        if any(ch in block for ch in _BOX_DRAWING):
+            return True
+        if any(tok in block for tok in _ASCII_ARROWS):
+            return True
+    return False
+
+
+# PR-diagram harness (#75): the §1 diagram is archetype-generated
+# (scripts/pr_diagram.py classify) and must be filled + show current->future.
+_STUB_MARKER = "<FILL:"
+
+
+def _diagram_has_stub(body: str) -> bool:
+    """True if any fenced block still carries an unfilled archetype slot."""
+    return any(_STUB_MARKER in block for block in _fenced_blocks(body))
+
+
+def _diagram_has_current_future(body: str) -> bool:
+    """True if a fenced block shows a current/future (or before/after) split."""
+    for block in _fenced_blocks(body):
+        low = block.lower()
+        if ("current" in low and "future" in low) or ("before" in low and "after" in low):
+            return True
+    return False
+
+
+# Issue #112: a heading may carry an enumerator before its title — `## 6.
+# Documentation`, `## (d) Documentation confirmation`, `### 1.2 Documentation`.
+# The old pattern demanded the word immediately after the hashes and so
+# false-negatived on every numbered body. Only *enumerator-shaped* prefixes are
+# tolerated (digits / a single letter / roman numerals, optionally bracketed and
+# followed by punctuation) — prose is still rejected, so `## Notes on
+# documentation` does not satisfy the heading requirement.
+_ENUMERATOR = r"(?:[(\[]?(?:\d+(?:\.\d+)*|[a-z]|[ivx]+)[)\].:]*[ \t]+){0,2}"
+
+
+def _heading_re(word: str) -> "re.Pattern[str]":
+    """Compile a heading matcher for ``word``, tolerant of enumerator prefixes."""
+    return re.compile(
+        rf"(?:^|\n)[ \t]*#{{1,6}}[ \t]*{_ENUMERATOR}{word}\b",
+        re.IGNORECASE,
+    )
+
+
+_DOC_HEADING_RE = _heading_re(r"documentation")
+_FOLLOWUPS_HEADING_RE = _heading_re(r"follow[\s\-]*ups?")
+
+
+def check_pr_body(body: str) -> list[str]:
+    """Validate ``body`` against the factory PR-body standard.
+
+    Returns a list of human-readable error strings. Empty list == compliant.
+    """
+    errors: list[str] = []
+    low = body.lower()
+
+    # 1. Fenced ASCII diagram
+    if not _has_ascii_diagram(body):
+        errors.append(
+            "No fenced ASCII diagram found — add at least one ``` block using "
+            "box-drawing/arrow characters (─│┌┐└┘→ or -->)."
+        )
+    else:
+        # 1a (#75): the archetype skeleton must be filled, not pasted raw.
+        if _diagram_has_stub(body):
+            errors.append(
+                "§1 diagram still contains unfilled `<FILL: ...>` archetype slots "
+                "— fill each from your diff (`scripts/pr_diagram.py classify`)."
+            )
+        # 1b (#75): the diagram must show current -> future, not just wiring.
+        if not _diagram_has_current_future(body):
+            errors.append(
+                "§1 diagram must show current -> future — label the fenced block "
+                "with CURRENT/FUTURE (or BEFORE/AFTER). See `scripts/pr_diagram.py "
+                "classify` for the right archetype."
+            )
+
+    # 2. Current State -> Future State pair
+    has_current = re.search(r"current[\s\-]*state", low) is not None
+    has_future = re.search(r"future[\s\-]*state", low) is not None
+    if not (has_current and has_future):
+        missing = []
+        if not has_current:
+            missing.append("`Current State`")
+        if not has_future:
+            missing.append("`Future State`")
+        errors.append(
+            "Current State -> Future State pair incomplete — missing "
+            + " and ".join(missing)
+            + "."
+        )
+
+    # 3. Provenance block (from issue #6786's scripts/provenance.py)
+    if not re.search(r"(^|\n)\s*#{1,6}?\s*provenance\b", low) and "provenance" not in low:
+        errors.append(
+            "No Provenance block — include the block emitted by "
+            "scripts/provenance.py (issue #6786)."
+        )
+
+    # 4. Documentation confirmation line
+    has_doc_heading = _DOC_HEADING_RE.search(body) is not None
+    has_doc_signal = (
+        "none applicable" in low
+        or "/prd update-decisions" in low
+        or "/prd update-progress" in low
+        or re.search(r"update[\s\-]*(decisions|progress)", low) is not None
+    )
+    if not (has_doc_heading and has_doc_signal):
+        errors.append(
+            "Documentation confirmation missing — add a `## Documentation` "
+            "section naming docs updated and which doc-maintenance command ran "
+            "(`/prd update-decisions` / `/prd update-progress`), or state "
+            "`none applicable`."
+        )
+
+    # 5. Follow-ups section (linked issues carrying execution prompts)
+    if not _FOLLOWUPS_HEADING_RE.search(body):
+        errors.append(
+            "No Follow-ups section — add `## Follow-ups` listing linked issues "
+            "(each carrying an execution prompt), or state `none`."
+        )
+
+    # 6. Issue-linkage discipline: Closes (full) or Refs/Part of (partial)
+    if not re.search(r"\b(closes|refs|part of)\s+#[0-9]+", low):
+        errors.append(
+            "No issue linkage — use `Closes #NNN` only when this PR fully "
+            "closes the issue, otherwise `Refs #NNN` (and update the issue)."
+        )
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify a PR body against the factory PR-body standard (#6788).",
+    )
+    parser.add_argument(
+        "--body-file",
+        help="Path to a file containing the PR body. Reads stdin if omitted.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.body_file:
+        try:
+            with open(args.body_file, encoding="utf-8") as fh:
+                body = fh.read()
+        except OSError as exc:  # pragma: no cover - usage error path
+            print(f"ERROR: cannot read --body-file: {exc}", file=sys.stderr)
+            return 2
+    else:
+        body = sys.stdin.read()
+
+    if not body.strip():
+        print("ERROR: empty PR body", file=sys.stderr)
+        return 2
+
+    errors = check_pr_body(body)
+    if errors:
+        print("PR body FAILS the factory standard (#6788):", file=sys.stderr)
+        for err in errors:
+            print(f"  - {err}", file=sys.stderr)
+        return 1
+
+    print("PR body OK — all six factory sections present (#6788).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/MagicMouseTray/DeviceCapability.cs
+++ b/MagicMouseTray/DeviceCapability.cs
@@ -80,9 +80,21 @@ internal static class DeviceCapability
             case DeviceKind.MagicMouseV3:
                 // v3 IS coupled to the filter: PATH-B recycle does FLIP:NoFilter -> read ->
                 // FLIP:AppleFilter, which needs applewirelessmouse present for Mode B restore.
+                // `driver` here is expected to be the PID-SCOPED status for this specific v3
+                // device (DriverHealthChecker.GetStatusForPid), not the global worst-state-wins
+                // value — the caller (TrayApp) is responsible for that distinction. Badge label
+                // is derived from the same "bound == Patched" fact the v1-binary-patch installer
+                // writes (LowerFilters=applewirelessmouse); there is no third driver to detect
+                // yet (v2-kmdf-driver has no shipped installer as of this writing).
+                var badge = driver switch
+                {
+                    DriverStatus.Ok => "Patched",
+                    DriverStatus.NotBound or DriverStatus.NotInstalled => "Stock/KMDF",
+                    _ => "Unknown",
+                };
                 if (lastPct >= 0)
                     return new("Split-vendor 0x90 via PATH-B recycle",
-                               "Battery read OK (reverts to Mode B between reads)", null, null);
+                               $"Driver: {badge} — battery read OK (reverts to Mode B between reads)", null, null);
                 if (lastPct == -2)
                 {
                     // Mode B: battery N/A until the next idle-gated recycle.
@@ -90,14 +102,14 @@ internal static class DeviceCapability
                     {
                         var (lbl, url) = ScrollFix(driver);
                         return new("Unified Feature 0x47 (blocked by Apple driver)",
-                                   "Mode B — recycle needs the Apple scroll driver", lbl, url);
+                                   $"Driver: {badge} — recycle needs the Apple scroll driver", lbl, url);
                     }
                     return new("Unified Feature 0x47 (blocked by Apple driver)",
-                               "Mode B — battery N/A until next read",
+                               $"Driver: {badge} — battery N/A until next read",
                                "Read Battery Now", null); // in-app: V3RecycleManager.ForceReadNowAsync
                 }
                 return new("Split-vendor 0x90 via PATH-B recycle",
-                           "No reading — check driver/pairing", "Scroll/driver help", ScrollFixAnchor);
+                           $"Driver: {badge} — no reading, check driver/pairing", "Scroll/driver help", ScrollFixAnchor);
 
             case DeviceKind.MagicKeyboard:
                 // ACTIVE-READ target: -2 means "present but Feature 0x47 cap absent"

--- a/MagicMouseTray/DriverHealthChecker.cs
+++ b/MagicMouseTray/DriverHealthChecker.cs
@@ -156,4 +156,62 @@ internal static class DriverHealthChecker
             return DriverStatus.Error; // fail open — don't nag user on transient registry errors, but surface as error state
         }
     }
+
+    // Per-PID variant of GetStatus(), scoped to one device (e.g. the v3 Magic Mouse, PID 0323)
+    // instead of worst-state-wins across every paired Apple mouse. Needed because the v3 driver
+    // badge must reflect THAT device's binding, not whatever other mouse happens to be unbound.
+    // Reuses the same BTHENUM/LowerFilters mechanism as GetStatus() — verified against
+    // v1-binary-patch/installer/Install-MagicMousePatch.ps1, which registers the SAME
+    // "applewirelessmouse" service/LowerFilters entry for the v3 mouse as for v1/v2.
+    internal static DriverStatus GetStatusForPid(string pid)
+    {
+        pid = pid.ToLowerInvariant();
+        try
+        {
+            using var svcKey = Registry.LocalMachine.OpenSubKey(ServiceKey, writable: false);
+            if (svcKey == null) return DriverStatus.NotInstalled;
+
+            using var btEnumKey = Registry.LocalMachine.OpenSubKey(BtHidEnumBase, writable: false);
+            if (btEnumKey == null) return DriverStatus.Ok; // service present, nothing paired
+
+            foreach (var subkeyName in btEnumKey.GetSubKeyNames())
+            {
+                if (!subkeyName.StartsWith(HidUuidPrefix, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                bool isApple = false;
+                foreach (var seg in AppleVidSegments)
+                    if (subkeyName.Contains(seg, StringComparison.OrdinalIgnoreCase))
+                    { isApple = true; break; }
+                if (!isApple) continue;
+
+                int pidIdx = subkeyName.LastIndexOf("_PID&", StringComparison.OrdinalIgnoreCase);
+                if (pidIdx < 0 || pidIdx + 9 > subkeyName.Length) continue;
+                var keyPid = subkeyName.Substring(pidIdx + 5, 4).ToLowerInvariant();
+                if (keyPid != pid) continue;
+
+                using var deviceKey = btEnumKey.OpenSubKey(subkeyName, writable: false);
+                if (deviceKey == null) continue;
+                var instances = deviceKey.GetSubKeyNames();
+                if (instances.Length == 0) continue; // key exists but not currently paired
+
+                foreach (var instanceName in instances)
+                {
+                    using var instance = deviceKey.OpenSubKey(instanceName, writable: false);
+                    var filters = instance?.GetValue("LowerFilters") as string[];
+                    bool isBound = filters != null && Array.Exists(filters,
+                        f => f.Equals("applewirelessmouse", StringComparison.OrdinalIgnoreCase));
+                    Logger.Log($"DRIVER_CHECK_PID pid=0x{pid.ToUpper()} bound={isBound}");
+                    return isBound ? DriverStatus.Ok : DriverStatus.NotBound;
+                }
+            }
+
+            return DriverStatus.Ok; // PID not currently paired — nothing to warn about
+        }
+        catch (Exception ex)
+        {
+            Logger.Log($"DRIVER_CHECK_PID_FAILED pid={pid} err={ex.Message}");
+            return DriverStatus.Error;
+        }
+    }
 }

--- a/MagicMouseTray/TrayApp.cs
+++ b/MagicMouseTray/TrayApp.cs
@@ -26,6 +26,7 @@ internal sealed class TrayApp : IDisposable
     ToolStripMenuItem? _deviceSection;
     ToolStripMenuItem? _driverWarningItem;
     ToolStripSeparator? _driverWarningSeparator;
+    ToolStripMenuItem? _battReadItem;
 
     // Alert boundaries fired per-device this drain cycle. Cleared per-device when battery recovers.
     readonly Dictionary<string, HashSet<int>> _firedBoundaries = new(StringComparer.OrdinalIgnoreCase);
@@ -111,21 +112,13 @@ internal sealed class TrayApp : IDisposable
         menu.Items.Add(_deviceSection);
         menu.Items.Add(new ToolStripSeparator());
 
-        // --- Start with Windows ---
-        startupItem = new ToolStripMenuItem("Start with Windows")
-        {
-            Checked = _config.StartWithWindows
-        };
-        startupItem.Click += (_, _) =>
-        {
-            _config.SetStartWithWindows(!_config.StartWithWindows);
-            _startupItem.Checked = _config.StartWithWindows;
-        };
-        menu.Items.Add(startupItem);
-
-        menu.Items.Add(new ToolStripSeparator());
-
-        // --- Driver warning (shown when scroll driver is missing, unbound, or unknown model) ---
+        // --- Driver warning: scoped to UnknownAppleMouse only (an unrecognized Apple PID has
+        // no IBatteryDevice, so it can never get a real per-device row like the mice/keyboards
+        // below — this is the one remaining case that needs a floating banner). NotBound/
+        // NotInstalled/Error for KNOWN devices are surfaced per-row instead (see the capability
+        // matrix dropdown below), so this banner no longer duplicates those warnings. Positioned
+        // right under the device rows (not after Start with Windows) so it still reads as
+        // device-scoped rather than a general settings-area warning.
         _driverWarningItem = new ToolStripMenuItem("") { ForeColor = System.Drawing.Color.OrangeRed };
         _driverWarningItem.Click += (_, _) =>
         {
@@ -148,19 +141,33 @@ internal sealed class TrayApp : IDisposable
         menu.Items.Add(_driverWarningSeparator);
         UpdateDriverWarningItem();
 
-        // --- Battery Reads toggle (PATH-B v3 recycle on/off) ---
-        var battReadItem = new ToolStripMenuItem("Battery Reads [On]")
+        // --- Global settings ---
+        startupItem = new ToolStripMenuItem("Start with Windows")
+        {
+            Checked = _config.StartWithWindows
+        };
+        startupItem.Click += (_, _) =>
+        {
+            _config.SetStartWithWindows(!_config.StartWithWindows);
+            _startupItem.Checked = _config.StartWithWindows;
+        };
+        menu.Items.Add(startupItem);
+
+        // --- Battery Reads toggle (PATH-B v3 recycle on/off). Visibility is conditional:
+        // only meaningful when a v3 Magic Mouse is connected AND its driver is Patched
+        // (recomputed on every device-list refresh in UpdateDeviceMenuItems -> UpdateBatteryReadsVisibility).
+        _battReadItem = new ToolStripMenuItem("Battery Reads [On]")
         {
             Checked = _config.EnableV3Recycle
         };
-        battReadItem.Click += (_, _) =>
+        _battReadItem.Click += (_, _) =>
         {
             _config.SetEnableV3Recycle(!_config.EnableV3Recycle);
-            battReadItem.Text = _config.EnableV3Recycle ? "Battery Reads [On]" : "Battery Reads [Off]";
-            battReadItem.Checked = _config.EnableV3Recycle;
+            _battReadItem.Text = _config.EnableV3Recycle ? "Battery Reads [On]" : "Battery Reads [Off]";
+            _battReadItem.Checked = _config.EnableV3Recycle;
             if (_config.EnableV3Recycle) _recycleManager.ReEnable();
         };
-        menu.Items.Add(battReadItem);
+        menu.Items.Add(_battReadItem);
 
         // --- Third-party devices toggle (B2 experimental, default off) ---
         var thirdPartyItem = new ToolStripMenuItem(
@@ -176,6 +183,9 @@ internal sealed class TrayApp : IDisposable
         };
         menu.Items.Add(thirdPartyItem);
 
+        menu.Items.Add(new ToolStripSeparator());
+
+        // --- Actions ---
         // --- Refresh Now ---
         var refresh = new ToolStripMenuItem("Refresh Now (All Devices)");
         refresh.Click += (_, _) => _poller.RefreshNow();
@@ -237,35 +247,22 @@ internal sealed class TrayApp : IDisposable
         return menu;
     }
 
+    // Scoped to UnknownAppleMouse only — NotBound/NotInstalled/Error are surfaced per-row
+    // instead (the affected device already shows its own remediation action in the capability
+    // matrix dropdown; see DeviceCapability.Describe). Showing both would be a duplicate warning.
     void UpdateDriverWarningItem()
     {
         if (_driverWarningItem == null || _driverWarningSeparator == null) return;
 
-        if (_driverStatus == DriverStatus.Ok)
+        if (_driverStatus != DriverStatus.UnknownAppleMouse)
         {
             _driverWarningItem.Visible = false;
             _driverWarningSeparator.Visible = false;
             return;
         }
 
-        var (label, url) = _driverStatus switch
-        {
-            DriverStatus.UnknownAppleMouse =>
-                ("⚠ Unknown mouse model — check for app update",
-                 "https://github.com/ReviveBusiness/magic-mouse-tray/releases"),
-            DriverStatus.NotBound =>
-                ("⚠ Driver not bound — scroll fix needed",
-                 "https://github.com/ReviveBusiness/magic-mouse-tray#scroll-not-working"),
-            DriverStatus.Error =>
-                ("⚠ Driver reported an error — check Device Manager",
-                 "https://github.com/ReviveBusiness/magic-mouse-tray#scroll-not-working"),
-            _ =>
-                ("⚠ Install Apple Driver (scroll fix)",
-                 "https://github.com/tealtadpole/MagicMouse2DriversWin11x64/releases/tag/v3.0"),
-        };
-
-        _driverWarningItem.Text = label;
-        _driverWarningItem.Tag = url;
+        _driverWarningItem.Text = "⚠ Unknown mouse model — check for app update";
+        _driverWarningItem.Tag = "https://github.com/ReviveBusiness/magic-mouse-tray/releases";
         _driverWarningItem.Visible = true;
         _driverWarningSeparator.Visible = true;
     }
@@ -487,6 +484,7 @@ internal sealed class TrayApp : IDisposable
                 _tray.ContextMenuStrip?.Items.Remove(_deviceMenuItems[key]);
                 _deviceMenuItems.Remove(key);
             }
+            UpdateBatteryReadsVisibility();
             return;
         }
 
@@ -557,7 +555,13 @@ internal sealed class TrayApp : IDisposable
             var knd = DeviceCapability.KindForName(kv.Key);
             if (knd is { } k)
             {
-                var row = DeviceCapability.Describe(k, kv.Value.Pct, _driverStatus);
+                // v3 gets its own per-PID driver status instead of the global worst-state-wins
+                // value — otherwise an unrelated v1/v2 mouse in a bad driver state would
+                // incorrectly badge a fine v3 mouse (and vice versa).
+                var driverForRow = k == DeviceKind.MagicMouseV3
+                    ? DriverHealthChecker.GetStatusForPid(kv.Value.Pid)
+                    : _driverStatus;
+                var row = DeviceCapability.Describe(k, kv.Value.Pct, driverForRow);
                 item.DropDownItems.Add(new ToolStripMenuItem($"Read method: {row.ReadMethod}") { Enabled = false });
                 item.DropDownItems.Add(new ToolStripMenuItem($"Status: {row.Status}") { Enabled = false });
                 if (row.ActionLabel is { } al)
@@ -603,6 +607,22 @@ internal sealed class TrayApp : IDisposable
         }
 
         _deviceSection.Text = $"Devices ({_deviceBatteries.Count})";
+        UpdateBatteryReadsVisibility();
+    }
+
+    // Battery Reads only does anything for a v3 Magic Mouse with the patched driver bound
+    // (PATH-B recycle needs applewirelessmouse present to restore Mode B between reads) —
+    // noise for v1/v2 or for a v3 still on the stock driver. Recomputed on every device-list
+    // refresh (poll + menu Opening), matching the design's "not a static settings item" rule.
+    void UpdateBatteryReadsVisibility()
+    {
+        if (_battReadItem is null) return;
+
+        bool show = _deviceBatteries.Any(kv =>
+            kv.Value.Kind == DeviceKind.MagicMouseV3 &&
+            DriverHealthChecker.GetStatusForPid(kv.Value.Pid) == DriverStatus.Ok);
+
+        _battReadItem.Visible = show;
     }
 
     static string FormatInterval(TimeSpan t)

--- a/scripts/pr_diagram.py
+++ b/scripts/pr_diagram.py
@@ -1,0 +1,365 @@
+#!/usr/bin/env python3
+"""PR-diagram harness (issue #75) — classify a change, emit the right archetype.
+
+Implements the deterministic stages (1, 2, 5) of `design/pr-diagram-harness.md`.
+Stage 3 (filling the archetype's ``<FILL: ...>`` slots with the real
+current->future) is done by the authoring agent, which holds the diff + PRD in
+context; the strengthened ``.ai/validators/pr-body-check.py`` enforces the
+result (fenced ASCII + current/future split + no leftover ``<FILL:`` stub).
+
+A change gets EVERY diagram its surfaces call for, not one: a PR that adds a
+hook, a script, and a MOP carries an enforcement-flow, an automation-pipeline,
+and a deploy-topology diagram.
+
+Subcommands:
+  classify   Print every required archetype + a fill-in skeleton for each + a
+             current-state snapshot for a branch (default: HEAD vs ``main``).
+  verify     Diff-aware gate: assert a PR body carries a diagram for every
+             archetype the change requires (body-only rules live in the
+             validator; only this side can see the diff).
+  sync       Write/refresh the diagram block(s) into a Doc-Target doc (stage 5).
+
+Dependency-free (stdlib only); Python 3.9+ (``from __future__ import annotations``).
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ARCHETYPE_DIR = REPO_ROOT / "templates" / "diagrams"
+
+# Ordered highest-signal first. A change gets EVERY archetype it triggers, not
+# just the first — a PR that adds a hook, a script, and a MOP is three separate
+# things to see, so it carries three diagrams.
+ARCHETYPES = (
+    "enforcement-flow",
+    "automation-pipeline",
+    "deploy-topology",
+    "config-before-after",
+    "skill-flow",
+    "generic",
+    "none",
+)
+
+# What each archetype shows. Surfaced in the emitted label so a reader knows
+# whether they are looking at a flow, a structure, or a state delta.
+ROLES = {
+    "enforcement-flow": "process",
+    "automation-pipeline": "process",
+    "deploy-topology": "structure",
+    "config-before-after": "state",
+    "skill-flow": "process",
+    "generic": "structure",
+}
+
+_DOC_BLOCK_START = "<!-- pr-diagram:start -->"
+_DOC_BLOCK_END = "<!-- pr-diagram:end -->"
+
+# Per-diagram marker the harness emits and the diff-aware gate reads back.
+# Deliberately distinct from the :start/:end doc-block markers above.
+_MARKER_RE = re.compile(r"<!--\s*pr-diagram:\s*([a-z-]+)\s*(?:\([a-z]+\))?\s*-->")
+
+
+def _is_doc(path: str) -> bool:
+    # Real documentation only — NOT operational markdown under mops/ or .ai/skills/,
+    # which the taxonomy classifies by their directory.
+    if path.startswith(("design/", "docs/")):
+        return True
+    return "/" not in path and path.endswith(".md")  # top-level README/AGENTS/etc.
+
+
+def _is_test(path: str) -> bool:
+    tail = path.rsplit("/", 1)[-1]
+    return path.startswith("tests/") or "/tests/" in path or tail.startswith("test_")
+
+
+def plan(paths: list[str], ticket: str | None = None) -> list[str]:
+    """Map changed paths (+ optional RULE-050 ticket) to EVERY archetype needed.
+
+    Pure function — the whole classifier surface. ``paths`` are repo-relative.
+    Returns archetype keys in ``ARCHETYPES`` order (highest signal first), so a
+    PR spanning several surfaces carries a diagram for each one. ``["none"]``
+    means no archetype applies (docs-/tests-only); ``["generic"]`` means code
+    changed but no specific surface matched.
+    """
+    paths = [p for p in paths if p]
+    ticket = (ticket or "").upper()
+
+    # Docs-only / tests-only change: no archetype applies.
+    if paths and all(_is_doc(p) or _is_test(p) for p in paths):
+        return ["none"]
+
+    def touches(*prefixes: str) -> bool:
+        return any(p.startswith(prefixes) for p in paths)
+
+    keys: list[str] = []
+    # .ai/validators/ is an enforcement surface too: those ARE the gates.
+    if touches(".ai/hooks/", ".ai/guardrails/", ".ai/validators/"):
+        keys.append("enforcement-flow")
+    if touches("scripts/", ".forgejo/"):
+        keys.append("automation-pipeline")
+    if touches("mops/") or ticket == "INFRA":
+        keys.append("deploy-topology")
+    if touches(".ai/claude-config/") or any(
+        re.search(r"settings.*\.json$", p) for p in paths
+    ):
+        keys.append("config-before-after")
+    if touches(".ai/skills/"):
+        keys.append("skill-flow")
+
+    return keys or ["generic"]
+
+
+def classify(paths: list[str], ticket: str | None = None) -> str:
+    """The primary (highest-signal) archetype for a change. See ``plan``."""
+    return plan(paths, ticket)[0]
+
+
+def body_archetypes(body: str) -> list[str]:
+    """Archetype keys declared by ``<!-- pr-diagram: <key> -->`` markers in a body."""
+    found = [m.group(1) for m in _MARKER_RE.finditer(body)]
+    return [k for k in found if k in ARCHETYPES]
+
+
+def missing_archetypes(body: str, required: list[str]) -> list[str]:
+    """Required archetypes with no marked diagram in ``body`` (``none`` is a pass)."""
+    if required == ["none"]:
+        return []
+    present = set(body_archetypes(body))
+    return [k for k in required if k not in present]
+
+
+def load_archetype(key: str) -> str:
+    """Return the ASCII skeleton for ``key`` (empty string for ``none``)."""
+    if key == "none":
+        return ""
+    src = ARCHETYPE_DIR / f"{key}.txt"
+    if not src.exists():
+        raise FileNotFoundError(f"archetype not found: {src}")
+    return src.read_text(encoding="utf-8").rstrip("\n")
+
+
+def _git(args: list[str], repo_dir: Path) -> str:
+    r = subprocess.run(
+        ["git", "-C", str(repo_dir), *args],
+        capture_output=True,
+        text=True,
+    )
+    return r.stdout if r.returncode == 0 else ""
+
+
+def _rev_exists(ref: str, repo_dir: Path) -> bool:
+    return bool(_git(["rev-parse", "--verify", "--quiet", f"{ref}^{{commit}}"], repo_dir).strip())
+
+
+def resolve_base(base: str, repo_dir: Path) -> str:
+    """Resolve ``base`` to the fork point this branch actually diverged from (#159).
+
+    Two corrections over using ``base`` literally:
+
+    1. **Prefer the remote-tracking ref.** In a multi-worktree repo the local
+       ``main`` routinely lags ``origin/main``, so a bare ``main`` is a stale
+       ref whose diff sweeps in every *other* branch that landed since.
+    2. **Use the merge-base, not the tip.** ``merge-base <base> HEAD`` is the
+       commit this branch forked from, so the diff contains this branch's own
+       work and nothing that arrived on the base afterwards.
+
+    Falls back to ``base`` unchanged when there is no remote-tracking ref or no
+    common ancestor (e.g. a fresh repo with no ``origin``), so the caller is
+    never left without a usable ref.
+    """
+    candidate = base
+    if "/" not in base and _rev_exists(f"origin/{base}", repo_dir):
+        candidate = f"origin/{base}"
+    merge_base = _git(["merge-base", candidate, "HEAD"], repo_dir).strip()
+    return merge_base or candidate
+
+
+def changed_paths(base: str, repo_dir: Path) -> list[tuple[str, str]]:
+    """Return (status, path) for the working tree vs the fork point from ``base``.
+
+    ``base`` is resolved through :func:`resolve_base` first, so the file set is
+    this branch's own work — not whatever other in-flight branches have landed
+    on the base since (issue #159).
+
+    Two-dot diff (fork point vs working tree) so committed, staged, and
+    unstaged *tracked* changes are all seen; ``classify`` therefore still works
+    before the branch is committed, as long as new files have been ``git add``ed.
+
+    Untracked files are deliberately NOT included: they are local scratch (e.g.
+    ``.riley-session``), belong to no PR, and were a direct source of false
+    blast-radius claims in merged PR bodies (#159).
+    """
+    rows: list[tuple[str, str]] = []
+    out = _git(["diff", "--name-status", resolve_base(base, repo_dir)], repo_dir)
+    for line in out.splitlines():
+        parts = line.split("\t")
+        if len(parts) >= 2:
+            rows.append((parts[0][:1], parts[-1]))
+    return rows
+
+
+def _snapshot(rows: list[tuple[str, str]]) -> str:
+    """A terse current-state hint: what exists today (modified/deleted) vs new."""
+    existing = [p for s, p in rows if s in ("M", "D")]
+    added = [p for s, p in rows if s == "A"]
+    lines = ["current-state snapshot (what exists on base today):"]
+    lines += [f"  ~ {p}" for p in existing] or ["  (no pre-existing files touched)"]
+    if added:
+        lines.append("new in this PR:")
+        lines += [f"  + {p}" for p in added]
+    return "\n".join(lines)
+
+
+def render_block(key: str) -> str:
+    """The full §1 stanza for one archetype: marker + heading + fenced skeleton."""
+    role = ROLES.get(key, "structure")
+    return (
+        f"<!-- pr-diagram: {key} ({role}) -->\n"
+        f"#### {key} — {role}\n\n"
+        "```\n"
+        f"{load_archetype(key)}\n"
+        "```"
+    )
+
+
+def cmd_classify(args: argparse.Namespace) -> int:
+    repo_dir = Path(args.repo_dir).resolve()
+    rows = changed_paths(args.base, repo_dir)
+    keys = plan([p for _, p in rows], args.ticket)
+
+    print(f"archetypes ({len(keys)}): {', '.join(keys)}")
+    if keys == ["none"]:
+        print("docs-only / tests-only change — no archetype applies (state N/A).")
+        return 0
+    print()
+    print(_snapshot(rows))
+    print()
+    print(f"This change spans {len(keys)} surface(s); §1 (Architecture) carries a")
+    print("diagram for EACH. Paste every stanza below, keeping its <!-- pr-diagram: -->")
+    print("marker, and fill every <FILL: ...> slot from your diff.")
+    print()
+    for key in keys:
+        print(render_block(key))
+        print()
+    return 0
+
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    """Diff-aware gate: does the body carry every diagram this change needs?
+
+    Complements ``.ai/validators/pr-body-check.py``, which is body-only (and so
+    cannot know which archetypes a diff demands).
+    """
+    body = (
+        sys.stdin.read()
+        if args.body_file == "-"
+        else Path(args.body_file).read_text(encoding="utf-8")
+    )
+    repo_dir = Path(args.repo_dir).resolve()
+    rows = changed_paths(args.base, repo_dir)
+    required = plan([p for _, p in rows], args.ticket)
+    missing = missing_archetypes(body, required)
+
+    if missing:
+        print(
+            f"ERROR: PR body is missing {len(missing)} required diagram(s) (#75):",
+            file=sys.stderr,
+        )
+        for key in missing:
+            print(f"  - {key} ({ROLES.get(key, 'structure')})", file=sys.stderr)
+        print(
+            f"\nThis change touches {len(required)} surface(s): {', '.join(required)}.\n"
+            "Run `python3 scripts/pr_diagram.py classify` and paste every stanza.",
+            file=sys.stderr,
+        )
+        return 1
+    label = "no archetype required" if required == ["none"] else ", ".join(required)
+    print(f"OK: body carries every required diagram ({label}).")
+    return 0
+
+
+def sync_doc(doc_path: Path, diagram: str | list[str]) -> str:
+    """Return ``doc_path`` content with the pr-diagram block written/refreshed.
+
+    ``diagram`` is one diagram or several — the doc mirrors the same set the PR
+    body carries. Idempotent: replaces an existing delimited block, else appends
+    a new ``## Architecture (current -> future)`` section.
+    """
+    diagrams = [diagram] if isinstance(diagram, str) else list(diagram)
+    fences = "\n\n".join(f"```\n{d.rstrip()}\n```" for d in diagrams)
+    block = (
+        f"{_DOC_BLOCK_START}\n"
+        "## Architecture (current -> future)\n\n"
+        f"{fences}\n"
+        f"{_DOC_BLOCK_END}"
+    )
+    text = doc_path.read_text(encoding="utf-8") if doc_path.exists() else ""
+    pattern = re.compile(
+        re.escape(_DOC_BLOCK_START) + r".*?" + re.escape(_DOC_BLOCK_END),
+        re.DOTALL,
+    )
+    if pattern.search(text):
+        return pattern.sub(block, text)
+    sep = "" if text.endswith("\n\n") or text == "" else ("\n" if text.endswith("\n") else "\n\n")
+    return f"{text}{sep}{block}\n"
+
+
+def cmd_sync(args: argparse.Namespace) -> int:
+    doc_path = Path(args.doc_target)
+    diagrams: list[str] = []
+    for name in args.diagram_file:
+        src = Path(name)
+        if not src.exists():
+            print(f"ERROR: --diagram-file not found: {src}", file=sys.stderr)
+            return 2
+        text = src.read_text(encoding="utf-8")
+        if "<FILL:" in text:
+            print(f"ERROR: {src} still has <FILL: ...> slots — fill it first.", file=sys.stderr)
+            return 2
+        diagrams.append(text)
+    new_text = sync_doc(doc_path, diagrams)
+    doc_path.parent.mkdir(parents=True, exist_ok=True)
+    doc_path.write_text(new_text, encoding="utf-8")
+    print(f"synced {len(diagrams)} diagram(s) into {doc_path}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    c = sub.add_parser("classify", help="Print every required archetype + skeleton.")
+    c.add_argument("--base", default="main", help="Base ref to diff against (default: main).")
+    c.add_argument("--repo-dir", default=".", help="Repo working dir (default: .).")
+    c.add_argument("--ticket", default=None, help="RULE-050 ticket (e.g. INFRA) for a stronger signal.")
+    c.set_defaults(func=cmd_classify)
+
+    v = sub.add_parser("verify", help="Check a PR body carries every required diagram.")
+    v.add_argument("--body-file", required=True, help="PR body file, or '-' for stdin.")
+    v.add_argument("--base", default="main", help="Base ref to diff against (default: main).")
+    v.add_argument("--repo-dir", default=".", help="Repo working dir (default: .).")
+    v.add_argument("--ticket", default=None, help="RULE-050 ticket (e.g. INFRA).")
+    v.set_defaults(func=cmd_verify)
+
+    s = sub.add_parser("sync", help="Write/refresh the diagram block(s) into a doc.")
+    s.add_argument("--doc-target", required=True, help="Path to the doc to sync into.")
+    s.add_argument(
+        "--diagram-file",
+        required=True,
+        nargs="+",
+        help="File(s) holding the filled §1 diagram(s) — pass one per archetype.",
+    )
+    s.set_defaults(func=cmd_sync)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/diagrams/automation-pipeline.txt
+++ b/templates/diagrams/automation-pipeline.txt
@@ -1,0 +1,10 @@
+   <FILL: trigger>
+        |
+        v
+   <FILL: stage 1> --> <FILL: stage 2> --> <FILL: stage 3>
+        |
+        v
+   <FILL: output / result>
+
+   CURRENT: <FILL: today's flow, or (none)>
+   FUTURE:  <FILL: what this PR adds or changes>

--- a/templates/diagrams/config-before-after.txt
+++ b/templates/diagrams/config-before-after.txt
@@ -1,0 +1,4 @@
+   <FILL: config file / key>
+
+   BEFORE (current)                  AFTER (future)
+   <FILL: key = value now>    -->    <FILL: key = value after>

--- a/templates/diagrams/deploy-topology.txt
+++ b/templates/diagrams/deploy-topology.txt
@@ -1,0 +1,5 @@
+   CURRENT                                 FUTURE
+   +---------------------+                 +---------------------+
+   | <FILL: host / svc>  |  -- this PR --> | <FILL: host / svc>  |
+   | <FILL: state now>   |                 | <FILL: new state>   |
+   +---------------------+                 +---------------------+

--- a/templates/diagrams/enforcement-flow.txt
+++ b/templates/diagrams/enforcement-flow.txt
@@ -1,0 +1,12 @@
+   <FILL: trigger — e.g. Bash tool call / Write to protected path>
+          |
+          v
+   +---------------------------------+
+   | <FILL: gate / hook name>        |
+   +---------------------------------+
+      | allow             | block
+      v                   v
+   <FILL: proceeds>    <FILL: blocked + reason>
+
+   CURRENT: <FILL: what is enforced today, or (none)>
+   FUTURE:  <FILL: what this PR adds or changes>

--- a/templates/diagrams/generic.txt
+++ b/templates/diagrams/generic.txt
@@ -1,0 +1,5 @@
+   CURRENT                                 FUTURE
+   +---------------------+                 +---------------------+
+   | <FILL: component>   |  -- this PR --> | <FILL: component>   |
+   | <FILL: state now>   |                 | <FILL: new state>   |
+   +---------------------+                 +---------------------+

--- a/templates/diagrams/skill-flow.txt
+++ b/templates/diagrams/skill-flow.txt
@@ -1,0 +1,7 @@
+   /<FILL: skill> invoked
+        |
+        v
+   <FILL: step 1> --> <FILL: step 2> --> <FILL: gate> --> <FILL: result>
+
+   CURRENT: <FILL: today's flow, or (none)>
+   FUTURE:  <FILL: what this PR adds or changes>


### PR DESCRIPTION
Part of #68
PRD-NONE

## Summary

Implements the buildable subset of `docs/DESIGN-tray-ui-redesign.md` (issue #68): a real per-device driver badge for the v3 Magic Mouse (`Patched`/`Stock/KMDF`/`Unknown`), conditional visibility for the `Battery Reads` toggle (`v3Connected && v3Driver==Patched`), and a narrower/repositioned driver-warning banner scoped to `UnknownAppleMouse` only (known-device driver issues already surface per-row via the existing capability-matrix dropdown, so the floating banner no longer duplicates them).

`DriverHealthChecker.GetStatusForPid(pid)` is a new per-PID-scoped variant of the existing `GetStatus()` — added rather than modifying the global check, since `GetStatus()`'s worst-state-wins behavior across all paired Apple mice is a deliberate, documented heuristic (`DeviceCapability.cs` CAVEAT) still correct for v1/v2 rows. Only the v3 row now uses the scoped variant.

## Architecture (current -> future)

This PR also onboards two repo-tooling surfaces (found blocking `github.py create-pr` while opening this PR) — each gets its own archetype diagram per `scripts/pr_diagram.py classify` (issue #75):

<!-- pr-diagram: enforcement-flow (process) -->
#### enforcement-flow — process

```
github.py create-pr
        |
        v
+--------------------------------------------+
| .ai/validators/pr-body-check.py (#6788)     |
| .ai/validators/pr-admission-check.py (#38)  |
+--------------------------------------------+
   | pass                   | fail
   v                        v
PR opens                create-pr blocked,
                         error names the
                         missing section/citation

CURRENT: neither validator existed in this repo — create-pr had no way to
         check the factory PR-body standard or the unfiled-admission gate;
         every PR here shipped unchecked.
FUTURE:  both validators onboarded unmodified from RILEY's canonical
         `.ai/validators/` — create-pr now enforces the same gates every
         other repo enforces.
```

<!-- pr-diagram: automation-pipeline (process) -->
#### automation-pipeline — process

```
github.py create-pr
        |
        v
scripts/pr_diagram.py classify  (diff -> required archetype(s))
        |
        v
scripts/pr_diagram.py verify    (body carries a diagram per archetype)
        |
        v
PR body accepted / rejected, naming the missing archetype

CURRENT: repo had no diagram-archetype tooling — §1 diagrams were freeform
         and never classified per changed surface.
FUTURE:  scripts/pr_diagram.py + templates/diagrams/*.txt onboarded from
         `revive_ai-dev` (issue #75's actual build repo — RILEY's own copy
         of the script was missing the template files, a separate gap).
         Every PR touching `scripts/` or `.ai/validators/` now carries a
         classified, filled, current->future diagram for that surface.
```

## Current State -> Future State

```
CURRENT STATE                              FUTURE STATE
──────────────                             ─────────────
v3 Magic Mouse row shows generic     -->   v3 row shows "Driver: Patched" /
status text, no driver visibility          "Driver: Stock/KMDF" / "Driver:
                                            Unknown", from a per-PID check
                                            (not the global worst-state value)

Driver-warning banner fires for      -->   Banner fires ONLY for
UnknownAppleMouse/NotBound/                UnknownAppleMouse (the one case
NotInstalled/Error — duplicating           with no per-device row to attach
the same info already on affected          to); NotBound/NotInstalled/Error
device rows                                are per-row only

Battery Reads toggle always visible, -->   Toggle hidden unless a v3 mouse
useful only for v3 + patched driver        is connected AND its driver is
                                            Patched; recomputed on every
                                            device-list refresh

Menu order: Devices -> warning ->    -->   Devices -> scoped warning ->
Start with Windows -> Battery Reads        Global settings (Start with
-> Third-party -> Actions                  Windows, Battery Reads, Third-
                                            party) -> Actions (unchanged)
```

## Documentation

No docs updated — `docs/DESIGN-tray-ui-redesign.md` and `docs/SPEC-magic-tray-keyboard-battery.md` already describe this behavior and are unchanged. No `/prd update-decisions` / `/prd update-progress` ran — not applicable, this repo has no `/prd` doc-maintenance tooling (`.ai/` scaffold not onboarded — riley issue #7261).

## Follow-ups

- **v3 quick-switch control (design doc's open question) — not buildable yet.** Verified (not assumed, per the design doc's own instruction) against `apple-peripherals/magic-mouse-v3-fix/{v1-binary-patch,v2-kmdf-driver}`: the v3 mouse's "patched" state uses the *same* `applewirelessmouse` service/`LowerFilters` mechanism as v1/v2 (`Install-MagicMousePatch.ps1`), and `v2-kmdf-driver/` has no shipped `.sys`/installer — it's roadmap-only. A driver *badge* is real; a *switch* has nothing to switch to until that driver ships.
- **`UnknownAppleMouse` still isn't a true per-device row.** This PR narrows/repositions the existing global banner (least-risk partial fix) rather than the full fix, which needs `DeviceRegistry`/`IBatteryDevice` changes to synthesize a pseudo-device for an unmatched Apple PID — a larger, separate task.
- **v1 auto-remediation-on-detect (silent vs. confirm-first) is intentionally not implemented.** The design doc explicitly leaves this "a call for whoever builds this to make with Lesley" — not something to decide by guessing.
- **Keyboard `[Fix battery reads]` still links to docs, not the actual elevated script.** Investigated wiring it to `scripts/kbd-patch-cachedservices.ps1` directly; found `.github/workflows/release.yml` never packages `scripts/` into the published artifact (`dotnet publish` step only ships `MagicMouseTray.exe`), so invoking it by relative path would throw `FileNotFoundException` for every real user. Filed as #71 rather than shipping a broken button.

## Provenance

Resume this session:

```bash
cd /home/lesley/projects/RILEY && claude --dangerously-skip-permissions --resume db50f213-793c-4f9a-b355-9f998c394365
```

- **Workspace:** `/home/lesley/.claude/worktrees/ai-tray-ui-redesign-implement`
- **Claude session:** `db50f213-793c-4f9a-b355-9f998c394365`
