### PR TITLE
fix: restore Diagnostics scripts and ship them with the exe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,21 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
+    # Guards the MSB3030 class of break: a Content Include left pointing at a
+    # file that no longer exists fails the build for every PR, not just its own.
+    - name: Check csproj Content paths exist on disk
+      shell: pwsh
+      run: |
+        $proj = 'MagicMouseTray/MagicMouseTray.csproj'
+        $root = Split-Path -Parent $proj
+        $missing = @(
+          Select-Xml -Path $proj -XPath '//Content/@Include' |
+            ForEach-Object { $_.Node.Value } |
+            Where-Object { -not (Test-Path -LiteralPath (Join-Path $root ($_ -replace '\\', '/'))) }
+        )
+        if ($missing) { throw "csproj Content Include paths missing on disk: $($missing -join ', ')" }
+        Write-Host "All csproj Content Include paths exist."
+
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,14 @@ jobs:
     - name: Publish
       run: dotnet publish MagicMouseTray/MagicMouseTray.csproj -c Release -o publish
 
-    - name: Stage keyboard battery patch
+    - name: Stage keyboard patch and diagnostic scripts
       shell: pwsh
       run: |
         Copy-Item -LiteralPath scripts/kbd-patch-cachedservices.ps1 publish/kbd-patch-cachedservices.ps1
         Copy-Item -LiteralPath scripts/Install-KeyboardBattery.cmd publish/Install-KeyboardBattery.cmd
+        Copy-Item -LiteralPath scripts/capture-state.ps1 publish/capture-state.ps1
+        Copy-Item -LiteralPath diagnose-driver.ps1 publish/diagnose-driver.ps1
+        Copy-Item -LiteralPath scripts/mm-bt-stack-snapshot.ps1 publish/mm-bt-stack-snapshot.ps1
 
     - name: Verify release artifacts
       run: pwsh -File scripts/verify-release.ps1 -PublishDir publish

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: release
 
-# Build, test, publish, optionally Authenticode-sign, and attach the exe plus
-# the keyboard battery patch on a v* tag.
+# Build, test, publish, optionally Authenticode-sign, and attach the exe, keyboard
+# battery patch, and Diagnostics menu scripts on a v* tag.
 on:
   push:
     tags:
@@ -37,14 +37,24 @@ jobs:
       - name: Publish (single-file, self-contained win-x64)
         run: dotnet publish MagicMouseTray/MagicMouseTray.csproj -c Release -o publish
 
-      - name: Stage keyboard battery patch
+      - name: Stage keyboard patch and diagnostic scripts
         shell: pwsh
         run: |
           Copy-Item -LiteralPath scripts/kbd-patch-cachedservices.ps1 publish/kbd-patch-cachedservices.ps1
           Copy-Item -LiteralPath scripts/Install-KeyboardBattery.cmd publish/Install-KeyboardBattery.cmd
-          if (-not (Test-Path publish/MagicMouseTray.exe)) { throw 'publish/MagicMouseTray.exe missing' }
-          if (-not (Test-Path publish/kbd-patch-cachedservices.ps1)) { throw 'kbd-patch-cachedservices.ps1 missing' }
-          if (-not (Test-Path publish/Install-KeyboardBattery.cmd)) { throw 'Install-KeyboardBattery.cmd missing' }
+          Copy-Item -LiteralPath scripts/capture-state.ps1 publish/capture-state.ps1
+          Copy-Item -LiteralPath diagnose-driver.ps1 publish/diagnose-driver.ps1
+          Copy-Item -LiteralPath scripts/mm-bt-stack-snapshot.ps1 publish/mm-bt-stack-snapshot.ps1
+          foreach ($f in @(
+            'publish/MagicMouseTray.exe',
+            'publish/kbd-patch-cachedservices.ps1',
+            'publish/Install-KeyboardBattery.cmd',
+            'publish/capture-state.ps1',
+            'publish/diagnose-driver.ps1',
+            'publish/mm-bt-stack-snapshot.ps1'
+          )) {
+            if (-not (Test-Path $f)) { throw "$f missing" }
+          }
 
       # Optional Authenticode signing — runs only when the PFX secrets exist.
       - name: Sign (optional)
@@ -60,4 +70,4 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${{ github.ref_name }}" "publish/MagicMouseTray.exe" "publish/kbd-patch-cachedservices.ps1" "publish/Install-KeyboardBattery.cmd" "publish/SHA256SUMS" --generate-notes
+        run: gh release create "${{ github.ref_name }}" "publish/MagicMouseTray.exe" "publish/kbd-patch-cachedservices.ps1" "publish/Install-KeyboardBattery.cmd" "publish/capture-state.ps1" "publish/diagnose-driver.ps1" "publish/mm-bt-stack-snapshot.ps1" "publish/SHA256SUMS" --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,10 +64,12 @@ jobs:
           [IO.File]::WriteAllBytes("$env:RUNNER_TEMP\cert.pfx", [Convert]::FromBase64String($env:SIGN_PFX_BASE64))
           ./scripts/sign-app.ps1 -Exe publish/MagicMouseTray.exe -PfxPath "$env:RUNNER_TEMP\cert.pfx" -PfxPassword $env:SIGN_PFX_PASSWORD
 
+      # GITHUB_REF_NAME is a default Actions env var: read it instead of
+      # interpolating github.ref_name into the command line.
       - name: Verify release artifacts
-        run: pwsh -File scripts/verify-release.ps1 -PublishDir publish -Tag "${{ github.ref_name }}"
+        run: pwsh -File scripts/verify-release.ps1 -PublishDir publish -Tag "$env:GITHUB_REF_NAME"
 
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${{ github.ref_name }}" "publish/MagicMouseTray.exe" "publish/kbd-patch-cachedservices.ps1" "publish/Install-KeyboardBattery.cmd" "publish/capture-state.ps1" "publish/diagnose-driver.ps1" "publish/mm-bt-stack-snapshot.ps1" "publish/SHA256SUMS" --generate-notes
+        run: gh release create "$env:GITHUB_REF_NAME" "publish/MagicMouseTray.exe" "publish/kbd-patch-cachedservices.ps1" "publish/Install-KeyboardBattery.cmd" "publish/capture-state.ps1" "publish/diagnose-driver.ps1" "publish/mm-bt-stack-snapshot.ps1" "publish/SHA256SUMS" --generate-notes

