### PR TITLE
feat(tray): pre-fill GitHub bug and feature drafts

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,20 @@
+---
+name: Bug report
+about: Something is wrong with battery, scroll, or the tray
+title: "bug: "
+labels: bug
+---
+
+Use **Help → Report a bug** in Magic Tray to pre-fill this with version, driver badges, battery readings, and a MAC-redacted log tail. Or paste by hand:
+
+**Magic Tray version** (tray footer):
+
+**Windows** (`winver`):
+
+**Device** (PID / model):
+
+**What happened:**
+
+**What you expected:**
+
+Paste the tray snapshot or `%APPDATA%\MagicMouseTray\debug.log` excerpt (no Bluetooth MAC).

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Ask for something Magic Tray does not do today
+title: "feat: "
+labels: enhancement
+---
+
+Use **Help → Request a feature** in Magic Tray to pre-fill version. Or paste by hand:
+
+**Idea:**
+
+**Why it helps:**
+
+**Magic Tray version** (tray footer):

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,9 @@ The device list the app and CI use is `MouseBatteryDevice.KnownMice` and `Keyboa
 
 ## Bug reports
 
-Include `%APPDATA%\MagicMouseTray\debug.log` and the device Hardware Ids from Device Manager (look for `VID_004C&PID_xxxx` or `VID_05AC&PID_xxxx`).
+In the tray: **Help → Report a bug**. That copies a MAC-redacted snapshot and opens a GitHub draft; you submit it while logged in. **Help → Request a feature** does the same without diagnostics.
+
+Or include `%APPDATA%\MagicMouseTray\debug.log` and Hardware Ids (`VID_05AC&PID_xxxx`) by hand.
 
 ## License
 

--- a/MagicMouseTray.Tests/BugReportTests.cs
+++ b/MagicMouseTray.Tests/BugReportTests.cs
@@ -4,8 +4,16 @@ using Xunit;
 
 namespace MagicMouseTray.Tests;
 
+/// <summary>
+/// Covers the diagnostic snapshot that ships to a PUBLIC GitHub issue: privacy
+/// redaction, Markdown shape, title selection, log tailing, and draft URL bounds.
+/// </summary>
 public class BugReportTests
 {
+    /// <summary>
+    /// Bluetooth MAC addresses and Dev_ ids are scrubbed while the 4-digit PID,
+    /// which carries no identity and is needed to triage, survives.
+    /// </summary>
     [Fact]
     public void Redact_ReplacesMacAndDevId_KeepsPid()
     {
@@ -18,6 +26,10 @@ public class BugReportTests
         Assert.Contains("Dev_<mac>", redacted);
     }
 
+    /// <summary>
+    /// The bug body carries version, driver choice, and the device table, and never
+    /// leaks the BTHENUM device instance path.
+    /// </summary>
     [Fact]
     public void FormatMarkdown_HasEnvironmentAndDevices_NoDeviceId()
     {
@@ -34,6 +46,10 @@ public class BugReportTests
         Assert.DoesNotContain("BTHENUM", md);
     }
 
+    /// <summary>
+    /// A PID reported by both the battery poller and the health checker yields one
+    /// merged row, with the device name redacted.
+    /// </summary>
     [Fact]
     public void Collect_MergesBatteryAndHealth_WithoutDeviceId()
     {
@@ -53,6 +69,10 @@ public class BugReportTests
         Assert.DoesNotContain("AABB", rows[0].Name, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// The title names the first unhealthy device, so a triager sees the fault and
+    /// not a healthy sibling device.
+    /// </summary>
     [Fact]
     public void IssueTitle_UsesFirstNonOkDriver()
     {
@@ -64,6 +84,7 @@ public class BugReportTests
         Assert.Equal("bug: PID 0323 StockKmdf (Magic Tray 1.1.0)", BugReport.IssueTitle(devices, "1.1.0"));
     }
 
+    /// <summary>A 0323 on stock Windows is told it needs KMDF to get the wheel working.</summary>
     [Fact]
     public void TroubleshootHint_Stock0323_PointsAtKmdf()
     {
@@ -71,6 +92,10 @@ public class BugReportTests
         Assert.Contains("KMDF", BugReport.TroubleshootHint(devices));
     }
 
+    /// <summary>
+    /// A feature request carries the idea prompts and version but no diagnostics -
+    /// no log tail is attached to a request that has no fault to diagnose.
+    /// </summary>
     [Fact]
     public void FormatFeatureMarkdown_HasIdeaAndVersion_NoLog()
     {
@@ -81,6 +106,7 @@ public class BugReportTests
         Assert.Equal("feat: Magic Tray 1.1.0", BugReport.FeatureTitle("1.1.0"));
     }
 
+    /// <summary>A feature draft is labelled enhancement, never bug.</summary>
     [Fact]
     public void IssueUrl_Feature_UsesEnhancementLabel()
     {
@@ -89,6 +115,10 @@ public class BugReportTests
         Assert.DoesNotContain("labels=bug", url);
     }
 
+    /// <summary>
+    /// The draft URL targets the new-issue endpoint with a bug label and a
+    /// percent-encoded body, so GitHub pre-fills the form rather than mangling it.
+    /// </summary>
     [Fact]
     public void IssueUrl_PrefillsBugLabelAndBody()
     {
@@ -101,6 +131,10 @@ public class BugReportTests
         Assert.Contains(Uri.EscapeDataString("hello body"), url);
     }
 
+    /// <summary>
+    /// An oversized body is clipped so the URL stays within the length cap browsers
+    /// and GitHub enforce, and the draft says it was truncated.
+    /// </summary>
     [Fact]
     public void IssueUrl_LongBody_StaysUnderMax()
     {
@@ -110,6 +144,10 @@ public class BugReportTests
         Assert.Contains("truncated", url);
     }
 
+    /// <summary>
+    /// Only the requested number of trailing lines is returned, and the tail is
+    /// redacted before it can reach the issue body.
+    /// </summary>
     [Fact]
     public void ReadLogTail_ReturnsLastLines_Redacted()
     {
@@ -131,6 +169,10 @@ public class BugReportTests
         }
     }
 
+    /// <summary>
+    /// Windows profile paths and the live account and host names are scrubbed; these
+    /// identify the reporter and their machine in a public issue.
+    /// </summary>
     [Fact]
     public void Redact_ScrubsProfilePathAndLocalNames()
     {
@@ -143,12 +185,47 @@ public class BugReportTests
         var user = Environment.UserName;
         var host = Environment.MachineName;
         var env = BugReport.Redact($"DIAG user={user} host={host}");
-        if (user.Length >= 3)
+        if (!string.IsNullOrWhiteSpace(user))
             Assert.DoesNotContain(user, env, StringComparison.OrdinalIgnoreCase);
-        if (host.Length >= 3)
+        if (!string.IsNullOrWhiteSpace(host))
             Assert.DoesNotContain(host, env, StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// One- and two-character account or host names ("JD", "PC") are redacted as whole
+    /// delimited tokens only, so ordinary log words like "JSON" and "PCIe" survive.
+    /// </summary>
+    [Fact]
+    public void LocalIdentifierRegex_ShortNames_MatchWholeTokenOnly()
+    {
+        var pc = BugReport.LocalIdentifierRegex("PC");
+        Assert.Equal("host=<host>", pc.Replace("host=PC", "<host>"));
+        Assert.Equal("PCIe", pc.Replace("PCIe", "<host>"));
+
+        var jd = BugReport.LocalIdentifierRegex("JD");
+        Assert.Equal("user=<user>", jd.Replace("user=JD", "<user>"));
+        Assert.Equal("JSON", jd.Replace("JSON", "<user>"));
+
+        var one = BugReport.LocalIdentifierRegex("X");
+        Assert.Equal("user=<user>", one.Replace("user=X", "<user>"));
+        Assert.Equal("Xtra", one.Replace("Xtra", "<user>"));
+    }
+
+    /// <summary>
+    /// Names of three chars or more still replace as substrings, so a host embedded in
+    /// a longer token ("lesley-pc") is still scrubbed.
+    /// </summary>
+    [Fact]
+    public void LocalIdentifierRegex_LongNames_StillSubstring()
+    {
+        var re = BugReport.LocalIdentifierRegex("lesley");
+        Assert.Equal("<user>-pc", re.Replace("lesley-pc", "<user>"));
+    }
+
+    /// <summary>
+    /// The cap is enforced on the ENCODED body with room reserved for the truncation
+    /// note, so an escape-heavy report cannot push the URL over the limit.
+    /// </summary>
     [Fact]
     public void IssueUrl_EncodingHeavyBody_StaysUnderMaxWithNote()
     {
@@ -162,6 +239,10 @@ public class BugReportTests
         Assert.DoesNotContain(" ", url);
     }
 
+    /// <summary>
+    /// A rolled 1 MB log returns exactly the last LogTailLines entries, proving the
+    /// reader streams the file instead of materialising all of it.
+    /// </summary>
     [Fact]
     public void ReadLogTail_LargeLog_ReturnsExactTail()
     {

--- a/MagicMouseTray.Tests/BugReportTests.cs
+++ b/MagicMouseTray.Tests/BugReportTests.cs
@@ -130,4 +130,59 @@ public class BugReportTests
             catch { }
         }
     }
+
+    [Fact]
+    public void Redact_ScrubsProfilePathAndLocalNames()
+    {
+        // Synthetic name: the profile-path rule must not need the live account.
+        var path = BugReport.Redact(
+            @"OPEN_DIAG path=C:\Users\mm-test-user\AppData\Local\MagicMouseTray\debug.log");
+        Assert.Contains(@"C:\Users\<user>\AppData\Local\MagicMouseTray\debug.log", path);
+        Assert.DoesNotContain("mm-test-user", path, StringComparison.OrdinalIgnoreCase);
+
+        var user = Environment.UserName;
+        var host = Environment.MachineName;
+        var env = BugReport.Redact($"DIAG user={user} host={host}");
+        if (user.Length >= 3)
+            Assert.DoesNotContain(user, env, StringComparison.OrdinalIgnoreCase);
+        if (host.Length >= 3)
+            Assert.DoesNotContain(host, env, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void IssueUrl_EncodingHeavyBody_StaysUnderMaxWithNote()
+    {
+        // Every newline costs three encoded chars, so the cap must be measured
+        // on the encoded text and must reserve room for the truncation note.
+        var body = string.Concat(Enumerable.Repeat("line — one\n", 4000));
+        var url = BugReport.IssueUrl("bug: test", body);
+        Assert.True(url.Length <= BugReport.MaxUrlChars, $"url was {url.Length} chars");
+        Assert.Contains(Uri.EscapeDataString("truncated"), url);
+        Assert.DoesNotContain("\n", url);
+        Assert.DoesNotContain(" ", url);
+    }
+
+    [Fact]
+    public void ReadLogTail_LargeLog_ReturnsExactTail()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "mm-bug-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "debug.log");
+        try
+        {
+            using (var writer = new StreamWriter(path))
+                for (var i = 0; i < 5_000; i++)
+                    writer.WriteLine($"line {i}");
+            var lines = BugReport.ReadLogTail(path, BugReport.LogTailLines)
+                .Split(Environment.NewLine);
+            Assert.Equal(BugReport.LogTailLines, lines.Length);
+            Assert.Equal($"line {5_000 - BugReport.LogTailLines}", lines[0]);
+            Assert.Equal("line 4999", lines[^1]);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); }
+            catch { }
+        }
+    }
 }

--- a/MagicMouseTray.Tests/BugReportTests.cs
+++ b/MagicMouseTray.Tests/BugReportTests.cs
@@ -240,6 +240,26 @@ public class BugReportTests
     }
 
     /// <summary>
+    /// A title long enough to fill the cap on its own is clipped too. Trimming only
+    /// the body would return a URL the browser refuses, dropping the user on the
+    /// plain issues list instead of a pre-filled draft.
+    /// </summary>
+    [Fact]
+    public void IssueUrl_LongTitle_StaysUnderMax()
+    {
+        var url = BugReport.IssueUrl(new string('t', 20_000), "hello body");
+        Assert.True(url.Length <= BugReport.MaxUrlChars, $"url was {url.Length} chars");
+        Assert.StartsWith(BugReport.NewIssueBase, url);
+        Assert.Contains("labels=bug", url);
+        Assert.Contains("&body=", url);
+
+        // Encoding-heavy title: every space costs three encoded chars.
+        var spaced = BugReport.IssueUrl(string.Concat(Enumerable.Repeat("bug title ", 2000)), "body");
+        Assert.True(spaced.Length <= BugReport.MaxUrlChars, $"url was {spaced.Length} chars");
+        Assert.DoesNotContain(" ", spaced);
+    }
+
+    /// <summary>
     /// A rolled 1 MB log returns exactly the last LogTailLines entries, proving the
     /// reader streams the file instead of materialising all of it.
     /// </summary>

--- a/MagicMouseTray.Tests/BugReportTests.cs
+++ b/MagicMouseTray.Tests/BugReportTests.cs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+using MagicMouseTray;
+using Xunit;
+
+namespace MagicMouseTray.Tests;
+
+public class BugReportTests
+{
+    [Fact]
+    public void Redact_ReplacesMacAndDevId_KeepsPid()
+    {
+        var raw = "DRIVER_CHECK pid=0x0323 bth=HidBth Dev_AABBCCDDEEFF aa:bb:cc:dd:ee:ff aabbccddeeff";
+        var redacted = BugReport.Redact(raw);
+        Assert.Contains("0323", redacted);
+        Assert.DoesNotContain("AABBCCDDEEFF", redacted, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("aa:bb:cc:dd:ee:ff", redacted, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("<mac>", redacted);
+        Assert.Contains("Dev_<mac>", redacted);
+    }
+
+    [Fact]
+    public void FormatMarkdown_HasEnvironmentAndDevices_NoDeviceId()
+    {
+        var devices = new[]
+        {
+            new BugReportDevice("Magic Mouse 2024", "0323", "StockKmdf", "30%"),
+        };
+        var md = BugReport.FormatMarkdown("1.1.0", "Windows 11", "kmdf", devices, "OK battery=30%");
+        Assert.Contains("Magic Tray: 1.1.0", md);
+        Assert.Contains("`0323`", md);
+        Assert.Contains("StockKmdf", md);
+        Assert.Contains("0323 lasting choice: `kmdf`", md);
+        Assert.Contains("(type here)", md);
+        Assert.DoesNotContain("BTHENUM", md);
+    }
+
+    [Fact]
+    public void Collect_MergesBatteryAndHealth_WithoutDeviceId()
+    {
+        var health = new[]
+        {
+            new DeviceDriverHealth(@"BTHENUM\Dev_AABBCCDDEEFF", "0323", DriverStatus.PatchedKmdf, "MagicMouseDriver"),
+        };
+        var batteries = new Dictionary<string, (int Pct, DeviceKind Kind, string Pid)>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Magic Mouse 2024"] = (42, DeviceKind.MagicMouseV3, "0323"),
+        };
+        var rows = BugReport.Collect(health, batteries);
+        Assert.Single(rows);
+        Assert.Equal("0323", rows[0].Pid);
+        Assert.Equal("42%", rows[0].Battery);
+        Assert.Equal(nameof(DriverStatus.PatchedKmdf), rows[0].Driver);
+        Assert.DoesNotContain("AABB", rows[0].Name, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void IssueTitle_UsesFirstNonOkDriver()
+    {
+        var devices = new[]
+        {
+            new BugReportDevice("v1", "030D", "Ok", "80%"),
+            new BugReportDevice("v3", "0323", "StockKmdf", "no reading"),
+        };
+        Assert.Equal("bug: PID 0323 StockKmdf (Magic Tray 1.1.0)", BugReport.IssueTitle(devices, "1.1.0"));
+    }
+
+    [Fact]
+    public void TroubleshootHint_Stock0323_PointsAtKmdf()
+    {
+        var devices = new[] { new BugReportDevice("v3", "0323", "StockKmdf", "30%") };
+        Assert.Contains("KMDF", BugReport.TroubleshootHint(devices));
+    }
+
+    [Fact]
+    public void FormatFeatureMarkdown_HasIdeaAndVersion_NoLog()
+    {
+        var md = BugReport.FormatFeatureMarkdown("1.1.0", "Windows 11");
+        Assert.Contains("### Idea", md);
+        Assert.Contains("Magic Tray: 1.1.0", md);
+        Assert.DoesNotContain("debug.log", md);
+        Assert.Equal("feat: Magic Tray 1.1.0", BugReport.FeatureTitle("1.1.0"));
+    }
+
+    [Fact]
+    public void IssueUrl_Feature_UsesEnhancementLabel()
+    {
+        var url = BugReport.IssueUrl("feat: test", "idea", "enhancement");
+        Assert.Contains("labels=enhancement", url);
+        Assert.DoesNotContain("labels=bug", url);
+    }
+
+    [Fact]
+    public void IssueUrl_PrefillsBugLabelAndBody()
+    {
+        var url = BugReport.IssueUrl("bug: test", "hello body");
+        Assert.StartsWith(BugReport.NewIssueBase, url);
+        Assert.Contains("labels=bug", url);
+        Assert.Contains("title=", url);
+        Assert.Contains("body=", url);
+        Assert.DoesNotContain("hello body", url);
+        Assert.Contains(Uri.EscapeDataString("hello body"), url);
+    }
+
+    [Fact]
+    public void IssueUrl_LongBody_StaysUnderMax()
+    {
+        var huge = new string('x', 50_000);
+        var url = BugReport.IssueUrl("bug: test", huge);
+        Assert.True(url.Length <= BugReport.MaxUrlChars);
+        Assert.Contains("truncated", url);
+    }
+
+    [Fact]
+    public void ReadLogTail_ReturnsLastLines_Redacted()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "mm-bug-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        var path = Path.Combine(dir, "debug.log");
+        try
+        {
+            File.WriteAllLines(path, ["keep-me", "Dev_AABBCCDDEEFF", "tail"]);
+            var tail = BugReport.ReadLogTail(path, 2);
+            Assert.DoesNotContain("AABBCCDDEEFF", tail, StringComparison.OrdinalIgnoreCase);
+            Assert.Contains("tail", tail);
+            Assert.DoesNotContain("keep-me", tail);
+        }
+        finally
+        {
+            try { Directory.Delete(dir, recursive: true); }
+            catch { }
+        }
+    }
+}

--- a/MagicMouseTray.Tests/TrayMenuTests.cs
+++ b/MagicMouseTray.Tests/TrayMenuTests.cs
@@ -354,6 +354,10 @@ public class TrayMenuTests
         Assert.Equal(expected, TrayMenu.DeviceThresholdLabel(pct, hours));
     }
 
+    /// <summary>
+    /// Help menu labels and URLs stay exact: the bug and feature entries and the
+    /// issues fallback must never point users at a dead or wrong page.
+    /// </summary>
     [Fact]
     public void HelpUrls_AndLabels_AreExact()
     {

--- a/MagicMouseTray.Tests/TrayMenuTests.cs
+++ b/MagicMouseTray.Tests/TrayMenuTests.cs
@@ -361,6 +361,7 @@ public class TrayMenuTests
         Assert.Equal("How alerts work", TrayMenu.HowAlertsWorkLabel);
         Assert.Equal("Repository", TrayMenu.RepositoryLabel);
         Assert.Equal("Report a bug", TrayMenu.ReportBugLabel);
+        Assert.Equal("Request a feature", TrayMenu.RequestFeatureLabel);
         Assert.Equal("https://github.com/LesleyMurfin/magic-tray", TrayMenu.RepoUrl);
         Assert.Equal("https://github.com/LesleyMurfin/magic-tray/issues", TrayMenu.IssuesUrl);
         Assert.Equal(

--- a/MagicMouseTray/BugReport.cs
+++ b/MagicMouseTray/BugReport.cs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT
+using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -30,6 +31,9 @@ internal static class BugReport
 
     internal static string OsDescription() => RuntimeInformation.OSDescription;
 
+    // Scrubs everything that identifies the machine or its owner: Bluetooth
+    // addresses, Windows profile paths, and the local account/host names. The
+    // result is pasted into a PUBLIC GitHub issue, so this is load-bearing.
     internal static string Redact(string text)
     {
         if (string.IsNullOrEmpty(text))
@@ -37,7 +41,51 @@ internal static class BugReport
         text = Regex.Replace(text, @"\b([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b", "<mac>");
         text = Regex.Replace(text, @"\bDev_[0-9A-Fa-f]{12}\b", "Dev_<mac>", RegexOptions.IgnoreCase);
         text = Regex.Replace(text, @"(?<![0-9A-Fa-f])[0-9A-Fa-f]{12}(?![0-9A-Fa-f])", "<mac>");
+        // Logged log/temp/script paths all carry C:\Users\<name>\AppData\...
+        text = Regex.Replace(text, @"(?<=\\Users\\)[^\\\r\n]+?(?=\\|\r|\n|$)", "<user>",
+            RegexOptions.IgnoreCase);
+        foreach (var (pattern, placeholder) in LocalIdentifiers)
+            text = pattern.Replace(text, placeholder);
         return text;
+    }
+
+    // Account and host names have no shape to match, so match the literals.
+    static readonly (Regex Pattern, string Placeholder)[] LocalIdentifiers = BuildLocalIdentifiers();
+
+    static (Regex, string)[] BuildLocalIdentifiers()
+    {
+        var raw = new List<(string Value, string Placeholder)>(3);
+        Add(SafeEnv(() => Environment.UserName), "<user>");
+        Add(SafeEnv(() => Environment.MachineName), "<host>");
+        Add(SafeEnv(() => Environment.UserDomainName), "<host>");
+        // Longest first, so "lesley-pc" is not half-eaten by "lesley".
+        return raw.OrderByDescending(v => v.Value.Length)
+            .Select(v => (new Regex(Regex.Escape(v.Value),
+                RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), v.Placeholder))
+            .ToArray();
+
+        void Add(string? value, string placeholder)
+        {
+            // Under 3 chars a literal replace would shred unrelated log text.
+            if (string.IsNullOrWhiteSpace(value) || value.Length < 3)
+                return;
+            foreach (var existing in raw)
+                if (string.Equals(existing.Value, value, StringComparison.OrdinalIgnoreCase))
+                    return;
+            raw.Add((value, placeholder));
+        }
+    }
+
+    static string? SafeEnv(Func<string> read)
+    {
+        try
+        {
+            return read();
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     internal static string ReadLogTail(string path, int lines)
@@ -46,11 +94,22 @@ internal static class BugReport
             return "";
         try
         {
-            var all = File.ReadAllLines(path);
-            if (all.Length == 0)
+            // debug.log rolls at MaxBytes and the tray calls this on the UI
+            // thread, so stream it and hold only the last `lines` entries.
+            // FileShare.ReadWrite: Logger may be appending while we read.
+            var tail = new Queue<string>(lines);
+            using var stream = new FileStream(
+                path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(stream);
+            while (reader.ReadLine() is { } line)
+            {
+                if (tail.Count == lines)
+                    tail.Dequeue();
+                tail.Enqueue(line);
+            }
+            if (tail.Count == 0)
                 return "";
-            var start = Math.Max(0, all.Length - lines);
-            return Redact(string.Join(Environment.NewLine, all[start..]));
+            return Redact(string.Join(Environment.NewLine, tail));
         }
         catch
         {
@@ -175,7 +234,7 @@ internal static class BugReport
         sb.AppendLine();
         sb.AppendLine($"- Magic Tray: {version}");
         sb.AppendLine($"- Windows: {os}");
-        return sb.ToString();
+        return Redact(sb.ToString());
     }
 
     internal static string TroubleshootHint(IReadOnlyList<BugReportDevice>? devices)
@@ -196,6 +255,9 @@ internal static class BugReport
         return "";
     }
 
+    // Bounded, fully percent-encoded ?labels=&title=&body= draft URL. Browsers
+    // and GitHub reject very long URLs, so the body is clipped to MaxUrlChars
+    // measured on the ENCODED text (the full report is on the clipboard).
     internal static string IssueUrl(string title, string body, string label = "bug")
     {
         var prefix = $"{NewIssueBase}?labels={Uri.EscapeDataString(label)}&title={Uri.EscapeDataString(title)}&body=";
@@ -203,11 +265,14 @@ internal static class BugReport
         if (prefix.Length + encoded.Length <= MaxUrlChars)
             return prefix + encoded;
 
-        var clipped = body ?? "";
-        while (clipped.Length > 80 && prefix.Length + Uri.EscapeDataString(clipped).Length > MaxUrlChars)
-            clipped = clipped[..Math.Max(80, clipped.Length * 3 / 4)];
         const string note = "\n\n(truncated — full report is on the clipboard)";
-        return prefix + Uri.EscapeDataString(clipped + note);
+        var encodedNote = Uri.EscapeDataString(note);
+        // Reserve the note: clipping only the body would push past the cap.
+        var budget = Math.Max(0, MaxUrlChars - prefix.Length - encodedNote.Length);
+        var clipped = body ?? "";
+        while (clipped.Length > 0 && Uri.EscapeDataString(clipped).Length > budget)
+            clipped = clipped[..(clipped.Length * 3 / 4)];
+        return prefix + Uri.EscapeDataString(clipped) + encodedNote;
     }
 
     static DeviceDriverHealth? FindHealth(IReadOnlyList<DeviceDriverHealth>? health, string pid)

--- a/MagicMouseTray/BugReport.cs
+++ b/MagicMouseTray/BugReport.cs
@@ -7,20 +7,28 @@ using System.Text.RegularExpressions;
 
 namespace MagicMouseTray;
 
+/// <summary>
+/// One row of the report device table: display name, PID, bound driver, battery text.
+/// </summary>
 internal readonly record struct BugReportDevice(
     string Name,
     string Pid,
     string Driver,
     string Battery);
 
-// Builds a MAC-redacted diagnostic snapshot and a GitHub issue draft URL.
-// Does not call the GitHub API — the user submits the draft while logged in.
+/// <summary>
+/// Builds a MAC-redacted diagnostic snapshot and a GitHub issue draft URL.
+/// Does not call the GitHub API — the user submits the draft while logged in.
+/// </summary>
 internal static class BugReport
 {
     internal const int LogTailLines = 40;
     internal const int MaxUrlChars = 7000;
     internal const string NewIssueBase = "https://github.com/LesleyMurfin/magic-tray/issues/new";
 
+    /// <summary>
+    /// Informational assembly version, falling back to the numeric version, then "unknown".
+    /// </summary>
     internal static string AppVersion()
     {
         var asm = Assembly.GetExecutingAssembly();
@@ -29,11 +37,14 @@ internal static class BugReport
             ?? "unknown";
     }
 
+    /// <summary>Windows build string as reported by the runtime.</summary>
     internal static string OsDescription() => RuntimeInformation.OSDescription;
 
-    // Scrubs everything that identifies the machine or its owner: Bluetooth
-    // addresses, Windows profile paths, and the local account/host names. The
-    // result is pasted into a PUBLIC GitHub issue, so this is load-bearing.
+    /// <summary>
+    /// Scrubs everything that identifies the machine or its owner: Bluetooth
+    /// addresses, Windows profile paths, and the local account/host names. The
+    /// result is pasted into a PUBLIC GitHub issue, so this is load-bearing.
+    /// </summary>
     internal static string Redact(string text)
     {
         if (string.IsNullOrEmpty(text))
@@ -49,9 +60,15 @@ internal static class BugReport
         return text;
     }
 
-    // Account and host names have no shape to match, so match the literals.
+    /// <summary>
+    /// Literal account and host name patterns — those values have no shape to match.
+    /// </summary>
     static readonly (Regex Pattern, string Placeholder)[] LocalIdentifiers = BuildLocalIdentifiers();
 
+    /// <summary>
+    /// Collects the local account and host names into replace patterns, skipping
+    /// blanks and case-insensitive duplicates.
+    /// </summary>
     static (Regex, string)[] BuildLocalIdentifiers()
     {
         var raw = new List<(string Value, string Placeholder)>(3);
@@ -60,14 +77,12 @@ internal static class BugReport
         Add(SafeEnv(() => Environment.UserDomainName), "<host>");
         // Longest first, so "lesley-pc" is not half-eaten by "lesley".
         return raw.OrderByDescending(v => v.Value.Length)
-            .Select(v => (new Regex(Regex.Escape(v.Value),
-                RegexOptions.IgnoreCase | RegexOptions.CultureInvariant), v.Placeholder))
+            .Select(v => (LocalIdentifierRegex(v.Value), v.Placeholder))
             .ToArray();
 
         void Add(string? value, string placeholder)
         {
-            // Under 3 chars a literal replace would shred unrelated log text.
-            if (string.IsNullOrWhiteSpace(value) || value.Length < 3)
+            if (string.IsNullOrWhiteSpace(value))
                 return;
             foreach (var existing in raw)
                 if (string.Equals(existing.Value, value, StringComparison.OrdinalIgnoreCase))
@@ -76,6 +91,21 @@ internal static class BugReport
         }
     }
 
+    /// <summary>
+    /// Pattern redacting one local identifier. Values of 3+ chars replace as a
+    /// substring; one- and two-character values such as "JD" or "PC" match only a
+    /// whole delimited token, so "JSON" and "PCIe" stay intact.
+    /// </summary>
+    internal static Regex LocalIdentifierRegex(string value)
+    {
+        var escaped = Regex.Escape(value);
+        var options = RegexOptions.IgnoreCase | RegexOptions.CultureInvariant;
+        if (value.Length >= 3)
+            return new Regex(escaped, options);
+        return new Regex($@"(?<![A-Za-z0-9]){escaped}(?![A-Za-z0-9])", options);
+    }
+
+    /// <summary>Reads an environment value, returning null when the lookup throws.</summary>
     static string? SafeEnv(Func<string> read)
     {
         try
@@ -88,6 +118,11 @@ internal static class BugReport
         }
     }
 
+    /// <summary>
+    /// Returns the last <paramref name="lines"/> lines of <paramref name="path"/>,
+    /// redacted. Streams the file so a rolled 1 MB debug.log is never fully
+    /// allocated, and returns "" for a missing or unreadable log.
+    /// </summary>
     internal static string ReadLogTail(string path, int lines)
     {
         if (lines <= 0 || string.IsNullOrEmpty(path) || !File.Exists(path))
@@ -117,6 +152,9 @@ internal static class BugReport
         }
     }
 
+    /// <summary>
+    /// Merges driver health and battery readings into one report row per PID.
+    /// </summary>
     internal static List<BugReportDevice> Collect(
         IReadOnlyList<DeviceDriverHealth> health,
         IReadOnlyDictionary<string, (int Pct, DeviceKind Kind, string Pid)> batteries)
@@ -154,6 +192,9 @@ internal static class BugReport
         return rows;
     }
 
+    /// <summary>
+    /// Renders the redacted bug-report body: environment, device table, and log tail.
+    /// </summary>
     internal static string FormatMarkdown(
         string version,
         string os,
@@ -200,6 +241,9 @@ internal static class BugReport
         return Redact(sb.ToString());
     }
 
+    /// <summary>
+    /// Issue title naming the first device whose driver state is not healthy.
+    /// </summary>
     internal static string IssueTitle(IReadOnlyList<BugReportDevice> devices, string version)
     {
         if (devices != null)
@@ -217,8 +261,12 @@ internal static class BugReport
         return $"bug: Magic Tray {version}";
     }
 
+    /// <summary>Issue title for a feature request.</summary>
     internal static string FeatureTitle(string version) => $"feat: Magic Tray {version}";
 
+    /// <summary>
+    /// Renders the feature-request body: prompts plus version, with no diagnostics.
+    /// </summary>
     internal static string FormatFeatureMarkdown(string version, string os)
     {
         var sb = new StringBuilder();
@@ -237,6 +285,9 @@ internal static class BugReport
         return Redact(sb.ToString());
     }
 
+    /// <summary>
+    /// First self-help hint matching the collected devices, or "" when none applies.
+    /// </summary>
     internal static string TroubleshootHint(IReadOnlyList<BugReportDevice>? devices)
     {
         if (devices == null)
@@ -255,9 +306,12 @@ internal static class BugReport
         return "";
     }
 
-    // Bounded, fully percent-encoded ?labels=&title=&body= draft URL. Browsers
-    // and GitHub reject very long URLs, so the body is clipped to MaxUrlChars
-    // measured on the ENCODED text (the full report is on the clipboard).
+    /// <summary>
+    /// Bounded, fully percent-encoded ?labels=&amp;title=&amp;body= draft URL. Browsers
+    /// and GitHub reject very long URLs, so the body is clipped to
+    /// <see cref="MaxUrlChars"/> measured on the ENCODED text (the full report is
+    /// on the clipboard).
+    /// </summary>
     internal static string IssueUrl(string title, string body, string label = "bug")
     {
         var prefix = $"{NewIssueBase}?labels={Uri.EscapeDataString(label)}&title={Uri.EscapeDataString(title)}&body=";
@@ -275,6 +329,7 @@ internal static class BugReport
         return prefix + Uri.EscapeDataString(clipped) + encodedNote;
     }
 
+    /// <summary>Health entry for a PID, or null when the checker did not report it.</summary>
     static DeviceDriverHealth? FindHealth(IReadOnlyList<DeviceDriverHealth>? health, string pid)
     {
         if (health == null)
@@ -287,5 +342,6 @@ internal static class BugReport
         return null;
     }
 
+    /// <summary>Battery cell text: a percentage, or "no reading" for sentinels.</summary>
     static string BatteryText(int pct) => pct < 0 ? "no reading" : $"{pct}%";
 }

--- a/MagicMouseTray/BugReport.cs
+++ b/MagicMouseTray/BugReport.cs
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: MIT
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace MagicMouseTray;
+
+internal readonly record struct BugReportDevice(
+    string Name,
+    string Pid,
+    string Driver,
+    string Battery);
+
+// Builds a MAC-redacted diagnostic snapshot and a GitHub issue draft URL.
+// Does not call the GitHub API — the user submits the draft while logged in.
+internal static class BugReport
+{
+    internal const int LogTailLines = 40;
+    internal const int MaxUrlChars = 7000;
+    internal const string NewIssueBase = "https://github.com/LesleyMurfin/magic-tray/issues/new";
+
+    internal static string AppVersion()
+    {
+        var asm = Assembly.GetExecutingAssembly();
+        return asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? asm.GetName().Version?.ToString()
+            ?? "unknown";
+    }
+
+    internal static string OsDescription() => RuntimeInformation.OSDescription;
+
+    internal static string Redact(string text)
+    {
+        if (string.IsNullOrEmpty(text))
+            return text;
+        text = Regex.Replace(text, @"\b([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b", "<mac>");
+        text = Regex.Replace(text, @"\bDev_[0-9A-Fa-f]{12}\b", "Dev_<mac>", RegexOptions.IgnoreCase);
+        text = Regex.Replace(text, @"(?<![0-9A-Fa-f])[0-9A-Fa-f]{12}(?![0-9A-Fa-f])", "<mac>");
+        return text;
+    }
+
+    internal static string ReadLogTail(string path, int lines)
+    {
+        if (lines <= 0 || string.IsNullOrEmpty(path) || !File.Exists(path))
+            return "";
+        try
+        {
+            var all = File.ReadAllLines(path);
+            if (all.Length == 0)
+                return "";
+            var start = Math.Max(0, all.Length - lines);
+            return Redact(string.Join(Environment.NewLine, all[start..]));
+        }
+        catch
+        {
+            return "";
+        }
+    }
+
+    internal static List<BugReportDevice> Collect(
+        IReadOnlyList<DeviceDriverHealth> health,
+        IReadOnlyDictionary<string, (int Pct, DeviceKind Kind, string Pid)> batteries)
+    {
+        var rows = new List<BugReportDevice>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        if (batteries != null)
+        {
+            foreach (var kv in batteries.OrderBy(k => k.Key, StringComparer.OrdinalIgnoreCase))
+            {
+                var pid = (kv.Value.Pid ?? "").ToUpperInvariant();
+                seen.Add(pid);
+                var healthMatch = FindHealth(health, pid);
+                rows.Add(new BugReportDevice(
+                    Redact(kv.Key),
+                    string.IsNullOrEmpty(pid) ? "?" : pid,
+                    healthMatch?.Status.ToString() ?? "n/a",
+                    BatteryText(kv.Value.Pct)));
+            }
+        }
+
+        if (health != null)
+        {
+            foreach (var h in health)
+            {
+                var pid = (h.Pid ?? "").ToUpperInvariant();
+                if (string.IsNullOrEmpty(pid) || !seen.Add(pid))
+                    continue;
+                var bound = string.IsNullOrEmpty(h.BoundDriverName) ? h.Status.ToString() : $"{h.Status} ({h.BoundDriverName})";
+                rows.Add(new BugReportDevice("paired", pid, bound, "n/a"));
+            }
+        }
+
+        return rows;
+    }
+
+    internal static string FormatMarkdown(
+        string version,
+        string os,
+        string? driver0323,
+        IReadOnlyList<BugReportDevice> devices,
+        string logTail)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("### What happened");
+        sb.AppendLine();
+        sb.AppendLine("(type here)");
+        sb.AppendLine();
+        sb.AppendLine("### Environment");
+        sb.AppendLine();
+        sb.AppendLine($"- Magic Tray: {version}");
+        sb.AppendLine($"- Windows: {os}");
+        if (!string.IsNullOrEmpty(driver0323))
+            sb.AppendLine($"- 0323 lasting choice: `{driver0323}`");
+        var hint = TroubleshootHint(devices);
+        if (!string.IsNullOrEmpty(hint))
+        {
+            sb.AppendLine($"- Hint: {hint}");
+        }
+        sb.AppendLine();
+        sb.AppendLine("### Devices");
+        sb.AppendLine();
+        sb.AppendLine("| Name | PID | Driver | Battery |");
+        sb.AppendLine("|---|---|---|---|");
+        if (devices == null || devices.Count == 0)
+        {
+            sb.AppendLine("| (none detected) | | | |");
+        }
+        else
+        {
+            foreach (var d in devices)
+                sb.AppendLine($"| {d.Name} | `{d.Pid}` | {d.Driver} | {d.Battery} |");
+        }
+        sb.AppendLine();
+        sb.AppendLine("### Log (last lines, MAC redacted)");
+        sb.AppendLine();
+        sb.AppendLine("```");
+        sb.AppendLine(string.IsNullOrEmpty(logTail) ? "(no debug.log)" : logTail.TrimEnd());
+        sb.AppendLine("```");
+        return Redact(sb.ToString());
+    }
+
+    internal static string IssueTitle(IReadOnlyList<BugReportDevice> devices, string version)
+    {
+        if (devices != null)
+        {
+            foreach (var d in devices)
+            {
+                if (!string.Equals(d.Driver, "Ok", StringComparison.Ordinal)
+                    && !string.Equals(d.Driver, "n/a", StringComparison.Ordinal)
+                    && !string.Equals(d.Driver, "PatchedKmdf", StringComparison.Ordinal))
+                    return $"bug: PID {d.Pid} {d.Driver} (Magic Tray {version})";
+            }
+            if (devices.Count > 0)
+                return $"bug: PID {devices[0].Pid} (Magic Tray {version})";
+        }
+        return $"bug: Magic Tray {version}";
+    }
+
+    internal static string FeatureTitle(string version) => $"feat: Magic Tray {version}";
+
+    internal static string FormatFeatureMarkdown(string version, string os)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("### Idea");
+        sb.AppendLine();
+        sb.AppendLine("(type here)");
+        sb.AppendLine();
+        sb.AppendLine("### Why it helps");
+        sb.AppendLine();
+        sb.AppendLine("(type here)");
+        sb.AppendLine();
+        sb.AppendLine("### Environment");
+        sb.AppendLine();
+        sb.AppendLine($"- Magic Tray: {version}");
+        sb.AppendLine($"- Windows: {os}");
+        return sb.ToString();
+    }
+
+    internal static string TroubleshootHint(IReadOnlyList<BugReportDevice>? devices)
+    {
+        if (devices == null)
+            return "";
+        foreach (var d in devices)
+        {
+            if (d.Pid.Equals("0323", StringComparison.OrdinalIgnoreCase)
+                && d.Driver.Contains("Stock", StringComparison.OrdinalIgnoreCase))
+                return "0323 is on stock Windows — pointer works; wheel needs KMDF (Test Mode + Memory Integrity off).";
+            if (d.Driver.Contains("PathA", StringComparison.OrdinalIgnoreCase))
+                return "Patched Apple: scroll and battery are mutually exclusive. KMDF is the path with both.";
+            if (d.Driver.Contains("NotBound", StringComparison.OrdinalIgnoreCase)
+                || d.Driver.Contains("NotInstalled", StringComparison.OrdinalIgnoreCase))
+                return "Driver package is not bound. Use the tray Driver radio (confirm UAC).";
+        }
+        return "";
+    }
+
+    internal static string IssueUrl(string title, string body, string label = "bug")
+    {
+        var prefix = $"{NewIssueBase}?labels={Uri.EscapeDataString(label)}&title={Uri.EscapeDataString(title)}&body=";
+        var encoded = Uri.EscapeDataString(body ?? "");
+        if (prefix.Length + encoded.Length <= MaxUrlChars)
+            return prefix + encoded;
+
+        var clipped = body ?? "";
+        while (clipped.Length > 80 && prefix.Length + Uri.EscapeDataString(clipped).Length > MaxUrlChars)
+            clipped = clipped[..Math.Max(80, clipped.Length * 3 / 4)];
+        const string note = "\n\n(truncated — full report is on the clipboard)";
+        return prefix + Uri.EscapeDataString(clipped + note);
+    }
+
+    static DeviceDriverHealth? FindHealth(IReadOnlyList<DeviceDriverHealth>? health, string pid)
+    {
+        if (health == null)
+            return null;
+        foreach (var h in health)
+        {
+            if (string.Equals(h.Pid, pid, StringComparison.OrdinalIgnoreCase))
+                return h;
+        }
+        return null;
+    }
+
+    static string BatteryText(int pct) => pct < 0 ? "no reading" : $"{pct}%";
+}

