### PR TITLE
docs: sbagirici stack diagram + star their repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,14 @@ CI builds on a `v*` tag: test, publish win-x64, optional Authenticode (`SIGN_PFX
 
 ---
 
+## Credits
+
+The LowerFilter sandwich (app → Windows HID → **filter** → Bluetooth → mouse) is from [sbagirici/apple-magic-mouse-scroll-fix-windows](https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows). That Architecture diagram is why the v1/v2 scroll path is understandable. **Please star their repo.** We redraw it on [v3.html](https://lesleymurfin.github.io/magic-tray/v3.html#stack). Their installer is for v1/v2 with Apple’s signed `applewirelessmouse.sys`. Magic Mouse 2024 (`0323`) still uses KMDF from [magic-mouse-v3-windows-fix](https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix).
+
+v1/v2 Boot Camp INF packaging: [tealtadpole/MagicMouse2DriversWin11x64](https://github.com/tealtadpole/MagicMouse2DriversWin11x64).
+
+---
+
 ## License
 
 [MIT](LICENSE) · Copyright (c) 2026 Lesley Murfin.

--- a/docs/drivers.html
+++ b/docs/drivers.html
@@ -244,7 +244,42 @@
           </div>
         </div>
       </div>
-      <p>KMDF is the filter that keeps the two rooms apart. Full diagrams: <a href="v3.html#mode">Why v3 is hard</a>.</p>
+      <p>KMDF is the filter that keeps the two rooms apart. The sandwich picture is <a href="v3.html#stack">sbagirici’s</a>.</p>
+      <div class="diagram sba-pair">
+        <div class="sba">
+          <h3 class="sba-title">sbagirici · v1 / v2</h3>
+          <div class="layer"><strong>Application</strong></div>
+          <div class="layer"><strong>Windows HID stack</strong></div>
+          <div class="filter-wrap">
+            <div class="filter">
+              <strong>applewirelessmouse.sys</strong>
+              <em>← LowerFilter · multi-touch → scroll</em>
+            </div>
+          </div>
+          <div class="layer"><strong>Bluetooth HID</strong></div>
+          <div class="layer"><strong>Bluetooth stack</strong></div>
+          <div class="layer"><strong>Magic Mouse</strong> v1 / v2</div>
+        </div>
+        <div class="sba">
+          <h3 class="sba-title">Same sandwich · v3</h3>
+          <div class="layer"><strong>Application</strong></div>
+          <div class="layer"><strong>Windows HID stack</strong></div>
+          <div class="filter-wrap">
+            <div class="filter">
+              <strong>KMDF filter</strong>
+              <em>← same slot · two rooms stay apart</em>
+            </div>
+          </div>
+          <div class="layer"><strong>Bluetooth HID</strong></div>
+          <div class="layer"><strong>Bluetooth stack</strong></div>
+          <div class="layer"><strong>Magic Mouse 2024</strong> 0323</div>
+        </div>
+      </div>
+      <aside class="credit-box">
+        <h3>Star the person who drew this</h3>
+        <p><a href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows">sbagirici/apple-magic-mouse-scroll-fix-windows</a> — Architecture section. Please <strong>star their repo</strong>. Use their installer for v1/v2; use KMDF for 2024 / v3.</p>
+        <p class="cta"><a class="primary" href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows">Star sbagirici’s scroll fix</a></p>
+      </aside>
       <table>
         <thead><tr><th>Choice</th><th>Scroll</th><th>Battery</th><th>Test Mode</th></tr></thead>
         <tbody>
@@ -325,6 +360,8 @@
     <div class="bar">
       <p>Copyright 2026 Lesley Murfin · <a href="https://github.com/LesleyMurfin/magic-tray/blob/main/LICENSE">MIT</a> · not Magic Utilities</p>
       <p>
+        <a href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows">Star sbagirici</a>
+        ·
         <a href="https://github.com/LesleyMurfin/magic-tray">Star Magic Tray</a>
         ·
         <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">Star the v3 driver</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -174,6 +174,8 @@
     <div class="bar">
       <p>Copyright 2026 Lesley Murfin · <a href="https://github.com/LesleyMurfin/magic-tray/blob/main/LICENSE">MIT</a> · not Magic Utilities</p>
       <p>
+        <a href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows">Star sbagirici</a>
+        ·
         <a href="https://github.com/LesleyMurfin/magic-tray">Star Magic Tray</a>
         ·
         <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">Star the v3 driver</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -12,9 +12,9 @@
 
 - [Landing page](https://lesleymurfin.github.io/magic-tray/): Short answer + download + star both repos
 - [Which driver](https://lesleymurfin.github.io/magic-tray/drivers.html): PID → KMDF / Boot Camp / SDP / none. [#identify](https://lesleymurfin.github.io/magic-tray/drivers.html#identify) — Hardware Ids first, then AA door / Lightning / USB-C.
-- [Why v3 is hard](https://lesleymurfin.github.io/magic-tray/v3.html): 0323 vs v2, Mode A/B, research links
+- [Why v3 is hard](https://lesleymurfin.github.io/magic-tray/v3.html): 0323 vs v2, two-rooms, sbagirici LowerFilter stack. Star https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows
 - [Devices](https://lesleymurfin.github.io/magic-tray/devices.html): Why not one driver; why not MU
-- [Stars and signing](https://lesleymurfin.github.io/magic-tray/funding.html): Star both repos; EV + attestation goal; no scroll-killing subscription
+- [Stars and signing](https://lesleymurfin.github.io/magic-tray/funding.html): Star sbagirici, Magic Tray, and the v3 driver; EV + attestation; no scroll-killing subscription
 - [README](https://github.com/LesleyMurfin/magic-tray/blob/main/README.md): Install, driver matrix, Test Mode
 - [Battery alerts](https://lesleymurfin.github.io/magic-tray/ALERTS.md): Percent floor 10→5→1
 - [Hardware reports](https://lesleymurfin.github.io/magic-tray/TESTED.md): Who tested which PID

--- a/docs/site.css
+++ b/docs/site.css
@@ -817,3 +817,73 @@ ol.steps li { margin: 0.4rem 0; }
 }
 .path-steps .sep { border: 0; background: none; color: var(--faint); padding: 0; }
 
+
+.sba-pair {
+  display: grid;
+  gap: 1rem;
+}
+@media (min-width: 800px) {
+  .sba-pair { grid-template-columns: 1fr 1fr; }
+}
+.sba {
+  border: 1px solid var(--line-strong);
+  border-radius: 0.5rem;
+  overflow: hidden;
+  background: var(--bg-2);
+}
+.sba .sba-title {
+  margin: 0;
+  padding: 0.65rem 0.9rem;
+  font-size: 0.82rem;
+  font-family: var(--sans);
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--faint);
+  border-bottom: 1px solid var(--line);
+}
+.sba .layer {
+  padding: 0.62rem 0.9rem;
+  text-align: center;
+  border-bottom: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+.sba .layer:last-child { border-bottom: 0; }
+.sba .layer strong { display: block; color: var(--fg); font-weight: 650; }
+.sba .filter-wrap {
+  padding: 0.5rem 0.65rem;
+  background: var(--bg);
+  border-bottom: 1px solid var(--line);
+}
+.sba .filter {
+  border: 2px solid var(--accent);
+  border-radius: 0.4rem;
+  padding: 0.7rem 0.85rem;
+  background: color-mix(in srgb, var(--accent) 14%, var(--bg-2));
+  display: grid;
+  gap: 0.15rem;
+  text-align: center;
+}
+.sba .filter strong { color: var(--fg); font-size: 0.95rem; }
+.sba .filter em {
+  font-style: normal;
+  color: var(--accent-2);
+  font-size: 0.78rem;
+  font-weight: 650;
+}
+.credit-box {
+  margin: 1.4rem 0 1.8rem;
+  padding: 1rem 1.15rem 1.15rem;
+  border: 1px solid var(--line-strong);
+  border-radius: var(--radius);
+  background: var(--bg-2);
+}
+.credit-box h3 {
+  margin: 0 0 0.45rem;
+  font-size: 1.05rem;
+  font-family: var(--sans);
+}
+.credit-box p { color: var(--muted); margin: 0.4rem 0; }
+.credit-box .cta { margin: 0.85rem 0 0.35rem; }
+

--- a/docs/v3.html
+++ b/docs/v3.html
@@ -93,17 +93,46 @@
       <p class="caption" style="color:var(--faint);font-size:0.82rem;margin-top:-0.6rem;">Same idea as the Mode A / Mode B diagram in the kernel repo — without HID class names.</p>
 
       <h2 id="stack">Where the fix sits</h2>
-      <p>Windows does not turn a finger swipe into a wheel by itself on this mouse. A small driver sits <em>under</em> Windows and <em>above</em> Bluetooth and does that translation. On v1/v2 that driver is Apple’s Boot Camp filter. On v3 we use KMDF from <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">magic-mouse-v3-windows-fix</a>.</p>
-      <div class="diagram" style="max-width:28rem">
-        <ol class="stack">
-          <li>You — Chrome, Explorer, anything that scrolls</li>
-          <li>Windows</li>
-          <li class="hl"><strong>Filter driver</strong> — finger swipe becomes a wheel. Stops Windows from merging the two rooms.</li>
-          <li>Bluetooth</li>
-          <li>Magic Mouse</li>
-        </ol>
-        <p class="caption">Layout from <a href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows">sbagirici’s v1/v2 scroll fix</a> — the diagram that made the LowerFilter click. v3 is the same sandwich; the filling is KMDF, not Apple’s INF.</p>
+      <p>Windows does not turn a finger swipe into a wheel by itself on this mouse. A small driver sits <em>under</em> Windows and <em>above</em> Bluetooth. That picture is not ours.</p>
+      <div class="diagram sba-pair" role="img" aria-label="sbagirici LowerFilter stack for v1 v2, same stack with KMDF for v3">
+        <div class="sba">
+          <h3 class="sba-title">sbagirici · v1 / v2</h3>
+          <div class="layer"><strong>Application</strong> browser, Explorer</div>
+          <div class="layer"><strong>Windows HID stack</strong></div>
+          <div class="filter-wrap">
+            <div class="filter">
+              <strong>applewirelessmouse.sys</strong>
+              <em>← LowerFilter · multi-touch → scroll</em>
+            </div>
+          </div>
+          <div class="layer"><strong>Bluetooth HID driver</strong> hidbth.sys</div>
+          <div class="layer"><strong>Bluetooth stack</strong></div>
+          <div class="layer"><strong>Magic Mouse</strong> v1 / v2 hardware</div>
+        </div>
+        <div class="sba">
+          <h3 class="sba-title">Same sandwich · v3 / 2024</h3>
+          <div class="layer"><strong>Application</strong> browser, Explorer</div>
+          <div class="layer"><strong>Windows HID stack</strong></div>
+          <div class="filter-wrap">
+            <div class="filter">
+              <strong>KMDF filter</strong>
+              <em>← same slot · keeps the two rooms apart</em>
+            </div>
+          </div>
+          <div class="layer"><strong>Bluetooth HID driver</strong> hidbth.sys</div>
+          <div class="layer"><strong>Bluetooth stack</strong></div>
+          <div class="layer"><strong>Magic Mouse 2024</strong> PID 0323</div>
+        </div>
       </div>
+      <aside class="credit-box" id="sbagirici">
+        <h3>This diagram is sbagirici’s</h3>
+        <p><a href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows">sbagirici/apple-magic-mouse-scroll-fix-windows</a> is the README that made the LowerFilter click: app → Windows → <strong>filter</strong> → Bluetooth → mouse. We redrew it here so v3 is obvious. If that picture helped you, <strong>star their repo</strong> — they did the v1/v2 work we stood on.</p>
+        <p class="cta">
+          <a class="primary" href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows">Star sbagirici’s scroll fix</a>
+          <a class="ghost" href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows#architecture">Their Architecture section</a>
+        </p>
+        <p>Their installer uses Apple’s signed <code>applewirelessmouse.sys</code> for v1/v2. Do not put that on Magic Mouse 2024 (<code>0323</code>). That PID still needs KMDF from <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">magic-mouse-v3-windows-fix</a>.</p>
+      </aside>
       <div class="grid grid-2">
         <div class="card">
           <p class="meta">COL01</p>
@@ -145,6 +174,7 @@
       <div class="rail-card">
         <h2>Star if this helped</h2>
         <nav class="jump">
+          <a href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows">Star sbagirici’s scroll fix</a>
           <a href="https://github.com/LesleyMurfin/magic-tray">Star Magic Tray</a>
           <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">Star the v3 driver</a>
           <a href="funding.html">EV + attestation goal</a>
@@ -157,6 +187,8 @@
     <div class="bar">
       <p>Copyright 2026 Lesley Murfin · <a href="https://github.com/LesleyMurfin/magic-tray/blob/main/LICENSE">MIT</a> · not Magic Utilities</p>
       <p>
+        <a href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows">Star sbagirici</a>
+        ·
         <a href="https://github.com/LesleyMurfin/magic-tray">Star Magic Tray</a>
         ·
         <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">Star the v3 driver</a>


### PR DESCRIPTION
Redraws sbagirici’s Architecture sandwich next to the v3 KMDF filling. Credit and Star sbagirici CTA on v3.html, drivers.html, README, footers.