### PR TITLE
docs: community hardware test table

### DIFF
--- a/.github/ISSUE_TEMPLATE/missing-device.md
+++ b/.github/ISSUE_TEMPLATE/missing-device.md
@@ -1,0 +1,18 @@
+---
+name: Missing device / PID
+about: This Apple mouse, keyboard, or trackpad is not in KnownMice / KnownKeyboards
+title: "device: PID xxxx — model name"
+labels: device
+---
+
+The in-app catalog is `MouseBatteryDevice.KnownMice` and `KeyboardBatteryDevice.KnownKeyboards`. CI walks those lists. Do not open a `docs/TESTED.md` PR until the PID is in that catalog.
+
+**I checked KnownMice / KnownKeyboards and this PID is not there.**
+
+- Magic Tray version (tray footer):
+- Windows version (`winver`):
+- Device (mouse / keyboard / trackpad) and marketing name:
+- Hardware Ids from Device Manager (paste, e.g. `HID\VID_05AC&PID_0323` or `PID&0323`):
+- Connected over: Bluetooth / USB / both
+- What the tray shows today (nothing / unknown model / other):
+- `%APPDATA%\MagicMouseTray\debug.log` excerpt (optional):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,9 +23,13 @@ Do not vendor Magic Utilities binaries. Do not add a silent driver rebind. PATH-
 
 Driver URLs and package names belong in `DriverPackageCatalog.cs` — do not triplicate them.
 
+## Hardware reports
+
+If Magic Tray works (or fails) on a mouse, keyboard, or trackpad you own, add a row to [docs/TESTED.md](docs/TESTED.md) and open a PR. Include PID, Bluetooth vs USB, tray version, battery (`ok` / `no reading`), and driver badge. Sign the commit (`git commit -s`).
+
 ## Bug reports
 
-Include `%APPDATA%\MagicMouseTray\debug.log` and the device Hardware Ids from Device Manager (look for `VID_004C&PID_xxxx`).
+Include `%APPDATA%\MagicMouseTray\debug.log` and the device Hardware Ids from Device Manager (look for `VID_004C&PID_xxxx` or `VID_05AC&PID_xxxx`).
 
 ## License
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,11 @@ Driver URLs and package names belong in `DriverPackageCatalog.cs` — do not tri
 
 ## Hardware reports
 