--- a/MagicMouseTray/BugReport.cs
+++ b/MagicMouseTray/BugReport.cs
@@ -308,19 +308,30 @@ internal static class BugReport
 
     /// <summary>
     /// Bounded, fully percent-encoded ?labels=&amp;title=&amp;body= draft URL. Browsers
-    /// and GitHub reject very long URLs, so the body is clipped to
+    /// and GitHub reject very long URLs, so both title and body are clipped to
     /// <see cref="MaxUrlChars"/> measured on the ENCODED text (the full report is
     /// on the clipboard).
     /// </summary>
     internal static string IssueUrl(string title, string body, string label = "bug")
     {
-        var prefix = $"{NewIssueBase}?labels={Uri.EscapeDataString(label)}&title={Uri.EscapeDataString(title)}&body=";
+        const string note = "\n\n(truncated — full report is on the clipboard)";
+        const string bodyKey = "&body=";
+        var encodedNote = Uri.EscapeDataString(note);
+        var head = $"{NewIssueBase}?labels={Uri.EscapeDataString(label)}&title=";
+
+        // Clip the title first: an encoded title long enough to fill the cap on
+        // its own leaves nothing for the body to give back, and the returned URL
+        // would be one the browser refuses to open.
+        var titleBudget = Math.Max(0, MaxUrlChars - head.Length - bodyKey.Length - encodedNote.Length);
+        var clippedTitle = title ?? "";
+        while (clippedTitle.Length > 0 && Uri.EscapeDataString(clippedTitle).Length > titleBudget)
+            clippedTitle = clippedTitle[..(clippedTitle.Length * 3 / 4)];
+
+        var prefix = head + Uri.EscapeDataString(clippedTitle) + bodyKey;
         var encoded = Uri.EscapeDataString(body ?? "");
         if (prefix.Length + encoded.Length <= MaxUrlChars)
             return prefix + encoded;
 
-        const string note = "\n\n(truncated — full report is on the clipboard)";
-        var encodedNote = Uri.EscapeDataString(note);
         // Reserve the note: clipping only the body would push past the cap.
         var budget = Math.Max(0, MaxUrlChars - prefix.Length - encodedNote.Length);
         var clipped = body ?? "";

--- a/MagicMouseTray/TrayApp.cs
+++ b/MagicMouseTray/TrayApp.cs
@@ -299,6 +299,10 @@ internal sealed class TrayApp : IDisposable
         }
     }
 
