### PR TITLE
fix: point alerts help URL at main

### DIFF
--- a/MagicMouseTray.Tests/TrayMenuTests.cs
+++ b/MagicMouseTray.Tests/TrayMenuTests.cs
@@ -364,7 +364,7 @@ public class TrayMenuTests
         Assert.Equal("https://github.com/LesleyMurfin/magic-tray", TrayMenu.RepoUrl);
         Assert.Equal("https://github.com/LesleyMurfin/magic-tray/issues", TrayMenu.IssuesUrl);
         Assert.Equal(
-            "https://github.com/LesleyMurfin/magic-tray/blob/ship/magic-tray-ready/docs/ALERTS.md",
+            "https://github.com/LesleyMurfin/magic-tray/blob/main/docs/ALERTS.md",
             TrayMenu.AlertsDocUrl);
         Assert.Equal("https://github.com/LesleyMurfin/magic-tray/releases", TrayMenu.ReleasesUrl);
     }

--- a/MagicMouseTray/TrayApp.cs
+++ b/MagicMouseTray/TrayApp.cs
@@ -17,7 +17,7 @@ internal static class TrayMenu
     internal const string ReleasesUrl = "https://github.com/LesleyMurfin/magic-tray/releases";
     internal const string RepoUrl = "https://github.com/LesleyMurfin/magic-tray";
     internal const string IssuesUrl = "https://github.com/LesleyMurfin/magic-tray/issues";
-    internal const string AlertsDocUrl = "https://github.com/LesleyMurfin/magic-tray/blob/ship/magic-tray-ready/docs/ALERTS.md";
+    internal const string AlertsDocUrl = "https://github.com/LesleyMurfin/magic-tray/blob/main/docs/ALERTS.md";
     internal const string EnabledOnThisPc = "Enabled on this PC";
     internal const string HelpMenuLabel = "Help/Documentation";
     internal const string HowAlertsWorkLabel = "How alerts work";

--- a/docs/ALERTS.md
+++ b/docs/ALERTS.md
@@ -2,7 +2,7 @@
 
 Magic Tray warns you before a Magic Mouse, Magic Keyboard, or Magic Trackpad runs out. There are two kinds of warning: a **percent floor** you pick, and **time alerts** based on how fast that device has actually been draining.
 
-There is no evening reminder. The old 15% / 20% / 25% choices are gone.
+There is no evening reminder. The old 15% / 20% / 25% choices are gone: if an existing `config.ini` still carries `threshold=20` (or `threshold_<pid>=25`), that value is ignored on load and the floor falls back to **10%**.
 
 ## Percent floor (10 → 5 → 1)
 


### PR DESCRIPTION
Immediate 1.1.0 follow-up, reduced to issue #83 only.

- **#83** `TrayMenu.AlertsDocUrl` → `https://github.com/LesleyMurfin/magic-tray/blob/main/docs/ALERTS.md`, pinned by an exact-string assertion in `TrayMenuTests.HelpUrls_AndLabels_AreExact` so a branch-specific URL fails the build. The old `blob/ship/magic-tray-ready/...` URL rots once that branch is gone.
- `docs/ALERTS.md`: state that a legacy `threshold=15|20|25` left in an existing `config.ini` is ignored on load (`Config.IsValid` is 10/5/1) and the floor falls back to 10%. Previously the doc said only that the old *choices* were gone.

Scope removed from this PR:

- **#84** Enabled-on-this-PC docs → owned by #103, which rewrites that whole section (VID/PID gating, no-match path, same-model toggling). This PR does not touch that section.
- **#85** restore the three diagnostic scripts → already closed by #100 (merged 07c30ea). This PR no longer touches `diagnose-driver.ps1`, `scripts/capture-state.ps1`, or `scripts/mm-bt-stack-snapshot.ps1`, so the 9 CodeRabbit findings on them do not apply here; they were fixed in #100.

Still open: #86 custom %, #87 v1 enable live, #88 MU gestures, #89 0323 Test Mode, #65 SignPath, #70 e2e.