### PR TITLE
fix(tray): Enabled on this PC actually disables the device

### DIFF
--- a/MagicMouseTray.Tests/DeviceEnableTests.cs
+++ b/MagicMouseTray.Tests/DeviceEnableTests.cs
@@ -7,6 +7,39 @@ namespace MagicMouseTray.Tests;
 public class DeviceEnableTests
 {
     [Fact]
+    public void VidNeedles_030d_FromMouseCatalog()
+    {
+        var needles = DeviceEnable.VidNeedlesForPid("030d");
+        Assert.Contains("000205AC", needles, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("VID_05AC", needles, StringComparer.OrdinalIgnoreCase);
+        Assert.DoesNotContain("0000045e", needles, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void VidNeedles_0323_IncludesBleCompanyId()
+    {
+        var needles = DeviceEnable.VidNeedlesForPid("0323");
+        Assert.Contains("0001004C", needles, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("VID_05AC", needles, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void VidNeedles_0239_FromKeyboardCatalog()
+    {
+        var needles = DeviceEnable.VidNeedlesForPid("0239");
+        Assert.Contains("000205AC", needles, StringComparer.OrdinalIgnoreCase);
+        Assert.Contains("VID_05AC", needles, StringComparer.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void VidNeedles_UnknownPid_Empty()
+    {
+        Assert.Empty(DeviceEnable.VidNeedlesForPid("abcd"));
+        Assert.Empty(DeviceEnable.VidNeedlesForPid("logi"));
+        Assert.Empty(DeviceEnable.VidNeedlesForPid(""));
+    }
+
+    [Fact]
     public void Matches_Hid030d_Not0323()
     {
         const string hid = @"HID\VID_05AC&PID_030D&COL01\7&abc";
@@ -17,7 +50,7 @@ public class DeviceEnableTests
     }
 
     [Fact]
-    public void Matches_Bthenum030d_RequiresAppleVid()
+    public void Matches_Bthenum030d_RequiresCatalogVid()
     {
         const string bt =
             @"BTHENUM\{00001124-0000-1000-8000-00805f9b34fb}_VID&000205ac_PID&030d\8&def";
@@ -28,7 +61,7 @@ public class DeviceEnableTests
     }
 
     [Fact]
-    public void Matches_BthledeviceKeyboard_RequiresAppleVid()
+    public void Matches_BthledeviceKeyboard_RequiresCatalogVid()
     {
         const string ble =
             @"BTHLEDEVICE\{00001812-0000-1000-8000-00805f9b34fb}_VID&000205ac_PID&0239\8&abc";
@@ -40,7 +73,7 @@ public class DeviceEnableTests
     }
 
     [Fact]
-    public void DisableScript_QuotesInstanceId_AndFailsIfNone()
+    public void DisableScript_QuotesInstanceId_WalksAllEnum_CatalogVids()
     {
         var script = DeviceEnable.BuildScript("030d", enable: false);
         Assert.Contains("pnputil.exe", script, StringComparison.OrdinalIgnoreCase);
@@ -48,7 +81,9 @@ public class DeviceEnableTests
         Assert.DoesNotContain("/$verb $id", script, StringComparison.Ordinal);
         Assert.Contains("if ($ids.Count -eq 0)", script, StringComparison.Ordinal);
         Assert.Contains("exit 1", script, StringComparison.Ordinal);
-        Assert.Contains("BTHLEDEVICE", script, StringComparison.Ordinal);
+        Assert.Contains("GetSubKeyNames()", script, StringComparison.Ordinal);
+        Assert.Contains("000205AC", script, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("VID_05AC", script, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("030d", script, StringComparison.Ordinal);
         Assert.DoesNotContain("/enable-device", script, StringComparison.Ordinal);
         foreach (var name in DeviceEnable.ForbiddenNames)
@@ -56,22 +91,27 @@ public class DeviceEnableTests
     }
 
     [Fact]
-    public void DisableScript_ChildrenBeforeRadio()
+    public void DisableScript_SortsBthenumLast()
     {
         var script = DeviceEnable.BuildScript("030d", enable: false);
-        var hid = script.IndexOf("'HID'", StringComparison.Ordinal);
-        var bt = script.IndexOf("'BTHENUM'", StringComparison.Ordinal);
-        Assert.True(hid >= 0 && bt > hid);
+        Assert.Contains("StartsWith('BTHENUM\\'", script, StringComparison.Ordinal);
+        Assert.Contains("Sort-Object $rank)", script, StringComparison.Ordinal);
     }
 
     [Fact]
-    public void EnableScript_UsesEnableDevice_RadioBeforeChildren()
+    public void EnableScript_UsesEnableDevice_BthenumFirst()
     {
         var script = DeviceEnable.BuildScript("030d", enable: true);
         Assert.Contains("$verb = 'enable-device'", script, StringComparison.Ordinal);
         Assert.DoesNotContain("$verb = 'disable-device'", script, StringComparison.Ordinal);
-        var bt = script.IndexOf("'BTHENUM'", StringComparison.Ordinal);
-        var hid = script.LastIndexOf("'HID'", StringComparison.Ordinal);
-        Assert.True(bt >= 0 && hid > bt);
+        Assert.Contains("Sort-Object $rank -Descending", script, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildScript_UnknownPid_Throws()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            DeviceEnable.BuildScript("abcd", enable: false));
+        Assert.Contains("No catalog VID", ex.Message, StringComparison.Ordinal);
     }
 }

--- a/MagicMouseTray.Tests/DeviceEnableTests.cs
+++ b/MagicMouseTray.Tests/DeviceEnableTests.cs
@@ -28,11 +28,27 @@ public class DeviceEnableTests
     }
 
     [Fact]
-    public void DisableScript_PnputilOnly_NoDriverInstallers()
+    public void Matches_BthledeviceKeyboard_RequiresAppleVid()
+    {
+        const string ble =
+            @"BTHLEDEVICE\{00001812-0000-1000-8000-00805f9b34fb}_VID&000205ac_PID&0239\8&abc";
+        Assert.True(DeviceEnable.MatchesInstance(ble, "0239"));
+        Assert.False(DeviceEnable.MatchesInstance(ble, "030d"));
+        Assert.False(DeviceEnable.MatchesInstance(
+            @"BTHLEDEVICE\{00001812-0000-1000-8000-00805f9b34fb}_VID&0000045e_PID&0239\8&abc",
+            "0239"));
+    }
+
+    [Fact]
+    public void DisableScript_QuotesInstanceId_AndFailsIfNone()
     {
         var script = DeviceEnable.BuildScript("030d", enable: false);
         Assert.Contains("pnputil.exe", script, StringComparison.OrdinalIgnoreCase);
-        Assert.Contains("/disable-device", script, StringComparison.Ordinal);
+        Assert.Contains("\"/$verb\" \"$id\"", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("/$verb $id", script, StringComparison.Ordinal);
+        Assert.Contains("if ($ids.Count -eq 0)", script, StringComparison.Ordinal);
+        Assert.Contains("exit 1", script, StringComparison.Ordinal);
+        Assert.Contains("BTHLEDEVICE", script, StringComparison.Ordinal);
         Assert.Contains("030d", script, StringComparison.Ordinal);
         Assert.DoesNotContain("/enable-device", script, StringComparison.Ordinal);
         foreach (var name in DeviceEnable.ForbiddenNames)
@@ -40,10 +56,22 @@ public class DeviceEnableTests
     }
 
     [Fact]
-    public void EnableScript_UsesEnableDevice()
+    public void DisableScript_ChildrenBeforeRadio()
+    {
+        var script = DeviceEnable.BuildScript("030d", enable: false);
+        var hid = script.IndexOf("'HID'", StringComparison.Ordinal);
+        var bt = script.IndexOf("'BTHENUM'", StringComparison.Ordinal);
+        Assert.True(hid >= 0 && bt > hid);
+    }
+
+    [Fact]
+    public void EnableScript_UsesEnableDevice_RadioBeforeChildren()
     {
         var script = DeviceEnable.BuildScript("030d", enable: true);
-        Assert.Contains("/enable-device", script, StringComparison.Ordinal);
-        Assert.DoesNotContain("/disable-device", script, StringComparison.Ordinal);
+        Assert.Contains("$verb = 'enable-device'", script, StringComparison.Ordinal);
+        Assert.DoesNotContain("$verb = 'disable-device'", script, StringComparison.Ordinal);
+        var bt = script.IndexOf("'BTHENUM'", StringComparison.Ordinal);
+        var hid = script.LastIndexOf("'HID'", StringComparison.Ordinal);
+        Assert.True(bt >= 0 && hid > bt);
     }
 }

--- a/MagicMouseTray.Tests/DeviceEnableTests.cs
+++ b/MagicMouseTray.Tests/DeviceEnableTests.cs
@@ -91,6 +91,30 @@ public class DeviceEnableTests
     }
 
     [Fact]
+    public void Script_ReadsAndLogsContainerIdPerInstance()
+    {
+        foreach (var enable in new[] { false, true })
+        {
+            var script = DeviceEnable.BuildScript("030d", enable);
+            // ContainerID is read off each matched instance key...
+            Assert.Contains("GetValue('ContainerID')", script, StringComparison.Ordinal);
+            // ...recorded per instance id...
+            Assert.Contains("$containers[$full] = $container", script, StringComparison.Ordinal);
+            // ...and logged with the instance the verb is applied to.
+            Assert.Contains(
+                "Write-Host \"DEVICE_ENABLE $verb $id container=$($containers[$id])\"",
+                script,
+                StringComparison.Ordinal);
+            // Distinct containers are logged so support sees every physical
+            // device a per-PID row touched.
+            Assert.Contains(
+                "Write-Host \"DEVICE_ENABLE containers=$($distinct -join ',')\"",
+                script,
+                StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
     public void DisableScript_SortsBthenumLast()
     {
         var script = DeviceEnable.BuildScript("030d", enable: false);

--- a/MagicMouseTray/DeviceEnable.cs
+++ b/MagicMouseTray/DeviceEnable.cs
@@ -76,6 +76,7 @@ $pidA = 'PID_' + $targetPid
 $pidB = 'PID&' + $targetPid
 $vidNeedles = @(__VIDS__)
 $ids = New-Object System.Collections.Generic.List[string]
+$containers = @{}
 
 function Test-Vid([string]$n) {
     $low = $n.ToLowerInvariant()
@@ -95,7 +96,16 @@ function Add-Matching([string]$enumerator) {
         $dev = $root.OpenSubKey($sub)
         if (-not $dev) { continue }
         foreach ($inst in $dev.GetSubKeyNames()) {
-            [void]$ids.Add($enumerator + '\' + $sub + '\' + $inst)
+            $full = $enumerator + '\' + $sub + '\' + $inst
+            $container = ''
+            $instKey = $dev.OpenSubKey($inst)
+            if ($instKey) {
+                $container = [string]$instKey.GetValue('ContainerID')
+                $instKey.Dispose()
+            }
+            if ([string]::IsNullOrEmpty($container)) { $container = 'unknown' }
+            $containers[$full] = $container
+            [void]$ids.Add($full)
         }
         $dev.Dispose()
     }
@@ -124,9 +134,14 @@ if ($ids.Count -eq 0) {
     exit 1
 }
 
+# One ContainerID per physical device. Rows are per-PID, so two of the same
+# model on one PC appear here together and are toggled together.
+$distinct = @($containers.Values | Sort-Object -Unique)
+Write-Host "DEVICE_ENABLE containers=$($distinct -join ',')"
+
 $failed = 0
 foreach ($id in $ids) {
-    Write-Host "DEVICE_ENABLE $verb $id"
+    Write-Host "DEVICE_ENABLE $verb $id container=$($containers[$id])"
     & pnputil.exe "/$verb" "$id"
     if ($LASTEXITCODE -ne 0) { $failed++ }
 }
@@ -172,6 +187,7 @@ exit 0
             try { p.Kill(entireProcessTree: true); } catch { /* ignore */ }
             throw new InvalidOperationException("pnputil enable/disable timed out.");
         }
+        Logger.Log($"DEVICE_ENABLE pid={pid} exit={p.ExitCode}");
         if (p.ExitCode != 0)
             throw new InvalidOperationException($"pnputil exited {p.ExitCode}.");
     }

--- a/MagicMouseTray/DeviceEnable.cs
+++ b/MagicMouseTray/DeviceEnable.cs
@@ -4,8 +4,10 @@ using System.IO;
 
 namespace MagicMouseTray;
 
-// Enabled on this PC: stop/start the existing Windows device for this PID
+// Enabled on this PC: stop/start the Windows device for this catalog PID
 // so a Mac can take the Bluetooth link. No unpair. No driver installers.
+// VID needles come from KnownMice / KnownKeyboards — adding a device to
+// those tables is what makes enable/disable work for it.
 internal static class DeviceEnable
 {
     internal static readonly string[] ForbiddenNames =
@@ -17,6 +19,21 @@ internal static class DeviceEnable
         "FLIP:NoFilter",
     ];
 
+    internal static string[] VidNeedlesForPid(string pid)
+    {
+        if (string.IsNullOrEmpty(pid) || pid.Length != 4)
+            return [];
+        pid = pid.ToLowerInvariant();
+        var set = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var m in MouseBatteryDevice.KnownMice)
+            if (m.PidPattern.EndsWith(pid, StringComparison.OrdinalIgnoreCase))
+                set.Add(m.VidPattern);
+        foreach (var k in KeyboardBatteryDevice.KnownKeyboards)
+            if (k.PidPattern.EndsWith(pid, StringComparison.OrdinalIgnoreCase))
+                set.Add(k.VidPattern);
+        return [.. set];
+    }
+
     internal static bool MatchesInstance(string instanceId, string pid)
     {
         if (string.IsNullOrEmpty(instanceId) || string.IsNullOrEmpty(pid))
@@ -24,17 +41,18 @@ internal static class DeviceEnable
         pid = pid.ToLowerInvariant();
         if (pid.Length != 4)
             return false;
+        var needles = VidNeedlesForPid(pid);
+        if (needles.Length == 0)
+            return false;
         var low = instanceId.ToLowerInvariant();
-        if (low.Contains("pid_" + pid, StringComparison.Ordinal) ||
-            low.Contains("pid&" + pid, StringComparison.Ordinal))
+        if (!low.Contains("pid_" + pid, StringComparison.Ordinal) &&
+            !low.Contains("pid&" + pid, StringComparison.Ordinal))
+            return false;
+        foreach (var vid in needles)
         {
-            if ((low.Contains("bthenum", StringComparison.Ordinal) ||
-                 low.Contains("bthle", StringComparison.Ordinal)) &&
-                !low.Contains("_vid&000205ac_", StringComparison.Ordinal) &&
-                !low.Contains("_vid&0001004c_", StringComparison.Ordinal) &&
-                !low.Contains("vid_05ac", StringComparison.Ordinal))
-                return false;
-            return true;
+            if (!string.IsNullOrEmpty(vid) &&
+                low.Contains(vid.ToLowerInvariant(), StringComparison.Ordinal))
+                return true;
         }
         return false;
     }
@@ -42,7 +60,12 @@ internal static class DeviceEnable
     internal static string BuildScript(string pid, bool enable)
     {
         pid = pid.ToLowerInvariant();
+        var needles = VidNeedlesForPid(pid);
+        if (needles.Length == 0)
+            throw new InvalidOperationException($"No catalog VID for pid={pid}.");
         var verb = enable ? "enable-device" : "disable-device";
+        var vidLiteral = string.Join(", ", needles.Select(v =>
+            "'" + v.Replace("'", "''", StringComparison.Ordinal) + "'"));
         // "$id" is required: HID/BTHENUM instance IDs contain '&'. Unquoted,
         // PowerShell treats '&' as the call operator and pnputil never runs.
         var template = """
@@ -51,7 +74,7 @@ $targetPid = '__PID__'
 $verb = '__VERB__'
 $pidA = 'PID_' + $targetPid
 $pidB = 'PID&' + $targetPid
-$vidNeedles = @('_VID&000205ac_', '_VID&0001004c_', 'VID_05AC')
+$vidNeedles = @(__VIDS__)
 $ids = New-Object System.Collections.Generic.List[string]
 
 function Test-Vid([string]$n) {
@@ -79,12 +102,22 @@ function Add-Matching([string]$enumerator) {
     $root.Dispose()
 }
 
-$order = if ($verb -eq 'disable-device') {
-    @('HID', 'USB', 'BTHLE', 'BTHLEDEVICE', 'BTHENUM')
-} else {
-    @('BTHENUM', 'BTHLEDEVICE', 'BTHLE', 'USB', 'HID')
+$enumRoot = [Microsoft.Win32.Registry]::LocalMachine.OpenSubKey('SYSTEM\CurrentControlSet\Enum')
+if (-not $enumRoot) {
+    Write-Host 'DEVICE_ENABLE no Enum'
+    exit 1
 }
-foreach ($e in $order) { Add-Matching $e }
+foreach ($enumerator in $enumRoot.GetSubKeyNames()) {
+    Add-Matching $enumerator
+}
+$enumRoot.Dispose()
+
+$rank = { if ($_.StartsWith('BTHENUM\', [StringComparison]::OrdinalIgnoreCase)) { 1 } else { 0 } }
+if ($verb -eq 'disable-device') {
+    $ids = [System.Collections.Generic.List[string]]($ids | Sort-Object $rank)
+} else {
+    $ids = [System.Collections.Generic.List[string]]($ids | Sort-Object $rank -Descending)
+}
 
 if ($ids.Count -eq 0) {
     Write-Host "DEVICE_ENABLE no instances pid=$targetPid"
@@ -102,7 +135,8 @@ exit 0
 """;
         var script = template
             .Replace("__PID__", pid, StringComparison.Ordinal)
-            .Replace("__VERB__", verb, StringComparison.Ordinal);
+            .Replace("__VERB__", verb, StringComparison.Ordinal)
+            .Replace("__VIDS__", vidLiteral, StringComparison.Ordinal);
         foreach (var name in ForbiddenNames)
         {
             if (script.Contains(name, StringComparison.OrdinalIgnoreCase))
@@ -116,6 +150,8 @@ exit 0
         if (string.IsNullOrEmpty(pid) || pid.Length != 4)
             throw new InvalidOperationException("DeviceEnable needs a 4-hex PID.");
         pid = pid.ToLowerInvariant();
+        if (VidNeedlesForPid(pid).Length == 0)
+            throw new InvalidOperationException($"No catalog VID for pid={pid}.");
         var temp = Path.Combine(Path.GetTempPath(), $"mm-enable-{pid}.ps1");
         File.WriteAllText(temp, BuildScript(pid, enable));
         Logger.Log($"DEVICE_ENABLE pid={pid} val={enable.ToString().ToLowerInvariant()}");

--- a/MagicMouseTray/DeviceEnable.cs
+++ b/MagicMouseTray/DeviceEnable.cs
@@ -4,8 +4,8 @@ using System.IO;
 
 namespace MagicMouseTray;
 
-// Enabled on this PC V2: stop/start the existing Windows device for this PID.
-// No new driver. No unpair. No KMDF / PathA / Stock scripts.
+// Enabled on this PC: stop/start the existing Windows device for this PID
+// so a Mac can take the Bluetooth link. No unpair. No driver installers.
 internal static class DeviceEnable
 {
     internal static readonly string[] ForbiddenNames =
@@ -28,7 +28,8 @@ internal static class DeviceEnable
         if (low.Contains("pid_" + pid, StringComparison.Ordinal) ||
             low.Contains("pid&" + pid, StringComparison.Ordinal))
         {
-            if (low.Contains("bthenum", StringComparison.Ordinal) &&
+            if ((low.Contains("bthenum", StringComparison.Ordinal) ||
+                 low.Contains("bthle", StringComparison.Ordinal)) &&
                 !low.Contains("_vid&000205ac_", StringComparison.Ordinal) &&
                 !low.Contains("_vid&0001004c_", StringComparison.Ordinal) &&
                 !low.Contains("vid_05ac", StringComparison.Ordinal))
@@ -42,6 +43,8 @@ internal static class DeviceEnable
     {
         pid = pid.ToLowerInvariant();
         var verb = enable ? "enable-device" : "disable-device";
+        // "$id" is required: HID/BTHENUM instance IDs contain '&'. Unquoted,
+        // PowerShell treats '&' as the call operator and pnputil never runs.
         var template = """
 $ErrorActionPreference = 'Continue'
 $targetPid = '__PID__'
@@ -76,12 +79,26 @@ function Add-Matching([string]$enumerator) {
     $root.Dispose()
 }
 
-Add-Matching 'BTHENUM'
-Add-Matching 'HID'
-Add-Matching 'USB'
-foreach ($id in $ids) {
-    & pnputil.exe /__VERB__ $id | Out-Host
+$order = if ($verb -eq 'disable-device') {
+    @('HID', 'USB', 'BTHLE', 'BTHLEDEVICE', 'BTHENUM')
+} else {
+    @('BTHENUM', 'BTHLEDEVICE', 'BTHLE', 'USB', 'HID')
 }
+foreach ($e in $order) { Add-Matching $e }
+
+if ($ids.Count -eq 0) {
+    Write-Host "DEVICE_ENABLE no instances pid=$targetPid"
+    exit 1
+}
+
+$failed = 0
+foreach ($id in $ids) {
+    Write-Host "DEVICE_ENABLE $verb $id"
+    & pnputil.exe "/$verb" "$id"
+    if ($LASTEXITCODE -ne 0) { $failed++ }
+}
+if ($failed -ne 0) { exit 1 }
+exit 0
 """;
         var script = template
             .Replace("__PID__", pid, StringComparison.Ordinal)
@@ -96,7 +113,7 @@ foreach ($id in $ids) {
 
     internal static void Apply(string pid, bool enable)
     {
-        if (string.IsNullOrEmpty(pid) || pid.Length > 4)
+        if (string.IsNullOrEmpty(pid) || pid.Length != 4)
             throw new InvalidOperationException("DeviceEnable needs a 4-hex PID.");
         pid = pid.ToLowerInvariant();
         var temp = Path.Combine(Path.GetTempPath(), $"mm-enable-{pid}.ps1");

--- a/docs/ALERTS.md
+++ b/docs/ALERTS.md
@@ -44,7 +44,7 @@ Disconnect after a last good reading well above 1% is not death.
 
 ## Enabled on this PC
 
-Each device row has **Enabled on this PC** (on by default). Uncheck it, confirm, then accept UAC. Magic Tray disables that device’s Bluetooth / HID / USB nodes on **this PC**. The pointer or keyboard stops here so a Mac can use it. Pairing is unchanged — check the box again to bring it back.
+Each device row has **Enabled on this PC** (on by default). Uncheck it, confirm, then accept UAC. Magic Tray disables that device’s Bluetooth / HID / USB nodes on **this PC** using the same VID/PID catalog as battery discovery. The pointer or keyboard stops here so a Mac can use it. Pairing is unchanged — check the box again to bring it back. A new model is enabled for this control by adding it to `KnownMice` / `KnownKeyboards`.
 
 Cancelling UAC leaves it enabled. If no matching device is found, the tray reports failure and leaves the box checked.
 

--- a/docs/ALERTS.md
+++ b/docs/ALERTS.md
@@ -48,6 +48,8 @@ Each device row has **Enabled on this PC** (on by default). Uncheck it, confirm,
 
 Cancelling UAC leaves it enabled. If no matching device is found, the tray reports failure and leaves the box checked.
 
+Rows are per model, not per paired device. If you have **two of the same model** paired to this PC — two Magic Mouse v1, say — they share one row, and unchecking it disables **both**. The log records the `ContainerID` of every device instance that was touched, so `DEVICE_ENABLE containers=…` in the log tells you exactly which physical devices changed.
+
 
 ## Report a bug
 

--- a/docs/ALERTS.md
+++ b/docs/ALERTS.md
@@ -42,11 +42,12 @@ Disconnect after a last good reading well above 1% is not death.
 - At **0–1%** while connected: a plug-now window.
 - If it **disconnects**, that window **closes**. Disconnect is not treated as death — you can charge it.
 
-## Skip alerts for one device
+## Enabled on this PC
 
-Each device row has **Enabled on this PC** (on by default). Uncheck it to skip battery polling and alerts for that device on this computer. The row stays so you can turn it back on. Bluetooth pairing does not change.
+Each device row has **Enabled on this PC** (on by default). Uncheck it, confirm, then accept UAC. Magic Tray disables that device’s Bluetooth / HID / USB nodes on **this PC**. The pointer or keyboard stops here so a Mac can use it. Pairing is unchanged — check the box again to bring it back.
 
-Use this when the same mouse is mostly used on a Mac and you do not want this PC toasting about it.
+Cancelling UAC leaves it enabled. If no matching device is found, the tray reports failure and leaves the box checked.
+
 
 ## Report a bug
 


### PR DESCRIPTION
## Why

**Enabled on this PC** is the share-with-Mac control. Uncheck → this PC drops the device; Mac can take it. Pairing stays.

That never worked on live v1 (#87). Tests only grepped the script text. They never executed it.

Cause: instance IDs look like \`HID\\VID_05AC&PID_030D&COL01\\...\`. The script ran \`pnputil /disable-device \$id\` **unquoted**. PowerShell's \`&\` call operator ate the ID. \`pnputil\` did nothing. PowerShell still exited 0, so the tray kept the checkbox off and only skipped polling.

## Fix

- Quote \`\"/\$verb\" \"\$id\"\`
- \`exit 1\` if no instances, or if any pnputil fails (tray reverts the checkbox)
- Also walk \`BTHLE\` / \`BTHLEDEVICE\` (keyboards / BLE)
- Disable HID/USB/BLE before BTHENUM; enable the other way

## Not a live e2e

Cannot run \`net8.0-windows\` tests or pnputil from this WSL host. After merge, on the PC: uncheck Magic Mouse v1 → UAC → pointer stops; Mac should pick it up; re-check restores.

Closes #87

## Review follow-ups

- Exit code of the elevated process is now logged for **both** success and failure (`DEVICE_ENABLE pid=… exit=…`), so support logs record the result of every enable/disable — not just the failures.
- The generated script reads each matched instance's `ContainerID` and logs it (`… container={guid}`), plus one `DEVICE_ENABLE containers=…` summary line. One ContainerID per physical device, so the log now shows exactly which physical devices `pnputil` touched.
- **Deliberate partial fix:** CodeRabbit asked for per-device identity so two same-model devices are not toggled together. Tray rows are per-PID by design (battery discovery is per-PID too), so per-device selection means reworking rows and `IBatteryDevice` — out of scope here. `docs/ALERTS.md` now states plainly that two of the same model on one PC share a row and toggle together, and the ContainerID logging makes the affected devices visible. Follow-up issue for per-device rows to be filed separately.

Also documents the control in `docs/ALERTS.md`.

Closes #84