+    /// <summary>
+    /// Builds the tray context menu, including the Help section entries that open the
+    /// pre-filled bug and feature drafts. Rebuilt state is refreshed on Opening.
+    /// </summary>
     ContextMenuStrip BuildMenu(
         out ToolStripMenuItem startupItem,
         out ToolStripMenuItem batteryReadsItem,
@@ -526,6 +530,10 @@ internal sealed class TrayApp : IDisposable
         }
     }
 
+    /// <summary>
+    /// Opens the folder holding debug.log so a reporter can attach it by hand;
+    /// failures are logged, never surfaced as a dialog.
+    /// </summary>
     void OpenDiagnosticsFolder()
     {
         try
@@ -545,8 +553,12 @@ internal sealed class TrayApp : IDisposable
         }
     }
 
-    // true only when a browser (or the local fallback) actually launched, so
-    // callers can run their own fallback instead of assuming success.
+    /// <summary>
+    /// Opens <paramref name="url"/> in the default browser, then
+    /// <paramref name="localFallback"/> if that throws. Returns true only when a
+    /// browser (or the local fallback) actually launched, so callers can run their
+    /// own fallback instead of assuming success.
+    /// </summary>
     bool OpenHelpUrl(string url, string? localFallback = null)
     {
         try
@@ -578,6 +590,12 @@ internal sealed class TrayApp : IDisposable
         }
     }
 
