### PR TITLE
docs: Stripe Payment Link funding (off GitHub Sponsors)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,3 @@
-github: LesleyMurfin
+# Off GitHub Sponsors. Stripe Payment Link lives on the funding page
+# (replace with https://buy.stripe.com/... once the Dashboard link exists).
+custom: ["https://lesleymurfin.github.io/magic-tray/funding.html"]

--- a/docs/STRIPE-SETUP.md
+++ b/docs/STRIPE-SETUP.md
@@ -1,0 +1,15 @@
+# Stripe Payment Link (off GitHub Sponsors)
+
+GitHub Sponsors is **not** used. Cards never go through the tray app.
+
+An agent cannot finish Stripe identity/bank verification. You do this once in the browser.
+
+1. Open [https://dashboard.stripe.com/register](https://dashboard.stripe.com/register) (real `stripe.com` only). Enable 2FA.
+2. Complete identity (you or Revive Business Solutions) and a payout account.
+3. Product catalog → add product: **Magic Mouse v3 driver signing**  
+   Description: one-time contribution toward an EV code-signing certificate and Microsoft Hardware Dev Center attestation. MIT driver, no scroll kill.
+4. **Payment Links** → New → that product (one-time; optional recurring later).
+5. Copy `https://buy.stripe.com/…`.
+6. Tell an agent: replace `.github/FUNDING.yml` `custom:` with that URL, and put the same href on `docs/funding.html` as the primary CTA.
+
+Until step 5 exists, FUNDING.yml points at https://lesleymurfin.github.io/magic-tray/funding.html (stars + goal). Do not commit Stripe secret keys.

--- a/docs/funding.html
+++ b/docs/funding.html
@@ -33,11 +33,11 @@
   </header>
   <main>
     <h2>The goal</h2>
-    <p><strong>EV code-signing certificate + Microsoft Hardware Dev Center attestation</strong> for <code>MagicMouseDriver</code> in <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">magic-mouse-v3-windows-fix</a>. Then Magic Tray’s KMDF install no longer needs Test Mode. The tray app stays MIT and free. The signed <code>.sys</code> is published for everyone — no license check in the filter.</p>
+    <p><strong>EV code-signing certificate + Microsoft Hardware Dev Center attestation</strong> for <code>MagicMouseDriver</code> in <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">magic-mouse-v3-windows-fix</a>. Then Magic Tray’s KMDF install no longer needs Test Mode. The tray stays MIT. The signed <code>.sys</code> is published for everyone — no license check in the filter.</p>
     <ul class="plain">
-      <li>GitHub Sponsors (once enabled on LesleyMurfin) earmarked “EV + attestation.”</li>
-      <li>Until Sponsors is live, star both repos and watch this page.</li>
-      <li>We will <strong>not</strong> unbind scroll if money stops. That is the MU failure mode.</li>
+      <li><strong>Stripe (not GitHub Sponsors).</strong> One-time Payment Link toward “EV + attestation.” No cards inside the app. Link appears here after Stripe identity verification on stripe.com — then we set <code>buy.stripe.com/…</code> in <code>.github/FUNDING.yml</code>.</li>
+      <li>Until that link is live: <a href="https://github.com/LesleyMurfin/magic-tray">star Magic Tray</a> and <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">star the v3 driver</a>.</li>
+      <li>We will <strong>not</strong> unbind scroll if money stops.</li>
     </ul>
 
     <h2>What “signed publicly” means</h2>
@@ -58,12 +58,12 @@
       </tbody>
     </table>
 
-    <h2>Stars vs subscription vs pay-once driver</h2>
+    <h2>Stars vs Stripe vs subscription</h2>
     <table>
       <thead><tr><th></th><th>Funds</th><th>We do this?</th></tr></thead>
       <tbody>
-        <tr><td>Star both repos</td><td>Discoverability, nothing else</td><td>Yes — please</td></tr>
-        <tr><td>Sponsors → EV + attestation</td><td>One signed KMDF for everyone</td><td>Yes, that is the goal</td></tr>
+        <tr><td>Star both repos</td><td>Discoverability</td><td>Yes — please</td></tr>
+        <tr><td>Stripe Payment Link → EV + attestation</td><td>One signed KMDF for everyone</td><td>Yes — off GitHub Sponsors</td></tr>
         <tr><td>Pay-once signed .sys</td><td>Cert renewal</td><td>Maybe later; scroll must keep working if they never pay again</td></tr>
         <tr><td>Subscription that expires the filter</td><td>WHQL like MU</td><td><strong>No</strong></td></tr>
       </tbody>


### PR DESCRIPTION
Removes GitHub Sponsors from FUNDING.yml. Custom link is the funding page until a buy.stripe.com Payment Link is pasted. STRIPE-SETUP.md is the dashboard checklist.