### PR TITLE
fix(ci): do not copy diagnostic scripts removed by public strip

### DIFF
--- a/MagicMouseTray/MagicMouseTray.csproj
+++ b/MagicMouseTray/MagicMouseTray.csproj
@@ -28,9 +28,4 @@
   <ItemGroup>
     <InternalsVisibleTo Include="MagicMouseTray.Tests" />
   </ItemGroup>
-  <ItemGroup>
-    <Content Include="..\scripts\capture-state.ps1" Link="scripts\capture-state.ps1" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
-    <Content Include="..\diagnose-driver.ps1" Link="scripts\diagnose-driver.ps1" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
-    <Content Include="..\scripts\mm-bt-stack-snapshot.ps1" Link="scripts\mm-bt-stack-snapshot.ps1" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
## Why CI is red

`build-and-test` and `verify-publish` fail with MSB3030: the csproj still copies

- `scripts/capture-state.ps1`
- `diagnose-driver.ps1`
- `scripts/mm-bt-stack-snapshot.ps1`

Those files were deleted in the public strip (#76). Every PR and every `main` push fails until this is gone.

## This PR

Drop the `Content` includes. `DiagnosticScripts.Find` already returns null when the files are missing, so Diagnostics menu items stay hidden.

## Not this PR

[#90](https://github.com/LesleyMurfin/magic-tray/pull/90) restores the lab scripts instead. That also unblocks CI, but it puts internal diagnostics back on the public repo (CodeRabbit CHANGES_REQUESTED).