### PR TITLE
chore(release): 1.1.1

### DIFF
--- a/MagicMouseTray/MagicMouseTray.csproj
+++ b/MagicMouseTray/MagicMouseTray.csproj
@@ -16,9 +16,9 @@
     <!-- Allows building on non-Windows (e.g. restoring packages) -->
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ApplicationIcon>magic-mouse.ico</ApplicationIcon>
-    <Version>1.1.0</Version>
-    <AssemblyVersion>1.1.0.0</AssemblyVersion>
-    <FileVersion>1.1.0.0</FileVersion>
+    <Version>1.1.1</Version>
+    <AssemblyVersion>1.1.1.0</AssemblyVersion>
+    <FileVersion>1.1.1.0</FileVersion>
     <Product>Magic Tray</Product>
     <Title>Magic Tray</Title>
     <AssemblyTitle>Magic Tray</AssemblyTitle>


### PR DESCRIPTION
Version bump only. `scripts/verify-release.ps1` gates the `v*` tag against the csproj `<Version>`, so this must land before `v1.1.1` is tagged.

## What 1.1.1 contains (all fixes, no new features)

| PR | Fix | Issue |
|---|---|---|
| #103 | **Enabled on this PC actually disables the device.** In 1.1.0 the checkbox was a silent no-op. | #87, #84 |
| #90 | Alerts help link pointed at `blob/ship/magic-tray-ready/...`, a branch URL that rots. Now `blob/main`. | #83 |
| #100 | `main` did not build (`MSB3030`: csproj `Content Include`d three deleted scripts). Scripts restored and shipped with the exe; CI now fails fast on a dangling `Content` path. | #85 |

Docs-only changes also landed (#92, #93) and do not affect the exe.

## Why 1.1.1 and not 1.2.0
All three are bug fixes. #102 (pre-filled GitHub bug/feature drafts) is a **new feature** and is deliberately held back — merging it would make the next release 1.2.0 under semver.

## Detail on the headline fix
1.1.0 shipped a dead switch. Two defects:
- Instance IDs such as `HID\VID_05AC&PID_030D&COL01\...` were interpolated into PowerShell unquoted, so `&` parsed as the call operator, `pnputil` never ran, and the script still exited 0.
- Unchecking only skipped battery polling; it never disabled the device.

Now: IDs are quoted (`"/$verb" "$id"`), VID needles come from the `KnownMice`/`KnownKeyboards` catalog rather than a hardcoded Apple VID, the script walks every `HKLM\SYSTEM\CurrentControlSet\Enum\*` bus, it fails closed (`exit 1`) on no match or any `pnputil` failure, and the exit code is logged on success as well as failure.

## Release blocker before tagging
The live hardware pass for #87 has **not** been run: uncheck -> pointer dies on the PC -> Mac takes the link -> re-check restores. It cannot be run from this Linux host (no `net8.0-windows`, no `pnputil`). Verification so far is 282/282 CI tests, a generated-script parse check, and a run against a mocked registry hive with a mocked `pnputil`.

Since the entire point of this release is that this feature works, **do the live pass on the PC before tagging `v1.1.1`.**

## Known limitation, tracked not fixed
Rows are per-PID, so two of the same model share one switch (#113). The script now logs `DEVICE_ENABLE containers=<guids>` so support can see which physical devices a row touched.