### PR TITLE
docs(TESTED): Magic Mouse v1 030D battery ok

### DIFF
--- a/docs/TESTED.md
+++ b/docs/TESTED.md
@@ -41,5 +41,5 @@ One row per (PID, transport, Magic Tray version).
 | Model | PID | Transport | Tray | Windows | Battery | Driver | SDP | Tester | Date | Notes |
 |-------|-----|-----------|------|---------|---------|--------|-----|--------|------|-------|
 | Magic Mouse 2024 (USB-C) | `0323` | Bluetooth | 1.1.0 | Windows 11 | ok (30%) | KMDF | n/a | LesleyMurfin | 2026-09-02 | Live tray |
-| Magic Mouse v1 | `030D` | Bluetooth | 1.1.0 | Windows 11 | no reading | Boot Camp | n/a | LesleyMurfin | 2026-09-02 | Row present; battery not read |
+| Magic Mouse v1 | `030D` | Bluetooth | 1.1.0 | Windows 11 | ok (100%) | Boot Camp | n/a | LesleyMurfin | 2026-09-01 | Live tray; unified Feature 0x47 after poll |
 | Apple Wireless Keyboard (2011) | `0239` | Bluetooth | 1.1.0 | Windows 11 | ok (16%) | n/a | patched | LesleyMurfin | 2026-09-02 | Live tray |


### PR DESCRIPTION
Updates the seeded 030D row from \`no reading\` to \`ok (100%)\` after the live 1.1.0 Feature 0x47 poll (Boot Camp still bound).

Catalog unchanged. Hardware report only.