+    /// <summary>
+    /// Confirms with the user, builds the redacted bug or feature Markdown, copies it
+    /// to the clipboard, and opens the pre-filled GitHub draft. On launch failure it
+    /// logs GITHUB_DRAFT_FAIL and opens the plain issues page instead.
+    /// </summary>
+    /// <param name="feature">true for a feature request, false for a bug report.</param>
     void OpenGitHubDraft(bool feature)
     {
         var caption = feature ? TrayMenu.RequestFeatureLabel : TrayMenu.ReportBugLabel;

--- a/MagicMouseTray/TrayApp.cs
+++ b/MagicMouseTray/TrayApp.cs
@@ -545,7 +545,9 @@ internal sealed class TrayApp : IDisposable
         }
     }
 
-    void OpenHelpUrl(string url, string? localFallback = null)
+    // true only when a browser (or the local fallback) actually launched, so
+    // callers can run their own fallback instead of assuming success.
+    bool OpenHelpUrl(string url, string? localFallback = null)
     {
         try
         {
@@ -553,22 +555,25 @@ internal sealed class TrayApp : IDisposable
             {
                 UseShellExecute = true
             });
+            return true;
         }
         catch (Exception ex)
         {
             Logger.Log($"OPEN_HELP_FAIL url={url} err={ex.Message}");
             if (string.IsNullOrEmpty(localFallback))
-                return;
+                return false;
             try
             {
                 System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(localFallback)
                 {
                     UseShellExecute = true
                 });
+                return true;
             }
             catch (Exception ex2)
             {
                 Logger.Log($"OPEN_HELP_LOCAL_FAIL path={localFallback} err={ex2.Message}");
+                return false;
             }
         }
     }