--- a/MagicMouseTray/MagicMouseTray.csproj
+++ b/MagicMouseTray/MagicMouseTray.csproj
@@ -29,8 +29,8 @@
     <InternalsVisibleTo Include="MagicMouseTray.Tests" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="..\scripts\capture-state.ps1" Link="scripts\capture-state.ps1" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
-    <Content Include="..\diagnose-driver.ps1" Link="scripts\diagnose-driver.ps1" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
-    <Content Include="..\scripts\mm-bt-stack-snapshot.ps1" Link="scripts\mm-bt-stack-snapshot.ps1" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="..\scripts\capture-state.ps1" Link="capture-state.ps1" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="..\diagnose-driver.ps1" Link="diagnose-driver.ps1" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
+    <Content Include="..\scripts\mm-bt-stack-snapshot.ps1" Link="mm-bt-stack-snapshot.ps1" CopyToOutputDirectory="PreserveNewest" CopyToPublishDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Log file: `%APPDATA%\MagicMouseTray\debug.log`
 
 ## Releases
 
-CI builds on a `v*` tag: test, publish win-x64, optional Authenticode (`SIGN_PFX_*`), then attach `MagicMouseTray.exe`, `kbd-patch-cachedservices.ps1`, `Install-KeyboardBattery.cmd`, and `SHA256SUMS`. `scripts/verify-release.ps1` must pass before the GitHub Release is created.
+CI builds on a `v*` tag: test, publish win-x64, optional Authenticode (`SIGN_PFX_*`), then attach `MagicMouseTray.exe`, `kbd-patch-cachedservices.ps1`, `Install-KeyboardBattery.cmd`, `capture-state.ps1`, `diagnose-driver.ps1`, `mm-bt-stack-snapshot.ps1`, and `SHA256SUMS`. `scripts/verify-release.ps1` must pass before the GitHub Release is created.
 
 `FileVersion` / `AssemblyVersion` are `1.1.0.0`.
 

--- a/diagnose-driver.ps1
+++ b/diagnose-driver.ps1
@@ -7,7 +7,11 @@
 
 $driverName = "applewirelessmouse"
 $sysFile    = "C:\Windows\System32\drivers\$driverName.sys"