-If Magic Tray works (or fails) on a mouse, keyboard, or trackpad you own, add a row to [docs/TESTED.md](docs/TESTED.md) and open a PR. Include PID, Bluetooth vs USB, tray version, battery (`ok` / `no reading`), and driver badge. Sign the commit (`git commit -s`).
+The device list the app and CI use is `MouseBatteryDevice.KnownMice` and `KeyboardBatteryDevice.KnownKeyboards`.
+
+- **PID already in those tables:** add a row to [docs/TESTED.md](docs/TESTED.md) and open a PR (`git commit -s`).
+- **PID not in those tables:** [open a missing-device issue](https://github.com/LesleyMurfin/magic-tray/issues/new?template=missing-device.md). Do not PR `TESTED.md` for an unknown PID.
+
 
 ## Bug reports
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Right-click the tray icon.
 Footer shows **Magic Tray 1.1.0**.
 
 ## Supported mice
+Live hardware reports (who tested what): [docs/TESTED.md](docs/TESTED.md).
 
 | Model | Bluetooth PID | USB HID | Scroll driver | Battery |
 |---|---|---|---|---|
@@ -108,6 +109,8 @@ Battery rows only: percent, enable, threshold, and time alerts. **No** KMDF / Bo
 | Magic Trackpad (v1) | `0x030E` | `VID_05AC` `PID_030E` | AA — 48h toast + death modal |
 | Magic Trackpad 2 | `0x0265` | `VID_05AC` `PID_0265` | Lightning — 24h night-before + plug-now |
 | Magic Trackpad 2024 (USB-C) | `0x0324` | `VID_05AC` `PID_0324` | USB-C — 24h night-before + plug-now |
+
+Hardware reports, including devices not tested here: [docs/TESTED.md](docs/TESTED.md).
 
 ## Scroll
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ Right-click the tray icon.
 Footer shows **Magic Tray 1.1.0**.
 
 ## Supported mice
-Live hardware reports (who tested what): [docs/TESTED.md](docs/TESTED.md).
+
+Catalog in the app: [`KnownMice`](MagicMouseTray/MouseBatteryDevice.cs) (CI: [`EveryKnownMousePid_HasUsbVid05acRow`](MagicMouseTray.Tests/MouseBatteryDeviceTests.cs)). Hardware reports: [docs/TESTED.md](docs/TESTED.md). PID not listed? [Open an issue](https://github.com/LesleyMurfin/magic-tray/issues/new?template=missing-device.md).
 
 | Model | Bluetooth PID | USB HID | Scroll driver | Battery |
 |---|---|---|---|---|
@@ -90,7 +91,8 @@ Live hardware reports (who tested what): [docs/TESTED.md](docs/TESTED.md).
 
 ## Supported keyboards
 
-Keyboard battery on Bluetooth needs the one-time SDP-cache patch (see [Keyboard battery](#keyboard-battery)). USB HID battery is read when Windows exposes `VID_05AC` + the same PID.
+Catalog: [`KnownKeyboards`](MagicMouseTray/KeyboardBatteryDevice.cs) (CI: [`EveryKeyboardPid_HasUsbVid05acRow`](MagicMouseTray.Tests/KeyboardBatteryDeviceTests.cs)). Keyboard battery on Bluetooth needs the one-time SDP-cache patch (see [Keyboard battery](#keyboard-battery)). USB HID battery is read when Windows exposes `VID_05AC` + the same PID.
+
 
 | Model | Bluetooth PID | USB HID | Status |
 |---|---|---|---|
@@ -110,7 +112,7 @@ Battery rows only: percent, enable, threshold, and time alerts. **No** KMDF / Bo
 | Magic Trackpad 2 | `0x0265` | `VID_05AC` `PID_0265` | Lightning — 24h night-before + plug-now |
 | Magic Trackpad 2024 (USB-C) | `0x0324` | `VID_05AC` `PID_0324` | USB-C — 24h night-before + plug-now |
 
-Hardware reports, including devices not tested here: [docs/TESTED.md](docs/TESTED.md).
+Hardware reports: [docs/TESTED.md](docs/TESTED.md). Missing PID: [open an issue](https://github.com/LesleyMurfin/magic-tray/issues/new?template=missing-device.md).
 
 ## Scroll
 

--- a/docs/TESTED.md
+++ b/docs/TESTED.md
@@ -1,64 +1,45 @@
 # Hardware reports
 
-Community results for Magic Tray on real devices. **In the catalog** (README) is not the same as **tested here**.
+This file is **who tested what**. It is not the device catalog.
 
-Open a PR that adds or updates **one row**. Do not edit README status columns in the same PR unless you also tested.
+The catalog Magic Tray actually loads is in the app, and CI fails if it drifts:
 
-## How to add a row
+| What | Where |
+|------|--------|
+| Mice and trackpads | [`MouseBatteryDevice.KnownMice`](../MagicMouseTray/MouseBatteryDevice.cs) |
+| Keyboards | [`KeyboardBatteryDevice.KnownKeyboards`](../MagicMouseTray/KeyboardBatteryDevice.cs) |
+| CI: every mouse PID has a USB row | [`EveryKnownMousePid_HasUsbVid05acRow`](../MagicMouseTray.Tests/MouseBatteryDeviceTests.cs) |
+| CI: every keyboard PID has a USB row | [`EveryKeyboardPid_HasUsbVid05acRow`](../MagicMouseTray.Tests/KeyboardBatteryDeviceTests.cs) |
+| CI: every display name resolves | [`KindForNameTests`](../MagicMouseTray.Tests/KindForNameTests.cs) |
 
-1. Magic Tray version (tray footer, or exe Properties → Details).
-2. Device Manager → the HID device → Details → **Hardware Ids** (`PID_xxxx` or `PID&xxxx`).
-3. Bluetooth, USB, or both.
-4. After **Refresh Now**: battery percent, or `No reading`.
-5. Mice: driver badge (`KMDF` / `Boot Camp` / `Stock` / `Patched Apple` / `Not bound`).
-6. Keyboards: SDP patch applied or not.
+If your device is **not in those tables**, do not add it here. [Open an issue](https://github.com/LesleyMurfin/magic-tray/issues/new?template=missing-device.md) with the Hardware Id PID so it can be added to `KnownMice` / `KnownKeyboards` (and CI) first.
 
-Optional: `%APPDATA%\MagicMouseTray\debug.log` (`OK battery=…`) and Windows build (`winver`).
+If it **is** in the catalog and you ran Magic Tray on it, add a report row below.
+
+## How to add a report
+
+1. Confirm the PID exists in `KnownMice` or `KnownKeyboards`. Missing → [issue](https://github.com/LesleyMurfin/magic-tray/issues/new?template=missing-device.md).
+2. Tray version (footer, or exe Properties → Details).
+3. Device Manager → HID device → Details → **Hardware Ids**.
+4. Bluetooth, USB, or both.
+5. After **Refresh Now**: percent, or `No reading`.
+6. Mice: driver badge (`KMDF` / `Boot Camp` / `Stock` / `Patched Apple` / `Not bound`).
+7. Keyboards: SDP `patched` or `unpatched`.
+
+Open a PR that adds **one row**. Sign the commit (`git commit -s`).
 
 | Column | Values |
 |--------|--------|
-| Battery | `ok` (percent shown) / `no reading` / `untested` |
-| Driver | badge text, or `n/a` for keyboards and trackpads |
+| Battery | `ok` / `no reading` |
+| Driver | badge text, or `n/a` |
 | SDP | `patched` / `unpatched` / `n/a` |
 
-One row per (PID, transport, Magic Tray version). Duplicate PIDs with a different Windows build or tray version are fine.
+One row per (PID, transport, Magic Tray version).
 
 ## Reports
 
 | Model | PID | Transport | Tray | Windows | Battery | Driver | SDP | Tester | Date | Notes |
 |-------|-----|-----------|------|---------|---------|--------|-----|--------|------|-------|
-| Magic Mouse 2024 (USB-C) | `0323` | Bluetooth | 1.1.0 | Windows 11 | ok (30%) | KMDF | n/a | LesleyMurfin | 2026-09-02 | Live tray screenshot |
-| Magic Mouse v1 | `030D` | Bluetooth | 1.1.0 | Windows 11 | no reading | Boot Camp | n/a | LesleyMurfin | 2026-09-02 | Device row present; battery not read |
-| Apple Wireless Keyboard (2011) | `0239` | Bluetooth | 1.1.0 | Windows 11 | ok (16%) | n/a | patched | LesleyMurfin | 2026-09-02 | Live tray screenshot |
-
-## Not yet reported
-
-These PIDs are in the app. No hardware report in this file yet.
-
-### Mice
-
-| Model | PID |
-|-------|-----|
-| Magic Mouse v2 | `0269` |
-| Apple Wireless Mouse | `0310` |
-| Magic Mouse 2024 (USB) | `0323` |
-| Magic Mouse v1 (USB) | `030D` |
-
-### Keyboards
-
-| Model | PID |
-|-------|-----|
-| Apple Wireless Keyboard (2011) ISO / JIS | `023A` / `023B` |
-| Apple Wireless Keyboard (2011 ANSI/ISO/JIS rev) | `0255` / `0256` / `0257` |
-| Magic Keyboard / ISO | `024F` / `0250` |
-| Magic Keyboard with Touch ID / ISO | `0267` / `026C` |
-| Magic Keyboard (2021) / Touch ID / Numeric Keypad | `029C` / `029A` / `029F` |
-| Magic Keyboard (2024, USB-C) / Touch ID / Numeric Keypad | `0320` / `0321` / `0322` |
-
-### Trackpads (battery only — no scroll driver)
-
-| Model | PID |
-|-------|-----|
-| Magic Trackpad (v1) | `030E` |
-| Magic Trackpad 2 | `0265` |
-| Magic Trackpad 2024 (USB-C) | `0324` |
+| Magic Mouse 2024 (USB-C) | `0323` | Bluetooth | 1.1.0 | Windows 11 | ok (30%) | KMDF | n/a | LesleyMurfin | 2026-09-02 | Live tray |
+| Magic Mouse v1 | `030D` | Bluetooth | 1.1.0 | Windows 11 | no reading | Boot Camp | n/a | LesleyMurfin | 2026-09-02 | Row present; battery not read |
+| Apple Wireless Keyboard (2011) | `0239` | Bluetooth | 1.1.0 | Windows 11 | ok (16%) | n/a | patched | LesleyMurfin | 2026-09-02 | Live tray |

--- a/docs/TESTED.md
+++ b/docs/TESTED.md
@@ -1,0 +1,64 @@
+# Hardware reports
+
+Community results for Magic Tray on real devices. **In the catalog** (README) is not the same as **tested here**.
+
+Open a PR that adds or updates **one row**. Do not edit README status columns in the same PR unless you also tested.
+
+## How to add a row
+
+1. Magic Tray version (tray footer, or exe Properties → Details).
+2. Device Manager → the HID device → Details → **Hardware Ids** (`PID_xxxx` or `PID&xxxx`).
+3. Bluetooth, USB, or both.
+4. After **Refresh Now**: battery percent, or `No reading`.
+5. Mice: driver badge (`KMDF` / `Boot Camp` / `Stock` / `Patched Apple` / `Not bound`).
+6. Keyboards: SDP patch applied or not.
+
+Optional: `%APPDATA%\MagicMouseTray\debug.log` (`OK battery=…`) and Windows build (`winver`).
+
+| Column | Values |
+|--------|--------|
+| Battery | `ok` (percent shown) / `no reading` / `untested` |
+| Driver | badge text, or `n/a` for keyboards and trackpads |
+| SDP | `patched` / `unpatched` / `n/a` |
+
+One row per (PID, transport, Magic Tray version). Duplicate PIDs with a different Windows build or tray version are fine.
+
+## Reports
+
+| Model | PID | Transport | Tray | Windows | Battery | Driver | SDP | Tester | Date | Notes |
+|-------|-----|-----------|------|---------|---------|--------|-----|--------|------|-------|
+| Magic Mouse 2024 (USB-C) | `0323` | Bluetooth | 1.1.0 | Windows 11 | ok (30%) | KMDF | n/a | LesleyMurfin | 2026-09-02 | Live tray screenshot |
+| Magic Mouse v1 | `030D` | Bluetooth | 1.1.0 | Windows 11 | no reading | Boot Camp | n/a | LesleyMurfin | 2026-09-02 | Device row present; battery not read |
+| Apple Wireless Keyboard (2011) | `0239` | Bluetooth | 1.1.0 | Windows 11 | ok (16%) | n/a | patched | LesleyMurfin | 2026-09-02 | Live tray screenshot |
+
+## Not yet reported
+
+These PIDs are in the app. No hardware report in this file yet.
+
+### Mice
+
+| Model | PID |
+|-------|-----|
+| Magic Mouse v2 | `0269` |
+| Apple Wireless Mouse | `0310` |
+| Magic Mouse 2024 (USB) | `0323` |
+| Magic Mouse v1 (USB) | `030D` |
+
+### Keyboards
+
+| Model | PID |
+|-------|-----|
+| Apple Wireless Keyboard (2011) ISO / JIS | `023A` / `023B` |
+| Apple Wireless Keyboard (2011 ANSI/ISO/JIS rev) | `0255` / `0256` / `0257` |
+| Magic Keyboard / ISO | `024F` / `0250` |
+| Magic Keyboard with Touch ID / ISO | `0267` / `026C` |
+| Magic Keyboard (2021) / Touch ID / Numeric Keypad | `029C` / `029A` / `029F` |
+| Magic Keyboard (2024, USB-C) / Touch ID / Numeric Keypad | `0320` / `0321` / `0322` |
+
+### Trackpads (battery only — no scroll driver)
+
+| Model | PID |
+|-------|-----|
+| Magic Trackpad (v1) | `030E` |
+| Magic Trackpad 2 | `0265` |
+| Magic Trackpad 2024 (USB-C) | `0324` |


### PR DESCRIPTION
## Summary

There was no file for people to record that a specific Magic device works.

Adds [docs/TESTED.md](docs/TESTED.md): how to add a row, three 1.1.0 reports from this machine, and untested catalog PIDs. README and CONTRIBUTING link to it.