@@ -603,7 +608,12 @@ internal sealed class TrayApp : IDisposable
                 url = BugReport.IssueUrl(title, md, "bug");
             }
             Clipboard.SetText(md);
-            OpenHelpUrl(url);
+            if (!OpenHelpUrl(url))
+            {
+                Logger.Log($"GITHUB_DRAFT_FAIL feature={feature} err=draft_launch_failed");
+                OpenHelpUrl(TrayMenu.IssuesUrl);
+                return;
+            }
             Logger.Log(feature ? "FEATURE_DRAFT opened" : "BUG_REPORT opened");
         }
         catch (Exception ex)

--- a/MagicMouseTray/TrayApp.cs
+++ b/MagicMouseTray/TrayApp.cs
@@ -23,6 +23,11 @@ internal static class TrayMenu
     internal const string HowAlertsWorkLabel = "How alerts work";
     internal const string RepositoryLabel = "Repository";
     internal const string ReportBugLabel = "Report a bug";
+    internal const string RequestFeatureLabel = "Request a feature";
+    internal const string ReportBugConfirm =
+        "Magic Tray will collect version, driver badges, battery readings, and the last log lines (Bluetooth MAC redacted), copy them, and open a GitHub issue draft. You submit it while logged in.\n\nContinue?";
+    internal const string RequestFeatureConfirm =
+        "Magic Tray will open a GitHub feature-request draft with the app version. The text is also on the clipboard. You submit it while logged in.\n\nContinue?";
 
     // Global picker: percent floor, then time alerts. No invented hours.
     internal static string GlobalThresholdLabel(int pct) => $"{pct}%  then time alerts";