-$logFile    = "$env:USERPROFILE\Desktop\apple-mouse-diag.txt"
+$logDir     = [Environment]::GetFolderPath('Desktop')
+if ([string]::IsNullOrWhiteSpace($logDir) -or -not (Test-Path -LiteralPath $logDir -PathType Container)) {
+    $logDir = [System.IO.Path]::GetTempPath()
+}
+$logFile    = Join-Path $logDir 'apple-mouse-diag.txt'
 
 function Write-Log {
     param([string]$text)
@@ -53,6 +57,11 @@ function Get-TrustedSysinternalsExe {
         if (-not (Test-AdministratorOwnedFile $path)) { continue }
         $sig = Get-AuthenticodeSignature -LiteralPath $path
         if ($sig.Status -ne 'Valid') { continue }
+        # A valid chain alone proves nothing: require a Microsoft/Sysinternals
+        # publisher before we execute the binary.
+        $signer = $sig.SignerCertificate
+        if (-not $signer) { continue }
+        if ($signer.Subject -notmatch 'O=(Microsoft Corporation|Sysinternals)') { continue }
         return $path
     }
     return $null
@@ -95,14 +104,15 @@ $autorunsPath = Get-TrustedSysinternalsExe 'autorunsc.exe'
 if ($autorunsPath) {
     Write-Log "Using: $autorunsPath"
     # -nobanner suppresses header noise; pipe to Select-String handles Unicode
-    & $autorunsPath -accepteula -nobanner -a d 2>&1 |
+    # One enumeration is slow; run it once and reuse the captured output.
+    $autorunsOutput = @(& $autorunsPath -accepteula -nobanner -a d 2>&1)
+    $autorunsOutput |
         Select-String -Pattern "apple" -CaseSensitive:$false |
         ForEach-Object { Write-Log "  $_" }
 
     Write-Log ""
     Write-Log "--- Full driver list (all entries) ---"
-    & $autorunsPath -accepteula -nobanner -a d 2>&1 |
-        ForEach-Object { Write-Log "  $_" }
+    $autorunsOutput | ForEach-Object { Write-Log "  $_" }
 } else {
     Write-Log "autorunsc.exe not found in common paths. Skipping."
     Write-Log "Download from: https://learn.microsoft.com/sysinternals/downloads/autoruns"

--- a/diagnose-driver.ps1
+++ b/diagnose-driver.ps1
@@ -1,0 +1,191 @@
+#Requires -RunAsAdministrator
+<#
+.SYNOPSIS
+    Apple Wireless Mouse driver diagnostic script.
+    Run from PowerShell as Administrator.
+#>
+
+$driverName = "applewirelessmouse"
+$sysFile    = "C:\Windows\System32\drivers\$driverName.sys"
+$logFile    = "$env:USERPROFILE\Desktop\apple-mouse-diag.txt"
+
+function Write-Log {
+    param([string]$text)
+    $line = "[$(Get-Date -Format 'HH:mm:ss')] $text"
+    Write-Host $line
+    Add-Content -Path $logFile -Value $line
+}
+
+function Write-Section {
+    param([string]$title)
+    $bar = "=" * 60
+    Write-Log ""
+    Write-Log $bar
+    Write-Log "  $title"
+    Write-Log $bar
+}
+
+function Test-AdministratorOwnedFile {
+    param([string]$Path)
+    try {
+        $dir = Split-Path -Parent $Path
+        $acl = Get-Acl -LiteralPath $dir
+        $owner = $acl.Owner
+        return ($owner -like '*\SYSTEM' -or $owner -like '*\Administrators')
+    } catch {
+        return $false
+    }
+}
+
+function Get-TrustedSysinternalsExe {
+    param([string]$FileName)
+    $pf86 = ${env:ProgramFiles(x86)}
+    $candidates = @(
+        "C:\Tools\$FileName",
+        "C:\Sysinternals\$FileName",
+        (Join-Path $env:ProgramFiles "Sysinternals\$FileName")
+    )
+    if ($pf86) {
+        $candidates += (Join-Path $pf86 "Sysinternals\$FileName")
+    }
+    foreach ($path in $candidates) {
+        if (-not (Test-Path -LiteralPath $path)) { continue }
+        if (-not (Test-AdministratorOwnedFile $path)) { continue }
+        $sig = Get-AuthenticodeSignature -LiteralPath $path
+        if ($sig.Status -ne 'Valid') { continue }
+        return $path
+    }
+    return $null
+}
+
+# Start fresh log
+"" | Set-Content $logFile
+Write-Log "Apple Wireless Mouse Driver Diagnostic"
+Write-Log "Date: $(Get-Date)"
+
+# ── 1. Driver .sys file ──────────────────────────────────────
+Write-Section "1. Driver .sys file"
+if (Test-Path $sysFile) {
+    $file = Get-Item $sysFile
+    Write-Log "FOUND: $sysFile"
+    Write-Log "  Size:     $($file.Length) bytes"
+    Write-Log "  Modified: $($file.LastWriteTime)"
+
+    # Authenticode signature (built-in, no Sysinternals needed)
+    $sig = Get-AuthenticodeSignature $sysFile
+    Write-Log "  Signature status: $($sig.Status)"
+    Write-Log "  Signer:           $($sig.SignerCertificate.Subject)"
+} else {
+    Write-Log "NOT FOUND: $sysFile  <-- driver binary is missing"
+}
+
+# ── 2. Service config ────────────────────────────────────────
+Write-Section "2. Service config (sc qc)"
+$scOutput = & sc.exe qc $driverName 2>&1
+$scOutput | ForEach-Object { Write-Log "  $_" }
+
+Write-Section "2b. Service state (sc query)"
+$scQuery = & sc.exe query $driverName 2>&1
+$scQuery | ForEach-Object { Write-Log "  $_" }
+
+# ── 3. Autorunsc (Unicode-safe via Select-String) ────────────
+Write-Section "3. Autoruns - registered driver entries"
+$autorunsPath = Get-TrustedSysinternalsExe 'autorunsc.exe'
+
+if ($autorunsPath) {
+    Write-Log "Using: $autorunsPath"
+    # -nobanner suppresses header noise; pipe to Select-String handles Unicode
+    & $autorunsPath -accepteula -nobanner -a d 2>&1 |
+        Select-String -Pattern "apple" -CaseSensitive:$false |
+        ForEach-Object { Write-Log "  $_" }
+
+    Write-Log ""
+    Write-Log "--- Full driver list (all entries) ---"
+    & $autorunsPath -accepteula -nobanner -a d 2>&1 |
+        ForEach-Object { Write-Log "  $_" }
+} else {
+    Write-Log "autorunsc.exe not found in common paths. Skipping."
+    Write-Log "Download from: https://learn.microsoft.com/sysinternals/downloads/autoruns"
+}
+
+# ── 4. Sigcheck (if available) ───────────────────────────────
+Write-Section "4. Sigcheck - deep signature verification"
+$sigcheckPath = Get-TrustedSysinternalsExe 'sigcheck.exe'
+
+if ($sigcheckPath -and (Test-Path $sysFile)) {
+    & $sigcheckPath -accepteula -i -a $sysFile 2>&1 |
+        ForEach-Object { Write-Log "  $_" }
+} elseif (-not $sigcheckPath) {
+    Write-Log "sigcheck.exe not found. Skipping."
+} else {
+    Write-Log "Driver .sys not present - skipping sigcheck."
+}
+
+# ── 5. pnputil device info ───────────────────────────────────
+Write-Section "5. PnP devices - Apple HID/BT entries"
+& pnputil /enum-devices 2>&1 |
+    Select-String -Pattern "apple|00001124-0000-1000-8000-00805f9b34fb" -CaseSensitive:$false |
+    ForEach-Object { Write-Log "  $_" }
+
+Write-Section "5b. INF package info (Apple / applewirelessmouse)"
+$driverText = (& pnputil /enum-drivers 2>&1 | Out-String)
+$driverBlocks = [regex]::Split($driverText, '(?mi)(?=^\s*Published Name\s*:)')
+$matchedPackage = $false
+foreach ($block in $driverBlocks) {
+    if ($block -notmatch '(?im)Provider Name\s*:.*Apple|Original Name\s*:.*apple') {
+        continue
+    }
+    $matchedPackage = $true
+    foreach ($line in ($block -split '\r?\n')) {
+        if ($line.Trim().Length -gt 0) {
+            Write-Log "  $($line.TrimEnd())"
+        }
+    }
+    Write-Log ""
+}
+if (-not $matchedPackage) {
+    Write-Log "  (no Apple / applewirelessmouse driver packages found)"
+}
+
+# ── 6. Windows Event Log errors ──────────────────────────────
+Write-Section "6. System event log - driver/service errors (last 48h)"
+$since = (Get-Date).AddHours(-48)
+Get-WinEvent -FilterHashtable @{
+    LogName   = 'System'
+    StartTime = $since
+    Id        = @(7000, 7001, 7009, 7011, 7022, 7023, 7026, 7034, 7043)
+} -ErrorAction SilentlyContinue |
+    Where-Object {
+        $_.Message -match "apple|wirelessmouse|hid" -or $_.ProviderName -match "apple"
+    } |
+    Sort-Object TimeCreated |
+    ForEach-Object {
+        Write-Log "  [$($_.TimeCreated)] ID=$($_.Id) - $($_.Message -replace '\s+',' ')"
+    }
+
+Write-Section "7. Registry - LowerFilters entry"
+$hidClassRoot = "HKLM:\SYSTEM\CurrentControlSet\Control\Class\{745a17a0-74d3-11d0-b6fe-00a0c90f57da}"
+try {
+    $instances = @(Get-ChildItem -LiteralPath $hidClassRoot -ErrorAction Stop |
+        Where-Object { $_.PSChildName -match '^\d{4}$' })
+    if ($instances.Count -eq 0) {
+        Write-Log "  No numbered HID class instances found"
+    }
+    foreach ($inst in $instances) {
+        $lf = $inst.GetValue('LowerFilters')
+        $desc = $inst.GetValue('DriverDesc')
+        if ($null -eq $lf) {
+            Write-Log "  $($inst.PSChildName) ($desc): (no LowerFilters)"
+        } else {
+            Write-Log "  $($inst.PSChildName) ($desc): $($lf -join ', ')"
+        }
+    }
+} catch {
+    Write-Log "  Could not read HID class registry: $_"
+}
+
+# ── Done ─────────────────────────────────────────────────────
+Write-Section "DONE"
+Write-Log "Full log saved to: $logFile"
+Write-Host ""
+Write-Host "Log written to: $logFile" -ForegroundColor Cyan

--- a/scripts/capture-state.ps1
+++ b/scripts/capture-state.ps1
@@ -1,0 +1,228 @@
+# capture-state.ps1 - Snapshot Magic Mouse device state for reboot comparison
+# Run before a reboot, then again after, then compare.
+#
+# Usage:
+#   .\capture-state.ps1 -Label "pre-reboot"         -> saves state-pre-reboot.json
+#   .\capture-state.ps1 -Label "post-reboot-1"      -> saves state-post-reboot-1.json
+#   .\capture-state.ps1 -Compare .\state-pre-reboot.json .\state-post-reboot-1.json
+#
+# Saved to current directory unless -OutputDir is specified.
+# Run elevated (some queries need admin for sc.exe and registry reads).
+
+param(
+    [string]$Label = "",
+    [switch]$Compare,
+    [string]$FileA = "",
+    [string]$FileB = "",
+    [string]$OutputDir = "."
+)
+
+Set-StrictMode -Version 2
+
+# ---- Compare mode ----
+if ($Compare) {
+    if (-not $FileA -or -not $FileB) {
+        # Try positional args if Compare was used with positional params
+        $args2 = $args
+        Write-Host "Usage: capture-state.ps1 -Compare <fileA.json> <fileB.json>" -ForegroundColor Yellow
+        exit 1
+    }
+
+    $a = Get-Content $FileA -Raw | ConvertFrom-Json
+    $b = Get-Content $FileB -Raw | ConvertFrom-Json
+
+    function Assert-StateSnapshot {
+        param($Obj, [string]$Path)
+        if ($null -eq $Obj) {
+            throw "Invalid snapshot: $Path is empty."
+        }
+        $required = @(
+            'col01Present', 'col02Present', 'filterInStack',
+            'lowerFiltersEnumKey', 'lowerFiltersDriverKey',
+            'serviceState', 'hidDeviceCount'
+        )
+        foreach ($name in $required) {
+            if ($null -eq $Obj.PSObject.Properties[$name]) {
+                throw "Invalid snapshot ${Path}: missing property '$name'."
+            }
+        }
+        foreach ($name in @('col01Present', 'col02Present', 'filterInStack')) {
+            $val = $Obj.$name
+            if ($null -ne $val -and $val -isnot [bool]) {
+                throw "Invalid snapshot ${Path}: '$name' must be boolean."
+            }
+        }
+        $count = $Obj.hidDeviceCount
+        if ($null -ne $count -and -not (
+                $count -is [int] -or $count -is [long] -or
+                $count -is [decimal] -or $count -is [double])) {
+            throw "Invalid snapshot ${Path}: 'hidDeviceCount' must be a number."
+        }
+        if ($null -ne $Obj.serviceState -and $Obj.serviceState -isnot [string]) {
+            throw "Invalid snapshot ${Path}: 'serviceState' must be a string."
+        }
+    }
+
+    try {
+        Assert-StateSnapshot $a $FileA
+        Assert-StateSnapshot $b $FileB
+    } catch {
+        Write-Host $_.Exception.Message -ForegroundColor Red
+        exit 1
+    }
+
+    Write-Host ""
+    Write-Host "=== STATE COMPARISON ===" -ForegroundColor Cyan
+    Write-Host "  A: $($a.label)  [$($a.timestamp)]"
+    Write-Host "  B: $($b.label)  [$($b.timestamp)]"
+    Write-Host ""
+
+    function Diff-Field {
+        param($Name, $ValA, $ValB, [switch]$GoodIfTrue, [switch]$GoodIfEqual)
+        $changed = ($ValA -ne $ValB) -and ($null -ne $ValA) -and ($null -ne $ValB)
+        if ($changed) {
+            $color = "Yellow"
+            if ($GoodIfTrue  -and $ValB) { $color = "Green" }
+            if ($GoodIfTrue  -and !$ValB) { $color = "Red" }
+            if ($GoodIfEqual) { $color = "Yellow" }
+            Write-Host "  CHANGED  $Name" -ForegroundColor $color
+            Write-Host "           A: $ValA"
+            Write-Host "           B: $ValB"
+        } else {
+            Write-Host "  same     $Name = $ValA"
+        }
+    }
+
+    Diff-Field "col01Present"           $a.col01Present          $b.col01Present          -GoodIfTrue
+    Diff-Field "col02Present"           $a.col02Present          $b.col02Present          -GoodIfTrue
+    Diff-Field "filterInStack"          $a.filterInStack         $b.filterInStack
+    Diff-Field "lowerFiltersEnumKey"    ($a.lowerFiltersEnumKey  -join ',') ($b.lowerFiltersEnumKey  -join ',') -GoodIfEqual
+    Diff-Field "lowerFiltersDriverKey"  ($a.lowerFiltersDriverKey -join ',') ($b.lowerFiltersDriverKey -join ',') -GoodIfEqual
+    Diff-Field "serviceState"           $a.serviceState          $b.serviceState
+    Diff-Field "hidDeviceCount"         $a.hidDeviceCount        $b.hidDeviceCount        -GoodIfTrue
+
+    Write-Host ""
+    Write-Host "=== STARTUP-REPAIR LOG (B only - last 10 lines) ===" -ForegroundColor Cyan
+    if ($b.startupRepairLog) {
+        $b.startupRepairLog | Select-Object -Last 10 | ForEach-Object { Write-Host "  $_" }
+    } else {
+        Write-Host "  (no log data in B)"
+    }
+    Write-Host ""
+    exit 0
+}
+
+# ---- Capture mode ----
+if (-not $Label) {
+    $Label = "capture-$(Get-Date -Format 'yyyyMMdd-HHmmss')"
+    Write-Host "No -Label specified, using: $Label" -ForegroundColor Yellow
+}
+
+$mmPid = "0323"
+$state = [ordered]@{
+    label              = $Label
+    timestamp          = (Get-Date -Format 'yyyy-MM-dd HH:mm:ss')
+    col01Present       = $false
+    col02Present       = $false
+    filterInStack      = $false
+    hidDeviceCount     = 0
+    hidDevices         = @()
+    bthenumInstanceId  = ""
+    lowerFiltersEnumKey    = @()
+    lowerFiltersDriverKey  = @()
+    serviceState       = ""
+    startupRepairLog   = @()
+}
+
+# Find BTHENUM parent
+$btDev = Get-PnpDevice -ErrorAction SilentlyContinue |
+    Where-Object { $_.InstanceId -match 'BTHENUM' -and
+                   $_.InstanceId -match '00001124' -and
+                   $_.InstanceId -match "_PID&$mmPid" -and
+                   $_.Status -eq 'OK' } |
+    Select-Object -First 1
+
+if ($btDev) {
+    $state.bthenumInstanceId = $btDev.InstanceId
+
+    # Driver stack
+    try {
+        $stackProp = Get-PnpDeviceProperty -InstanceId $btDev.InstanceId `
+            -KeyName 'DEVPKEY_Device_Stack' -ErrorAction SilentlyContinue
+        if ($stackProp -and $stackProp.Data) {
+            $stackStr = $stackProp.Data -join ' '
+            $state.filterInStack = $stackStr -imatch 'applewirelessmouse'
+        }
+    } catch {}
+
+    # LowerFilters - Enum key
+    $btRegPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\" + $btDev.InstanceId
+    try {
+        $lf = (Get-ItemProperty -Path $btRegPath -Name LowerFilters -ErrorAction SilentlyContinue).LowerFilters
+        if ($lf) { $state.lowerFiltersEnumKey = @($lf) }
+    } catch {}
+
+    # LowerFilters - driver instance key
+    try {
+        $driverKey = (Get-ItemProperty -Path $btRegPath -Name Driver -ErrorAction SilentlyContinue).Driver
+        if ($driverKey) {
+            $driverInstPath = "HKLM:\SYSTEM\CurrentControlSet\Control\Class\$driverKey"
+            $lf2 = (Get-ItemProperty -Path $driverInstPath -Name LowerFilters -ErrorAction SilentlyContinue).LowerFilters
+            if ($lf2) { $state.lowerFiltersDriverKey = @($lf2) }
+        }
+    } catch {}
+}
+
+# HID devices with this PID
+$hidDevices = Get-PnpDevice -Class HIDClass -ErrorAction SilentlyContinue |
+    Where-Object {
+        $_.InstanceId -match ('^HID\\VID_05AC&PID_' + $mmPid) -and
+        $_.Status -eq 'OK'
+    }
+$hidList = @($hidDevices)
+$state.hidDeviceCount = $hidList.Count
+$state.hidDevices     = $hidList | ForEach-Object { @{ instanceId = $_.InstanceId; status = $_.Status } }
+$state.col01Present   = @($hidList | Where-Object { $_.InstanceId -match 'COL01' }).Count -gt 0
+$state.col02Present   = @($hidList | Where-Object { $_.InstanceId -match 'COL02' }).Count -gt 0
+
+# Service state
+try {
+    $scOut = & sc.exe query applewirelessmouse 2>&1
+    $state.serviceState = ($scOut | Where-Object { $_ -match 'STATE' } | Select-Object -First 1).Trim()
+} catch {}
+
+# startup-repair.log
+$logFile = "C:\ProgramData\MagicMouseTray\startup-repair.log"
+if (Test-Path $logFile) {
+    $state.startupRepairLog = @(Get-Content $logFile -Tail 20)
+}
+
+# Save JSON
+if (-not (Test-Path -LiteralPath $OutputDir -PathType Container)) {
+    New-Item -ItemType Directory -Path $OutputDir -Force -ErrorAction Stop | Out-Null
+}
+$outFile = Join-Path $OutputDir "state-$Label.json"
+$state | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath $outFile -Encoding UTF8 -ErrorAction Stop
+
+# Print summary
+Write-Host ""
+Write-Host "=== STATE CAPTURED: $Label ===" -ForegroundColor Cyan
+Write-Host "  Timestamp:      $($state.timestamp)"
+Write-Host "  COL01 (scroll): $($state.col01Present)" -ForegroundColor $(if ($state.col01Present) {"Green"} else {"Red"})
+Write-Host "  COL02 (battery):$($state.col02Present)" -ForegroundColor $(if ($state.col02Present) {"Green"} else {"Red"})
+Write-Host "  Filter in stack:$($state.filterInStack)"
+Write-Host "  LowerFilters(Enum):   $($state.lowerFiltersEnumKey -join ', ')"
+Write-Host "  LowerFilters(Driver): $($state.lowerFiltersDriverKey -join ', ')"
+Write-Host "  Service state:  $($state.serviceState)"
+Write-Host "  HID device count: $($state.hidDeviceCount)"
+if ($state.startupRepairLog.Count -gt 0) {
+    Write-Host "  Last log entry: $($state.startupRepairLog | Select-Object -Last 1)"
+}
+Write-Host ""
+Write-Host "Saved: $outFile" -ForegroundColor Green
+Write-Host ""
+Write-Host "Workflow:" -ForegroundColor Yellow
+Write-Host "  1. Run this NOW (before reboot):  capture-state.ps1 -Label pre-reboot"
+Write-Host "  2. Reboot"
+Write-Host "  3. Run after boot:                capture-state.ps1 -Label post-reboot-1"
+Write-Host "  4. Compare:                       capture-state.ps1 -Compare .\state-pre-reboot.json .\state-post-reboot-1.json"

--- a/scripts/capture-state.ps1
+++ b/scripts/capture-state.ps1
@@ -9,10 +9,13 @@
 # Saved to current directory unless -OutputDir is specified.
 # Run elevated (some queries need admin for sc.exe and registry reads).
 
+[CmdletBinding(PositionalBinding = $false)]
 param(
     [string]$Label = "",
     [switch]$Compare,
+    [Parameter(Position = 0)]
     [string]$FileA = "",
+    [Parameter(Position = 1)]
     [string]$FileB = "",
     [string]$OutputDir = "."
 )
@@ -22,8 +25,6 @@ Set-StrictMode -Version 2
 # ---- Compare mode ----
 if ($Compare) {
     if (-not $FileA -or -not $FileB) {
-        # Try positional args if Compare was used with positional params
-        $args2 = $args
         Write-Host "Usage: capture-state.ps1 -Compare <fileA.json> <fileB.json>" -ForegroundColor Yellow
         exit 1
     }
@@ -37,9 +38,10 @@ if ($Compare) {
             throw "Invalid snapshot: $Path is empty."
         }
         $required = @(
+            'label', 'timestamp',
             'col01Present', 'col02Present', 'filterInStack',
             'lowerFiltersEnumKey', 'lowerFiltersDriverKey',
-            'serviceState', 'hidDeviceCount'
+            'serviceState', 'hidDeviceCount', 'startupRepairLog'
         )
         foreach ($name in $required) {
             if ($null -eq $Obj.PSObject.Properties[$name]) {

--- a/scripts/mm-bt-stack-snapshot.ps1
+++ b/scripts/mm-bt-stack-snapshot.ps1
@@ -1,0 +1,191 @@
+<#
+.SYNOPSIS
+    Snapshot the live BT HID stack + filter chain across ALL paired Apple
+    devices. Compares v1 vs v3 Magic Mouse + Apple Keyboard binding state.
+
+    Output: bt-stack-snapshot.json + bt-stack-snapshot.txt (human-readable)
+#>
+[CmdletBinding()]
+param(
+    [string]$OutDir = '.'
+)
+
+$ErrorActionPreference = 'Continue'
+
+if (-not (Test-Path $OutDir)) { New-Item -Path $OutDir -ItemType Directory -Force -ErrorAction Stop | Out-Null }
+$ts = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+
+# All BTHENUM HID-class children
+$bthenum = Get-PnpDevice -Class HIDClass -ErrorAction SilentlyContinue |
+    Where-Object { $_.InstanceId -like 'BTHENUM\*' }
+
+# Look up the parent BTH device to get the MAC
+$results = @()
+foreach ($d in $bthenum) {
+    $rec = [ordered]@{
+        InstanceId = $d.InstanceId
+        FriendlyName = $d.FriendlyName
+        Status = $d.Status
+        Class = $d.Class
+        Manufacturer = $d.Manufacturer
+        Service = $d.Service
+        ProblemCode = $d.Problem
+    }
+
+    # Pull device parameters (LowerFilters, Service overrides) via registry
+    # InstanceId format: BTHENUM\Dev_<mac>\<...>  or BTHENUM\{guid}_VID...PID...\<...>
+    # The Driver Reg key is HKLM\SYSTEM\CCS\Enum\BTHENUM\<dev>\<inst>
+    $enumPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\$($d.InstanceId.Replace('\','\'))"
+    if (Test-Path $enumPath) {
+        try {
+            $k = Get-Item -LiteralPath $enumPath
+            $rec.HardwareID = ($k.GetValue('HardwareID', @()) -join ' | ')
+            $rec.Service_REG = $k.GetValue('Service', '')
+            $rec.ClassGUID = $k.GetValue('ClassGUID', '')
+            # Get Device Parameters\* (where LowerFilters live)
+            $dparam = Join-Path $enumPath 'Device Parameters'
+            if (Test-Path $dparam) {
+                $dpk = Get-Item -LiteralPath $dparam
+                $names = $dpk.GetValueNames()
+                $params = @{}
+                foreach ($n in $names) {
+                    $v = $dpk.GetValue($n)
+                    if ($v -is [string[]]) {
+                        $params[$n] = ($v -join ' | ')
+                    } elseif ($v -is [byte[]]) {
+                        $params[$n] = ('hex:' + ([System.BitConverter]::ToString($v) -replace '-',' '))
+                    } else {
+                        $params[$n] = $v
+                    }
+                }
+                $rec.DeviceParameters = $params
+            }
+            # Driver class node - LowerFilters can be class-level too
+            if ($k.GetValue('Driver', '')) {
+                $cls = "HKLM:\SYSTEM\CurrentControlSet\Control\Class\$($k.GetValue('Driver', ''))"
+                if (Test-Path $cls) {
+                    $clsk = Get-Item -LiteralPath $cls
+                    $cnames = $clsk.GetValueNames()
+                    $cparams = @{}
+                    foreach ($n in $cnames) {
+                        $v = $clsk.GetValue($n)
+                        if ($v -is [string[]]) {
+                            $cparams[$n] = ($v -join ' | ')
+                        } elseif ($v -is [byte[]]) {
+                            $cparams[$n] = ('hex:' + ([System.BitConverter]::ToString($v) -replace '-',' '))
+                        } else {
+                            $cparams[$n] = $v
+                        }
+                    }
+                    $rec.DriverClassParameters = $cparams
+                }
+            }
+        } catch {
+            $rec.RegistryReadError = $_.ToString()
+        }
+    } else {
+        $rec.NoEnumKey = $true
+    }
+    $results += [pscustomobject]$rec
+}
+
+# Also enumerate the Mouse class children (where the filtered HID wraps to Mouse)
+$mouseChildren = Get-PnpDevice -Class Mouse -ErrorAction SilentlyContinue |
+    Where-Object { $_.InstanceId -like 'HID\*' }
+
+# Snapshot tray-relevant pieces
+$batteryReadings = @()
+foreach ($d in $bthenum) {
+    try {
+        # Get-PnpDeviceProperty DEVPKEY_Device_BatteryLevel (255 if N/A)
+        $bp = Get-PnpDeviceProperty -InstanceId $d.InstanceId -KeyName 'DEVPKEY_Device_BatteryLevel' -ErrorAction SilentlyContinue
+        $val = if ($bp) { $bp.Data } else { $null }
+        $batteryReadings += [pscustomobject]@{
+            InstanceId = $d.InstanceId
+            FriendlyName = $d.FriendlyName
+            BatteryLevel_DEVPKEY = $val
+        }
+    } catch {}
+}
+
+# applewirelessmouse service
+$svc = Get-Service -Name 'applewirelessmouse' -ErrorAction SilentlyContinue
+$svcInfo = @{
+    Exists = ($null -ne $svc)
+    Status = if ($svc) { $svc.Status.ToString() } else { 'absent' }
+    StartType = if ($svc) { $svc.StartType.ToString() } else { '' }
+}
+# Driver file presence
+$driverPath = "$env:SystemRoot\System32\drivers\applewirelessmouse.sys"
+$svcInfo.DriverFileExists = (Test-Path $driverPath)
+if (Test-Path $driverPath) {
+    $fi = Get-Item -LiteralPath $driverPath
+    $svcInfo.DriverFileSize = $fi.Length
+    $svcInfo.DriverFileModified = $fi.LastWriteTime.ToString('o')
+}
+
+# applewirelessmouse INF lookup (which PIDs does it match?)
+$infs = Get-WindowsDriver -Online -ErrorAction SilentlyContinue |
+    Where-Object { $_.OriginalFileName -like '*applewirelessmouse*' -or $_.Driver -like '*applewirelessmouse*' }
+
+$snapshot = [ordered]@{
+    Captured = $ts
+    BTHENUMHIDChildren = $results
+    MouseClassChildren = ($mouseChildren | Select-Object InstanceId, FriendlyName, Status, ProblemCode, Service)
+    BatteryReadings = $batteryReadings
+    AppleFilterService = $svcInfo
+    AppleFilterINF = ($infs | Select-Object Driver, OriginalFileName, Inbox, ClassName, ProviderName, Date, Version, BootCritical)
+}
+
+$jsonOut = Join-Path $OutDir 'bt-stack-snapshot.json'
+$txtOut = Join-Path $OutDir 'bt-stack-snapshot.txt'
+$snapshot | ConvertTo-Json -Depth 8 | Set-Content -LiteralPath $jsonOut -Encoding UTF8 -ErrorAction Stop
+
+# Human-readable summary
+$lines = @()
+$lines += "=== BT HID stack snapshot @ $ts ==="
+$lines += ""
+$lines += "applewirelessmouse service:"
+$lines += "  Exists: $($svcInfo.Exists)  Status: $($svcInfo.Status)  StartType: $($svcInfo.StartType)"
+$lines += "  DriverFileExists: $($svcInfo.DriverFileExists)  Size: $($svcInfo.DriverFileSize)  Modified: $($svcInfo.DriverFileModified)"
+$lines += ""
+$lines += "applewirelessmouse INF entries:"
+foreach ($i in $infs) {
+    $lines += "  $($i.Driver) | $($i.OriginalFileName) | Inbox=$($i.Inbox)"
+}
+$lines += ""
+$lines += "BTHENUM HIDClass children:"
+foreach ($r in $results) {
+    $lines += ""
+    $lines += "  [$($r.Status)] $($r.InstanceId)"
+    $lines += "    FriendlyName: $($r.FriendlyName)"
+    $lines += "    Service: $($r.Service)  ServiceREG: $($r.Service_REG)"
+    $lines += "    Manufacturer: $($r.Manufacturer)"
+    if ($r.HardwareID) { $lines += "    HardwareID: $($r.HardwareID)" }
+    if ($r.DeviceParameters) {
+        $lf = $r.DeviceParameters['LowerFilters']
+        $uf = $r.DeviceParameters['UpperFilters']
+        if ($lf) { $lines += "    LowerFilters: $lf" }
+        if ($uf) { $lines += "    UpperFilters: $uf" }
+        foreach ($k in $r.DeviceParameters.Keys) {
+            if ($k -notin 'LowerFilters','UpperFilters') {
+                $lines += "    DevParam.$k = $($r.DeviceParameters[$k])"
+            }
+        }
+    }
+    if ($r.DriverClassParameters) {
+        $clf = $r.DriverClassParameters['LowerFilters']
+        if ($clf) { $lines += "    DriverClass.LowerFilters: $clf" }
+    }
+}
+$lines += ""
+$lines += "Battery readings (DEVPKEY_Device_BatteryLevel):"
+foreach ($b in $batteryReadings) {
+    $lines += "  $($b.FriendlyName) -> $($b.BatteryLevel_DEVPKEY)"
+}
+
+$lines | Set-Content -LiteralPath $txtOut -Encoding UTF8 -ErrorAction Stop
+
+Write-Host "[bt-snapshot] OK -> $jsonOut" -ForegroundColor Green
+Write-Host "[bt-snapshot] OK -> $txtOut" -ForegroundColor Green
+exit 0

--- a/scripts/mm-bt-stack-snapshot.ps1
+++ b/scripts/mm-bt-stack-snapshot.ps1
@@ -35,8 +35,8 @@ foreach ($d in $bthenum) {
     # Pull device parameters (LowerFilters, Service overrides) via registry
     # InstanceId format: BTHENUM\Dev_<mac>\<...>  or BTHENUM\{guid}_VID...PID...\<...>
     # The Driver Reg key is HKLM\SYSTEM\CCS\Enum\BTHENUM\<dev>\<inst>
-    $enumPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\$($d.InstanceId.Replace('\','\'))"
-    if (Test-Path $enumPath) {
+    $enumPath = "HKLM:\SYSTEM\CurrentControlSet\Enum\$($d.InstanceId)"
+    if (Test-Path -LiteralPath $enumPath) {
         try {
             $k = Get-Item -LiteralPath $enumPath
             $rec.HardwareID = ($k.GetValue('HardwareID', @()) -join ' | ')
@@ -44,7 +44,7 @@ foreach ($d in $bthenum) {
             $rec.ClassGUID = $k.GetValue('ClassGUID', '')
             # Get Device Parameters\* (where LowerFilters live)
             $dparam = Join-Path $enumPath 'Device Parameters'
-            if (Test-Path $dparam) {
+            if (Test-Path -LiteralPath $dparam) {
                 $dpk = Get-Item -LiteralPath $dparam
                 $names = $dpk.GetValueNames()
                 $params = @{}
@@ -63,7 +63,7 @@ foreach ($d in $bthenum) {
             # Driver class node - LowerFilters can be class-level too
             if ($k.GetValue('Driver', '')) {
                 $cls = "HKLM:\SYSTEM\CurrentControlSet\Control\Class\$($k.GetValue('Driver', ''))"
-                if (Test-Path $cls) {
+                if (Test-Path -LiteralPath $cls) {
                     $clsk = Get-Item -LiteralPath $cls
                     $cnames = $clsk.GetValueNames()
                     $cparams = @{}
@@ -125,8 +125,22 @@ if (Test-Path $driverPath) {
 }
 
 # applewirelessmouse INF lookup (which PIDs does it match?)
-$infs = Get-WindowsDriver -Online -ErrorAction SilentlyContinue |
-    Where-Object { $_.OriginalFileName -like '*applewirelessmouse*' -or $_.Driver -like '*applewirelessmouse*' }
+# Get-WindowsDriver -Online requires elevation. Record the elevation state and
+# any failure so an empty AppleFilterINF is never mistaken for "no Apple INF".
+$isElevated = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+    [Security.Principal.WindowsBuiltInRole]::Administrator)
+$infs = @()
+$infError = $null
+if (-not $isElevated) {
+    $infError = 'Not elevated: Get-WindowsDriver -Online requires Administrator.'
+} else {
+    try {
+        $infs = @(Get-WindowsDriver -Online -ErrorAction Stop |
+            Where-Object { $_.OriginalFileName -like '*applewirelessmouse*' -or $_.Driver -like '*applewirelessmouse*' })
+    } catch {
+        $infError = $_.ToString()
+    }
+}
 
 $snapshot = [ordered]@{
     Captured = $ts
@@ -135,6 +149,8 @@ $snapshot = [ordered]@{
     BatteryReadings = $batteryReadings
     AppleFilterService = $svcInfo
     AppleFilterINF = ($infs | Select-Object Driver, OriginalFileName, Inbox, ClassName, ProviderName, Date, Version, BootCritical)
+    AppleFilterINFElevated = $isElevated
+    AppleFilterINFError = $infError
 }
 
 $jsonOut = Join-Path $OutDir 'bt-stack-snapshot.json'
@@ -150,6 +166,7 @@ $lines += "  Exists: $($svcInfo.Exists)  Status: $($svcInfo.Status)  StartType: 
 $lines += "  DriverFileExists: $($svcInfo.DriverFileExists)  Size: $($svcInfo.DriverFileSize)  Modified: $($svcInfo.DriverFileModified)"
 $lines += ""
 $lines += "applewirelessmouse INF entries:"
+if ($infError) { $lines += "  (unavailable: $infError)" }
 foreach ($i in $infs) {
     $lines += "  $($i.Driver) | $($i.OriginalFileName) | Inbox=$($i.Inbox)"
 }

--- a/scripts/verify-release.ps1
+++ b/scripts/verify-release.ps1
@@ -71,7 +71,7 @@ try {
   $exeName = 'MagicMouseTray.exe'
   $ps1Name = 'kbd-patch-cachedservices.ps1'
   $cmdName = 'Install-KeyboardBattery.cmd'
-  $shipNames = @($exeName, $ps1Name, $cmdName)
+  $shipNames = @($exeName, $ps1Name, $cmdName, 'capture-state.ps1', 'diagnose-driver.ps1', 'mm-bt-stack-snapshot.ps1')
   $exePath = Join-Path $PublishDir $exeName
   $ps1Path = Join-Path $PublishDir $ps1Name
   $cmdPath = Join-Path $PublishDir $cmdName


### PR DESCRIPTION
## Why

CI is red because the csproj still copies \`capture-state.ps1\`, \`diagnose-driver.ps1\`, and \`mm-bt-stack-snapshot.ps1\` after #76 deleted them. Those are the scripts the tray **Diagnostics** menu launches (\`DiagnosticScripts.Find\`).

## What

- Restore only those three (not lab scripts). \`diagnose-driver.ps1\` stays at repo root; the others under \`scripts/\`.
- Flatten \`CopyToPublishDirectory\` so they sit **next to** \`MagicMouseTray.exe\` (tray Find looks in the exe directory first).
- Stage them in CI + release, require them in \`verify-release.ps1\`, attach them on the GitHub Release with the exe.

Supersedes #96 (drop the copies). Overlaps #90’s script restore; this PR also ships them with the exe.