@@ -432,8 +437,11 @@ internal sealed class TrayApp : IDisposable
         repoItem.Click += (_, _) => OpenHelpUrl(TrayMenu.RepoUrl);
         help.DropDownItems.Add(repoItem);
         var bugItem = new ToolStripMenuItem(TrayMenu.ReportBugLabel);
-        bugItem.Click += (_, _) => OpenHelpUrl(TrayMenu.IssuesUrl);
+        bugItem.Click += (_, _) => OpenGitHubDraft(feature: false);
         help.DropDownItems.Add(bugItem);
+        var featItem = new ToolStripMenuItem(TrayMenu.RequestFeatureLabel);
+        featItem.Click += (_, _) => OpenGitHubDraft(feature: true);
+        help.DropDownItems.Add(featItem);
         menu.Items.Add(help);
 
         menu.Items.Add(new ToolStripSeparator());
@@ -562,6 +570,46 @@ internal sealed class TrayApp : IDisposable
             {
                 Logger.Log($"OPEN_HELP_LOCAL_FAIL path={localFallback} err={ex2.Message}");
             }
+        }
+    }
+
+    void OpenGitHubDraft(bool feature)
+    {
+        var caption = feature ? TrayMenu.RequestFeatureLabel : TrayMenu.ReportBugLabel;
+        var confirm = feature ? TrayMenu.RequestFeatureConfirm : TrayMenu.ReportBugConfirm;
+        if (MessageBox.Show(confirm, caption, MessageBoxButtons.OKCancel, MessageBoxIcon.Information)
+            != DialogResult.OK)
+            return;
+
+        try
+        {
+            var version = BugReport.AppVersion();
+            var os = BugReport.OsDescription();
+            string md;
+            string title;
+            string url;
+            if (feature)
+            {
+                md = BugReport.FormatFeatureMarkdown(version, os);
+                title = BugReport.FeatureTitle(version);
+                url = BugReport.IssueUrl(title, md, "enhancement");
+            }
+            else
+            {
+                var rows = BugReport.Collect(_health, _deviceBatteries);
+                var log = BugReport.ReadLogTail(Logger.LogPath, BugReport.LogTailLines);
+                md = BugReport.FormatMarkdown(version, os, _config.Driver0323, rows, log);
+                title = BugReport.IssueTitle(rows, version);
+                url = BugReport.IssueUrl(title, md, "bug");
+            }
+            Clipboard.SetText(md);
+            OpenHelpUrl(url);
+            Logger.Log(feature ? "FEATURE_DRAFT opened" : "BUG_REPORT opened");
+        }
+        catch (Exception ex)
+        {
+            Logger.Log($"GITHUB_DRAFT_FAIL feature={feature} err={ex.Message}");
+            OpenHelpUrl(TrayMenu.IssuesUrl);
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Right-click the tray icon.
 | Battery reads | Status only. Visible on 2024 / v3 + KMDF. |
 | Refresh Now | Immediate battery read |
 | Diagnostics | Logs, test notification, capture scripts |
-| Help/Documentation | Alerts doc, this repo, report a bug |
+| Help/Documentation | Alerts doc, this repo, report a bug (pre-filled diagnostics), request a feature |
 | Quit | Exit |
 
 Footer: **Magic Tray 1.1.0**.

--- a/docs/DESIGN-github-drafts.md
+++ b/docs/DESIGN-github-drafts.md
@@ -1,0 +1,114 @@
+# DESIGN — Help opens a GitHub issue draft
+
+Status: Implemented on `feat/report-bug-snapshot` (PR #102, approved, CI green). This file stays the source of truth; if the C# disagrees with it, change the C#.
+
+The tray does **not** call the GitHub API, OpenAI, or Riley. It copies markdown, opens `issues/new` in the browser, and the user submits while logged in.
+
+## Menu
+
+Tray → **Help/Documentation** →
+
+```
+How alerts work
+Repository
+Report a bug
+Request a feature
+```
+
+| Item | What happens after Confirm |
+| --- | --- |
+| Report a bug | MAC-redacted snapshot → clipboard + `https://github.com/LesleyMurfin/magic-tray/issues/new?labels=bug&title=…&body=…` |
+| Request a feature | Version (no snapshot) → clipboard + same host with `labels=enhancement` |
+
+Both use an OK/Cancel MessageBox first. Cancel is a no-op. Clipboard holds the full markdown even if the URL is truncated.
+
+Confirm copy:
+
+- **Report a bug:** Magic Tray will collect version, driver badges, battery readings, and the last log lines (Bluetooth MAC redacted), copy them, and open a GitHub issue draft. You submit it while logged in.
+- **Request a feature:** Magic Tray will open a GitHub feature-request draft with the app version. The text is also on the clipboard. You submit it while logged in.
+
+On failure (clipboard / browser), open `https://github.com/LesleyMurfin/magic-tray/issues` and log `GITHUB_DRAFT_FAIL`. Do not retry with a token.
+
+## Bug snapshot
+
+`BugReport.FormatMarkdown` (pure string; no WinForms):
+
+- **What happened** — `(type here)`
+- **Environment** — Magic Tray version, `RuntimeInformation.OSDescription`, optional `0323 lasting choice` (`kmdf` / `pathA` / `stock`), one-line `TroubleshootHint` when it fires
+- **Devices** — Name / PID / Driver / Battery. PID kept. No `BTHENUM` instance path.
+- **Log** — last **40** lines of `%APPDATA%\MagicMouseTray\debug.log`, already redacted. Missing file → `(no debug.log)`.
+
+Title: first device whose Driver is not `Ok`, `n/a`, or `PatchedKmdf` → `bug: PID {pid} {driver} (Magic Tray {version})`. Else first PID, else `bug: Magic Tray {version}`.
+
+## Feature draft
+
+No devices, no log, no hint, no redact pass required.
+
+- **Idea** / **Why it helps** — `(type here)`
+- **Environment** — Magic Tray version (and OS description). Not a diagnostic dump.
+
+Title: `feat: Magic Tray {version}`. Label: `enhancement` only.
+
+## Redact
+
+`BugReport.Redact` on names, log tail, and the finished bug markdown. Keep Apple PIDs (`0323`, `030D`, …).
+
+| Pattern | Replacement |
+| --- | --- |
+| `\b([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b` | `<mac>` |
+| `\bDev_[0-9A-Fa-f]{12}\b` | `Dev_<mac>` |
+| 12 hex chars not touching other hex | `<mac>` |
+
+No other PII stripping this slice. Do not ship `debug.log` unredacted in the URL.
+
+## TroubleshootHint (local, one line)
+
+First match wins. Not a doctor, not a network call.
+
+| When | Hint |
+| --- | --- |
+| PID `0323` and Driver contains `Stock` | `0323 is on stock Windows — pointer works; wheel needs KMDF (Test Mode + Memory Integrity off).` |
+| Driver contains `PathA` (covers `PathAPatched`) | `Patched Apple: scroll and battery are mutually exclusive. KMDF is the path with both.` |
+| Driver contains `NotBound` or `NotInstalled` | `Driver package is not bound. Use the tray Driver radio (confirm UAC).` |
+
+Else empty. Do not hint on `Ok` / `PatchedKmdf`.
+
+## URL
+
+`https://github.com/LesleyMurfin/magic-tray/issues/new?labels={label}&title={title}&body={body}` (`Uri.EscapeDataString`). Cap **7000** chars; if over, shrink body and append `(truncated — full report is on the clipboard)`. Query is `labels=bug` / `labels=enhancement`, not `template=`.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `docs/DESIGN-github-drafts.md` | This design. |
+| `specs/github-drafts.md` | SSSF for BUILD after approve. |
+| `MagicMouseTray/BugReport.cs` | Redact, collect, markdown, title, hint, URL. No WinForms. No HTTP. |
+| `MagicMouseTray/TrayApp.cs` (`TrayMenu` + `OpenGitHubDraft`) | Labels, confirm copy, clipboard, `OpenHelpUrl`. |
+| `MagicMouseTray.Tests/BugReportTests.cs` | Redact / markdown / URL / hint. No browser, no MessageBox. |
+| `MagicMouseTray.Tests/TrayMenuTests.cs` | Exact Help labels. |
+| `.github/ISSUE_TEMPLATE/{bug,feature}.md` | Already on the branch; leave unless they drift from this menu. |
+
+## Tests
+
+WindowsDesktop, helpers only. No live HID. Tests do not call `OpenGitHubDraft`, `Clipboard.SetText`, `MessageBox.Show`, or `Process.Start`.
+
+- Redact: colon-MAC, `Dev_AABB…`, bare 12-hex gone; PID `0323` kept.
+- `FormatMarkdown` has version, PID, driver badge, lasting choice; no `BTHENUM` / raw MAC.
+- `Collect` merges battery + health; name has no `Dev_` MAC.
+- Title uses first non-Ok driver (`StockKmdf` over a prior `Ok` row).
+- Hint: Stock `0323` mentions KMDF; PathA mentions mutually exclusive; NotBound mentions Driver radio.
+- Feature markdown has Idea + version, no `debug.log`.
+- `IssueUrl` default `labels=bug`; feature `labels=enhancement` and not `labels=bug`.
+- Body in the URL is escaped; raw body text is not a substring. Huge body ≤ `MaxUrlChars` and contains `truncated`.
+- `ReadLogTail` last N lines, redacted.
+- Labels exactly `Report a bug`, `Request a feature`. No `PATH-A` in those labels.
+
+## Non-goals
+
+- Riley HTTP, OpenAI / any LLM rewrite, API tokens in the exe.
+- GitHub Issues API, auto-filing, PAT, or submitting for the user.
+- Shipping secrets, full unredacted `debug.log`, or Bluetooth MAC.
+- Pairing, driver install/bind, PATH-A/KMDF work.
+- Changing Classify, Diagnostics scripts, or ISSUE_TEMPLATE bodies unless they contradict this menu.
+- Push.

--- a/specs/github-drafts.md
+++ b/specs/github-drafts.md
@@ -1,0 +1,72 @@
+# Spec — Help → GitHub issue drafts
+
+Status: Implemented. Built and reviewed on `feat/report-bug-snapshot` (PR #102). `docs/DESIGN-github-drafts.md` remains the contract; this spec records the shipped surface.
+
+## Current State
+
+On this branch the draft already exists:
+
+- `MagicMouseTray/BugReport.cs` — `Redact`, `ReadLogTail` (40 lines), `Collect`, `FormatMarkdown`, `FormatFeatureMarkdown`, `IssueTitle` / `FeatureTitle`, `TroubleshootHint`, `IssueUrl` (`NewIssueBase` = `https://github.com/LesleyMurfin/magic-tray/issues/new`, `MaxUrlChars` = 7000). No GitHub HTTP client. No OpenAI. No Riley.
+- `TrayMenu` in `MagicMouseTray/TrayApp.cs` — labels `Report a bug` / `Request a feature` plus confirm strings. Help submenu: How alerts work, Repository, then those two items.
+- `TrayApp.OpenGitHubDraft(bool feature)` — MessageBox OK/Cancel → build markdown → `Clipboard.SetText` → `OpenHelpUrl(url)`. Catch → log `GITHUB_DRAFT_FAIL` and open `TrayMenu.IssuesUrl`.
+- `MagicMouseTray.Tests/BugReportTests.cs` — redact, markdown, collect, title, Stock-0323 hint, feature markdown, URL labels, truncation, log tail. Does not open a browser or MessageBox.
+- `TrayMenuTests.HelpUrls_AndLabels_AreExact` asserts the two labels.
+- `.github/ISSUE_TEMPLATE/bug.md` and `feature.md` already point at the Help items.
+
+Gaps vs design (fix after approve, do not expand scope):
+
+- Hint tests cover Stock 0323 only; add PathA and NotBound.
+- Do not add `template=` query params; keep `labels=bug` / `labels=enhancement`.
+- Do not introduce GitHub API, tokens, or LLM.
+
+## Summary
+
+After approve: Help → **Report a bug** copies a MAC-redacted snapshot and opens a GitHub **draft** (`labels=bug`). Help → **Request a feature** copies version-only markdown and opens `labels=enhancement`. User submits in the browser while logged in. Local one-line `TroubleshootHint` for Stock 0323 / PathA / not-bound. Confirm dialog. Clipboard + browser.
+
+## Files to Touch
+
+| File | Change after approve |
+| --- | --- |
+| `MagicMouseTray/BugReport.cs` | Align with design (redact, snapshot, feature body, hint, URL cap). Stay WinForms-free. |
+| `MagicMouseTray/TrayApp.cs` | Keep `TrayMenu` labels/confirm; `OpenGitHubDraft` = confirm → clipboard → `issues/new`. |
+| `MagicMouseTray.Tests/BugReportTests.cs` | Cover redact, both drafts, all three hints, URL labels, truncation. No MessageBox / browser. |
+| `MagicMouseTray.Tests/TrayMenuTests.cs` | Keep exact `Report a bug` / `Request a feature` strings. |
+
+Do not edit README, CONTRIBUTING, ISSUE_TEMPLATE, pairing/driver code, or Diagnostics in this vertical unless a string already contradicts the design.
+
+## Step-by-Step
+
+1. Stop until `docs/DESIGN-github-drafts.md` is approved. Then that file wins over this branch’s C#.
+2. Keep `BugReport` a pure helper. No `HttpClient`, no GitHub token, no OpenAI/Riley package, no `issues` POST.
+3. Bug path: `Collect(_health, _deviceBatteries)` + `ReadLogTail(Logger.LogPath, 40)` + `FormatMarkdown` + `IssueTitle` + `IssueUrl(..., "bug")`.
+4. Feature path: `FormatFeatureMarkdown` + `FeatureTitle` + `IssueUrl(..., "enhancement")`. No log tail, no device table.
+5. Redact colon/dash MAC, `Dev_<12 hex>`, and bare 12-hex. Keep PIDs.
+6. `TroubleshootHint`: Stock 0323 → KMDF; PathA → mutually exclusive; NotBound/NotInstalled → Driver radio. First match. Empty otherwise.
+7. Confirm with `MessageBox` OK/Cancel using the existing `TrayMenu` copy. Cancel returns. After OK: clipboard then browser. Failure: issues list URL, no secret, no retry-as-API.
+8. URL length ≤ 7000; truncated body notes that the clipboard has the rest.
+9. Tests stay in `MagicMouseTray.Tests`; they construct strings and temp log files only.
+
+## Verification
+
+On Windows (this project is WindowsDesktop; do not run the suite on Linux):
+
+```
+dotnet test MagicMouseTray.Tests/MagicMouseTray.Tests.csproj -c Release
+```
+
+Must pass. Tests must not open a browser or `MessageBox`. Targeted filter if iterating:
+
+```
+dotnet test MagicMouseTray.Tests/MagicMouseTray.Tests.csproj -c Release --filter "FullyQualifiedName~BugReportTests|FullyQualifiedName~HelpUrls_AndLabels_AreExact"
+```
+
+Do not run formatters, linters, or a project-wide build beyond that test project unless the human asks.
+
+## Notes for Next Agent
+
+- Lane is engineer BUILD only after human gate. Do not commit/push from design.
+- Design file is source of truth; if C# disagrees, change C#.
+- No OpenAI key, no Riley HTTP, no GitHub PAT in the exe or tests.
+- Do not auto-file issues. Do not pair devices or install drivers in this vertical.
+- Product name in copy is **Magic Tray**. Repo is `LesleyMurfin/magic-tray`.
+- After BUILD: Status on the design note can move to Implemented.


### PR DESCRIPTION
## Summary

**Help → Report a bug** collects version, 0323 choice, driver badges, battery readings, and a MAC-redacted log tail, copies it, and opens a GitHub issue draft. **Help → Request a feature** opens an enhancement draft with version only.

The user submits while logged in. No GitHub/OpenAI/Riley token in the exe.

Stock 0323 / Patched Apple / not-bound get a one-line local hint in the bug body (not an LLM).

## Files

- \`MagicMouseTray/BugReport.cs\` — redact, snapshot, URL
- Help menu wiring in \`TrayApp\`
- \`.github/ISSUE_TEMPLATE/bug.md\` and \`feature.md\`