### PR TITLE
docs: black-purple, plain English, real keyboards

### DIFF
--- a/docs/devices.html
+++ b/docs/devices.html
@@ -34,14 +34,18 @@
     <article id="content" class="primary">
       <header class="page-intro">
         <p class="kicker"><a href="./">Magic Tray</a> · catalog</p>
-        <h1>Every Magic device is a different Windows problem</h1>
-        <p class="lead">Apple’s Windows story stopped at Boot Camp. Later PIDs are different HID layouts, power sources, and missing INF lines. We built a tray that tells the truth per PID — not one kernel driver for the whole line, and not a paid clone of Magic Utilities.</p>
+        <h1>Each Apple device needs its own answer</h1>
+        <ul class="facts">
+          <li>A mouse, a keyboard, and a trackpad are not the same thing to Windows.</li>
+          <li>Even two Magic Mice can be different if one is old and one is 2024.</li>
+          <li>We do not pretend one driver fixes everything. We do not copy Magic Utilities.</li>
+        </ul>
       </header>
 
       <h2>Side by side</h2>
       <table>
         <thead>
-          <tr><th>Device</th><th>PID</th><th>Power</th><th>Scroll on Windows</th><th>Battery in Magic Tray</th></tr>
+          <tr><th>Device</th><th>Windows name</th><th>Power</th><th>Scroll</th><th>Battery in the tray</th></tr>
         </thead>
         <tbody>
           <tr><td>Magic Mouse v1</td><td><code>030D</code></td><td>AA</td><td>Boot Camp INF</td><td>HID 0x90 / Feature if exposed</td></tr>
@@ -52,7 +56,11 @@
           <tr><td>Trackpad 1 / 2 / 2024</td><td><code>030E</code> / <code>0265</code> / <code>0324</code></td><td>AA / Lightning / USB-C</td><td>We do not ship a trackpad driver</td><td>HID when Windows exposes it</td></tr>
         </tbody>
       </table>
-      <p>Not sure which one you are holding? <a href="drivers.html#identify">Tell versions apart</a>. Catalog in code: <a href="https://github.com/LesleyMurfin/magic-tray/blob/main/MagicMouseTray/MouseBatteryDevice.cs">KnownMice</a>, <a href="https://github.com/LesleyMurfin/magic-tray/blob/main/MagicMouseTray/KeyboardBatteryDevice.cs">KnownKeyboards</a>. Reports: <a href="TESTED.md">TESTED.md</a>.</p>
+      <ul class="facts">
+        <li>Not sure which one you have? <a href="drivers.html#identify">Look at the bottom</a>.</li>
+        <li>The list we actually ship is in code: <a href="https://github.com/LesleyMurfin/magic-tray/blob/main/MagicMouseTray/MouseBatteryDevice.cs">mice</a>, <a href="https://github.com/LesleyMurfin/magic-tray/blob/main/MagicMouseTray/KeyboardBatteryDevice.cs">keyboards</a>.</li>
+        <li>Who tested what: <a href="TESTED.md">TESTED.md</a>.</li>
+      </ul>
 
       <h2>Mice</h2>
       <div class="ident-grid cols-4">
@@ -106,26 +114,14 @@
         </div>
       </div>
 
-      <h2>Why we went this way</h2>
-      <div class="grid grid-2">
-        <div class="card">
-          <h3>v1/v2 already have a signed package</h3>
-          <p>Replacing Boot Camp with self-signed KMDF would force Test Mode on people who do not need it.</p>
-        </div>
-        <div class="card">
-          <h3>v3 is a new PID and a different collection layout</h3>
-          <p>Forcing applewirelessmouse onto <code>0323</code> is the patched-Apple path: scroll vs battery, still unsigned. KMDF is the rewrite we could own. <a href="v3.html">Why v3 is hard</a>.</p>
-        </div>
-        <div class="card">
-          <h3>Keyboards are not missing a mouse filter</h3>
-          <p>The descriptor is Input-only; Windows cannot poll battery until an SDP registry patch. That is not a <code>.sys</code>.</p>
-        </div>
-        <div class="card">
-          <h3>Trackpad gestures are a product</h3>
-          <p>MU sells that. We ship battery rows only so we do not pretend we cloned it.</p>
-        </div>
-      </div>
-      <p>In vs out vs MU: <a href="DESIGN-mu-free-parity.md">DESIGN-mu-free-parity.md</a>. If you need WHQL + Secure Boot on a 2024 mouse today, MU is still the commercial signed-driver answer. If you need battery + mouse scroll without a subscription, this is what we could ship honestly — and <a href="funding.html">stars plus an EV cert</a> are how the v3 filter becomes a normal Windows driver.</p>
+      <h2>Why it is split this way</h2>
+      <ul class="facts">
+        <li>Old mice already have a signed Apple driver. Replacing it would make people turn on Test Mode for no reason.</li>
+        <li>The 2024 mouse is a new Windows name. The old Apple file does not list it.</li>
+        <li>Keyboards already type. We only flip a setting so battery % shows up.</li>
+        <li>Trackpad gestures are a whole product. We only show battery.</li>
+        <li>If you need a paid, Microsoft-signed 2024 mouse driver today, Magic Utilities still sells that. We will not kill scroll if you stop paying, because we do not charge for scroll.</li>
+      </ul>
     </article>
 
     <aside class="rail">

--- a/docs/drivers.html
+++ b/docs/drivers.html
@@ -34,40 +34,47 @@
     <article id="content" class="primary">
       <header class="page-intro">
         <p class="kicker"><a href="./">Magic Tray</a> · drivers</p>
-        <h1>Which Windows driver do I need?</h1>
-        <p class="lead">There is no single Apple mouse INF that is correct for every Magic device. Identify the PID you have. Magic Tray will not silently rebind.</p>
+        <h1>Which extra software do you need?</h1>
+        <ul class="facts">
+          <li>Windows does not treat every Apple mouse the same.</li>
+          <li>First find out which device you have.</li>
+          <li>Then install only that one. The tray will not guess.</li>
+        </ul>
       </header>
 
       <ul class="pick">
-        <li><a href="#identify">How to tell which Magic device you have<small>Hardware Ids first, then AA door / Lightning / USB-C</small></a></li>
-        <li><a href="#v3">Magic Mouse 2024 / v3 (USB-C)<small>PID 0323 · KMDF · Test Mode until we get attestation</small></a></li>
+        <li><a href="#identify">How to tell which device you have<small>Hardware Ids first, then the port on the bottom</small></a></li>
+        <li><a href="#v3">Magic Mouse 2024 / v3 (USB-C)<small>PID 0323 · KMDF · Test Mode until Microsoft signs it</small></a></li>
         <li><a href="#v1v2">Magic Mouse v1, v2, or Apple Wireless Mouse<small>PID 030D / 0269 / 0310 · Boot Camp · no Test Mode</small></a></li>
-        <li><a href="#keyboard">Magic Keyboard / Apple Wireless Keyboard<small>No .sys · SDP patch · -Mac required</small></a></li>
+        <li><a href="#keyboard">Magic Keyboard<small>No .sys · SDP patch · needs -Mac</small></a></li>
         <li><a href="#trackpad">Magic Trackpad<small>No driver from us · battery only</small></a></li>
       </ul>
 
       <section id="identify">
         <h2>How to tell which Magic device you have</h2>
-        <p>The physical port is a hint. <strong>Hardware Ids are the authority.</strong> Two mice can look similar; <code>PID_0323</code> and <code>PID_0269</code> are not the same Windows device.</p>
+        <ul class="facts">
+          <li>Two mice can look the same. The charger on the bottom is only a hint.</li>
+          <li>Windows has the real name. It looks like <code>PID_0323</code>.</li>
+        </ul>
 
         <div class="how">
-          <h3>1. Read Hardware Ids in Device Manager</h3>
+          <h3>1. Ask Windows the real name</h3>
           <ol>
-            <li>Open <strong>Device Manager</strong>.</li>
-            <li>Find the HID or Bluetooth Apple device (Mice and other pointing devices, Keyboards, or Bluetooth).</li>
-            <li>Properties → <strong>Details</strong> → Hardware Ids.</li>
-            <li>Look for <code>PID_0323</code> or <code>PID&amp;0323</code> (same pattern for <code>030D</code>, <code>0269</code>, <code>0310</code>, and the rest). USB HID is <code>VID_05AC&amp;PID_xxxx</code>. Bluetooth rows use <code>PID&amp;xxxx</code>.</li>
+            <li>Right-click the Start button. Click <strong>Device Manager</strong>.</li>
+            <li>Open <strong>Mice and other pointing devices</strong> (or Keyboards).</li>
+            <li>Double-click the Apple device.</li>
+            <li>Open the <strong>Details</strong> tab. Pick <strong>Hardware Ids</strong> in the list.</li>
+            <li>Find the four characters after <code>PID_</code> or <code>PID&amp;</code>. That is the name.</li>
           </ol>
-          <p class="note">If the PID is not in <a href="https://github.com/LesleyMurfin/magic-tray/blob/main/MagicMouseTray/MouseBatteryDevice.cs">KnownMice</a> or <a href="https://github.com/LesleyMurfin/magic-tray/blob/main/MagicMouseTray/KeyboardBatteryDevice.cs">KnownKeyboards</a>, do not guess a driver. <a href="https://github.com/LesleyMurfin/magic-tray/issues/new?template=missing-device.md">File a missing-device issue</a>.</p>
+          <p class="note">If that name is not on this page, do not guess. <a href="https://github.com/LesleyMurfin/magic-tray/issues/new?template=missing-device.md">Tell us the name</a>.</p>
         </div>
 
         <div class="how">
-          <h3>2. Then look at the bottom of the device</h3>
-          <p>Flip it. The charging port — or the AA door if there is no port — matches the generation:</p>
+          <h3>2. Then look with your eyes</h3>
           <ul class="plain">
-            <li><strong>AA door, no port</strong> — Mouse v1 (<code>030D</code>), Apple Wireless Mouse (<code>0310</code>), Trackpad 1 (<code>030E</code>), 2011 keyboard.</li>
-            <li><strong>Lightning on the bottom</strong> — Mouse v2 (<code>0269</code>), Trackpad 2 (<code>0265</code>), Lightning keyboards.</li>
-            <li><strong>USB-C oval</strong> — Mouse 2024 (<code>0323</code>), Trackpad 2024 (<code>0324</code>), 2024 keyboards.</li>
+            <li><strong>Door for AA batteries</strong> — old mouse, old trackpad, or old keyboard.</li>
+            <li><strong>Lightning hole</strong> (skinny, like an old iPhone charger) — Magic Mouse 2, Trackpad 2, Lightning keyboard.</li>
+            <li><strong>USB-C hole</strong> (small oval, like a new phone) — 2024 mouse, trackpad, or keyboard.</li>
           </ul>
         </div>
 
@@ -178,55 +185,101 @@
         </div>
 
         <h3>Keyboards</h3>
+        <ul class="facts">
+          <li>A Magic Keyboard is long and flat, with keys. It does not look like a mouse.</li>
+          <li>Look at the <strong>back edge</strong> (the side facing away from you) or flip it over.</li>
+          <li>If yours has extra number keys on the right, or a Touch ID button, it is still the same kind of keyboard.</li>
+        </ul>
         <div class="ident-grid cols-3">
           <article class="ident-card">
-            <div class="ident-visual">
-              <div class="bottom-view keyboard aa" aria-hidden="true">
-                <span class="tag">Bottom</span>
-                <span class="aa-door"><span class="aa-cell"></span><span class="aa-cell"></span></span>
+            <div class="ident-visual kb-visual">
+              <div class="kb" aria-hidden="true">
+                <div class="kb-face">
+                  <div class="kb-r"></div>
+                  <div class="kb-r"></div>
+                  <div class="kb-r"></div>
+                  <div class="kb-r"></div>
+                  <div class="kb-r space"><i></i></div>
+                </div>
+                <div class="kb-find">
+                  <span class="aa-door"><span class="aa-cell"></span><span class="aa-cell"></span></span>
+                  <p><strong>Flip it over</strong> Door for two AA batteries. No charging hole.</p>
+                </div>
               </div>
             </div>
             <div class="ident-body">
-              <p class="pid-line">0239 / 023A / 023B · 2011 · AA</p>
-              <h3>Apple Wireless Keyboard A1314</h3>
-              <p>AA door. Also <code>0255</code> / <code>0256</code> / <code>0257</code> (ANSI/ISO/JIS).</p>
-              <a href="#keyboard">SDP path</a>
+              <p class="pid-line">Old · AA batteries</p>
+              <h3>Apple Wireless Keyboard</h3>
+              <ul class="facts">
+                <li>White or silver. Takes AA batteries.</li>
+                <li>Windows name includes <code>0239</code> (or <code>023A</code>, <code>023B</code>, <code>0255</code>…).</li>
+              </ul>
+              <a href="#keyboard">How we read battery</a>
             </div>
           </article>
           <article class="ident-card">
-            <div class="ident-visual">
-              <div class="bottom-view keyboard lightning" aria-hidden="true">
-                <span class="tag">Bottom</span>
-                <span class="port lightning"></span>
+            <div class="ident-visual kb-visual">
+              <div class="kb" aria-hidden="true">
+                <div class="kb-face">
+                  <div class="kb-r"></div>
+                  <div class="kb-r"></div>
+                  <div class="kb-r"></div>
+                  <div class="kb-r"></div>
+                  <div class="kb-r space"><i></i></div>
+                </div>
+                <div class="kb-find">
+                  <span class="port lightning"></span>
+                  <p><strong>Back edge</strong> Skinny Lightning hole — same shape as an old iPhone charger.</p>
+                </div>
               </div>
             </div>
             <div class="ident-body">
-              <p class="pid-line">024F · Lightning</p>
-              <h3>Magic Keyboard A1644</h3>
-              <p>Lightning. Related PIDs <code>0250</code>, <code>0267</code>, <code>026C</code>, <code>029C</code>, <code>029A</code>, <code>029F</code>.</p>
-              <a href="#keyboard">SDP path</a>
+              <p class="pid-line">Lightning charger</p>
+              <h3>Magic Keyboard (Lightning)</h3>
+              <ul class="facts">
+                <li>Rechargeable. Lightning on the back edge, not USB-C.</li>
+                <li>Windows name often includes <code>024F</code>.</li>
+              </ul>
+              <a href="#keyboard">How we read battery</a>
             </div>
           </article>
           <article class="ident-card">
-            <div class="ident-visual">
-              <div class="bottom-view keyboard usbc" aria-hidden="true">
-                <span class="tag">Bottom</span>
-                <span class="port usbc"></span>
+            <div class="ident-visual kb-visual">
+              <div class="kb" aria-hidden="true">
+                <div class="kb-face">
+                  <div class="kb-r"></div>
+                  <div class="kb-r"></div>
+                  <div class="kb-r"></div>
+                  <div class="kb-r"></div>
+                  <div class="kb-r space"><i></i></div>
+                </div>
+                <div class="kb-find">
+                  <span class="port usbc"></span>
+                  <p><strong>Back edge</strong> Small oval USB-C hole — like most new phones.</p>
+                </div>
               </div>
             </div>
             <div class="ident-body">
-              <p class="pid-line">0320 / 0321 / 0322 · 2024 · USB-C</p>
-              <h3>Magic Keyboard 2024</h3>
-              <p>USB-C. <code>0321</code> Touch ID, <code>0322</code> numeric keypad — extra PIDs, same SDP path.</p>
-              <a href="#keyboard">SDP path</a>
+              <p class="pid-line">2024 · USB-C</p>
+              <h3>Magic Keyboard (USB-C)</h3>
+              <ul class="facts">
+                <li>Newest. USB-C on the back edge.</li>
+                <li>Windows name includes <code>0320</code>, <code>0321</code> (Touch ID), or <code>0322</code> (number pad).</li>
+              </ul>
+              <a href="#keyboard">How we read battery</a>
             </div>
           </article>
         </div>
-        <p class="note">Touch ID (<code>0267</code>, <code>026C</code>, <code>029A</code>, <code>0321</code>) and numeric keypad (<code>029F</code>, <code>0322</code>) are extra PIDs, not extra drivers. Same keyboard SDP patch.</p>
       </section>
 
-      <h2 id="v3">Magic Mouse 2024 / v3 — 0323</h2>
-      <p><strong>KMDF</strong> from <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">magic-mouse-v3-windows-fix</a> — only path we recommend for scroll <em>and</em> battery. Why the 2024 mouse is not v2: <a href="v3.html">diagrams</a>. Why Test Mode: <a href="funding.html">signing</a>.</p>
+      <h2 id="v3">Magic Mouse 2024 (USB-C)</h2>
+      <ul class="facts">
+        <li>This is the new mouse with USB-C on the bottom.</li>
+        <li>Windows name: <code>0323</code>.</li>
+        <li>Apple never gave Windows a driver for it. Finger-scroll often dies.</li>
+        <li>We install an extra piece called KMDF from <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">this driver project</a>.</li>
+        <li>Pictures: <a href="v3.html">why the 2024 mouse is different</a>.</li>
+      </ul>
       <div class="diagram pair">
         <div class="panel ok">
           <h3>Working</h3>
@@ -244,7 +297,10 @@
           </div>
         </div>
       </div>
-      <p>KMDF is the filter that keeps the two rooms apart. The sandwich picture is <a href="v3.html#stack">sbagirici’s</a>.</p>
+      <ul class="facts">
+        <li>The extra piece sits in the middle of that sandwich so scroll and battery can both work.</li>
+        <li>The sandwich picture is from <a href="v3.html#stack">sbagirici</a>, who explained this for older mice.</li>
+      </ul>
       <div class="diagram sba-pair">
         <div class="sba">
           <h3 class="sba-title">sbagirici · v1 / v2</h3>
@@ -276,8 +332,12 @@
         </div>
       </div>
       <aside class="credit-box">
-        <h3>Star the person who drew this</h3>
-        <p><a href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows">sbagirici/apple-magic-mouse-scroll-fix-windows</a> — Architecture section. Please <strong>star their repo</strong>. Use their installer for v1/v2; use KMDF for 2024 / v3.</p>
+        <h3>Who drew the sandwich?</h3>
+        <ul class="facts">
+          <li><a href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows">sbagirici</a> drew it for Magic Mouse v1 and v2.</li>
+          <li>Please star their project if the picture helped.</li>
+          <li>Do not use their installer on the 2024 USB-C mouse.</li>
+        </ul>
         <p class="cta"><a class="primary" href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows">Star sbagirici’s scroll fix</a></p>
       </aside>
       <table>
@@ -294,10 +354,15 @@
         <li>Still no scroll → unpair / re-pair.</li>
       </ol>
 
-      <h2 id="v1v2">v1 / v2 / Apple Wireless Mouse</h2>
-      <p><a href="https://github.com/tealtadpole/MagicMouse2DriversWin11x64">tealtadpole Boot Camp INF</a>. Catalog-signed. Do not install v3 KMDF on these PIDs.</p>
+      <h2 id="v1v2">Older Magic Mouse (v1 or v2)</h2>
+      <ul class="facts">
+        <li>v1 has a battery door. v2 has Lightning on the bottom.</li>
+        <li>Apple already wrote a Windows driver for these. It is in Boot Camp.</li>
+        <li>We use the copy from <a href="https://github.com/tealtadpole/MagicMouse2DriversWin11x64">tealtadpole</a>.</li>
+        <li>No Test Mode. Do not put the 2024 driver on these mice.</li>
+      </ul>
       <table>
-        <thead><tr><th>Device</th><th>PID</th><th>Power</th><th>Path</th></tr></thead>
+        <thead><tr><th>What you have</th><th>Windows name</th><th>Look for</th><th>Install</th></tr></thead>
         <tbody>
           <tr><td>Magic Mouse v1</td><td><code>030D</code></td><td>AA door</td><td>Boot Camp</td></tr>
           <tr><td>Magic Mouse v2</td><td><code>0269</code></td><td>Lightning</td><td>Boot Camp</td></tr>
@@ -305,8 +370,13 @@
         </tbody>
       </table>
 
-      <h2 id="keyboard">Keyboards</h2>
-      <p>SDP registry patch, not a kernel driver. <code>Install-KeyboardBattery.cmd -Mac …</code> from the <a href="https://github.com/LesleyMurfin/magic-tray/releases/latest">Release</a>. Re-pairing wipes it.</p>
+      <h2 id="keyboard">Keyboards — battery only</h2>
+      <ul class="facts">
+        <li>Your keyboard already types. We do not install a keyboard driver.</li>
+        <li>Windows just will not tell us the battery % until we flip a small setting.</li>
+        <li>That setting lives in a script in the <a href="https://github.com/LesleyMurfin/magic-tray/releases/latest">Release</a>: <code>Install-KeyboardBattery.cmd</code>.</li>
+        <li>If you unpair the keyboard, run the script again.</li>
+      </ul>
       <table>
         <thead><tr><th>Generation</th><th>PIDs</th><th>Power</th></tr></thead>
         <tbody>
@@ -316,8 +386,12 @@
         </tbody>
       </table>
 
-      <h2 id="trackpad">Trackpads</h2>
-      <p>Battery and alerts only. No tap / 3-finger / KMDF. PIDs: <code>030E</code> (AA), <code>0265</code> (Lightning), <code>0324</code> (USB-C).</p>
+      <h2 id="trackpad">Trackpads — battery only</h2>
+      <ul class="facts">
+        <li>We show battery % in the tray.</li>
+        <li>We do not add tap, 3-finger swipe, or a trackpad driver. That is a different product.</li>
+        <li>AA door, Lightning, or USB-C on the bottom tells you which generation it is.</li>
+      </ul>
     </article>
 
     <aside class="rail">

--- a/docs/funding.html
+++ b/docs/funding.html
@@ -34,12 +34,20 @@
     <article id="content" class="primary">
       <header class="page-intro">
         <p class="kicker"><a href="./">Magic Tray</a> · signing</p>
-        <h1>If this saved you a subscription, star both repos</h1>
-        <p class="lead">Stars are the free signal that these projects are used. The paid gap is a public code-signing cert so the <strong>Magic Mouse v3 (2024)</strong> KMDF driver can load with Secure Boot on — not a Magic Utilities-style trial that kills scroll.</p>
+        <h1>If this helped, star the projects</h1>
+        <ul class="facts">
+          <li>A star on GitHub is free and tells other people the project is used.</li>
+          <li>The 2024 mouse driver is not signed by Microsoft yet, so Windows makes you turn on Test Mode.</li>
+          <li>Money would buy a real signing certificate so Test Mode can go away — for everyone, not as a monthly fee.</li>
+        </ul>
       </header>
 
-      <h2 id="goal">The goal</h2>
-      <p><strong>EV code-signing certificate + Microsoft Hardware Dev Center attestation</strong> for <code>MagicMouseDriver</code> in <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">magic-mouse-v3-windows-fix</a>. Then Magic Tray’s KMDF install no longer needs Test Mode. The tray stays MIT. The signed <code>.sys</code> is published for everyone — no license check in the filter.</p>
+      <h2 id="goal">What we want</h2>
+      <ul class="facts">
+        <li>A proper code-signing certificate, then Microsoft to sign the 2024 mouse driver.</li>
+        <li>After that, the extra scroll piece loads on a normal Windows 11 PC.</li>
+        <li>The tray stays free. The driver stays free. Scroll does not turn off if money stops.</li>
+      </ul>
       <div class="grid grid-2">
         <div class="card">
           <h3>GitHub Sponsors</h3>
@@ -82,12 +90,12 @@
         </tbody>
       </table>
 
-      <h2 id="msft">Why Microsoft does not ship an OSS Apple mouse driver</h2>
-      <ul class="plain">
-        <li>There is no in-box <code>hid-magicmouse</code> on Windows. Boot Camp was Apple’s dump; 0323 never landed.</li>
-        <li>Linux can merge hid-magicmouse in-tree. Windows kernel mode needs a paid EV token and Partner Center. Community <code>.sys</code> files stay Test Mode toys.</li>
-        <li>HVCI / Secure Boot are default on new Windows 11 PCs. The 2010s “ignore the INF warning” path is gone.</li>
-        <li>Microsoft will not WHQL a device Apple does not submit. OSS cannot sign as Apple. Attestation is the developer path they did add — still EV + a legal entity.</li>
+      <h2 id="msft">Why Windows does not just include this</h2>
+      <ul class="facts">
+        <li>Windows has no built-in Magic Mouse driver like Linux does.</li>
+        <li>Apple’s old Boot Camp file never listed the 2024 mouse.</li>
+        <li>A community driver cannot pretend to be Apple. Microsoft will not logo it for free.</li>
+        <li>New PCs turn on extra security by default, so unsigned drivers are blocked.</li>
       </ul>
       <p>Research: <a href="v3.html">Why v3 is hard</a>. Practical install: <a href="drivers.html">Which driver</a>.</p>
     </article>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Magic Tray — Magic Mouse battery and scroll on Windows</title>
-  <meta name="description" content="Free MIT Windows tray for Apple Magic Mouse v1/v2/v3 (2024), Keyboard, and Trackpad. Which driver, why v3 is not v2, and how to fund public KMDF signing. Star both repos if it helps.">
+  <title>Magic Tray — battery and scroll for Apple Magic devices on Windows</title>
+  <meta name="description" content="Free MIT Windows tray. Battery percent for Magic Mouse, Keyboard, and Trackpad. Scroll for Magic Mouse v1/v2/v3. No subscription.">
   <link rel="canonical" href="https://lesleymurfin.github.io/magic-tray/">
   <link rel="describedby" href="https://lesleymurfin.github.io/magic-tray/llms.txt">
   <meta name="robots" content="index,follow">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Magic Tray">
-  <meta property="og:title" content="Magic Tray — Magic Mouse battery and scroll on Windows">
-  <meta property="og:description" content="Free MIT. Research-backed v3 vs v2 paths. Star the tray and the v3 driver if they saved you a subscription.">
+  <meta property="og:title" content="Magic Tray — battery and scroll on Windows">
+  <meta property="og:description" content="Free MIT tray for Magic Mouse, Keyboard, and Trackpad. No subscription.">
   <meta property="og:url" content="https://lesleymurfin.github.io/magic-tray/">
   <meta property="og:image" content="https://lesleymurfin.github.io/magic-tray/og.png">
   <meta property="og:image:width" content="1200">
@@ -39,9 +39,14 @@
   <section class="hero-wrap">
     <div class="hero">
       <div class="hero-copy">
-        <p class="kicker">MIT · Windows 10/11 · not Magic Utilities</p>
-        <h1>Magic Mouse battery and scroll on Windows. No subscription.</h1>
-        <p class="lead">Free tray for Apple <strong>Magic Mouse</strong> (v1, v2, and <strong>Magic Mouse 2024 / v3</strong>, PID <code>0323</code>), <strong>Magic Keyboard</strong>, and <strong>Magic Trackpad</strong>. Each PID is a different Windows problem. We document that, then install only the path that PID can use.</p>
+        <p class="kicker">Free · Windows 10/11 · not Magic Utilities</p>
+        <h1>Battery next to the clock. Scroll that actually works.</h1>
+        <ul class="facts">
+          <li>Magic Tray is a tiny program by the Windows clock.</li>
+          <li>It shows how much battery is left in your Apple mouse, keyboard, or trackpad.</li>
+          <li>If your Magic Mouse will not scroll, it can add the extra Windows piece that mouse needs.</li>
+          <li>Free. No monthly fee.</li>
+        </ul>
       </div>
       <div class="hero-media">
         <img class="shot" src="screenshot-menu.png" width="576" height="503" alt="Magic Tray 1.1.0 menu: keyboard, Magic Mouse 2024 v3 KMDF, Magic Mouse v1">
@@ -56,24 +61,20 @@
 
   <div class="shell">
     <article id="content" class="primary">
-      <h2>What it actually does</h2>
-      <div class="grid grid-3">
-        <div class="card">
-          <h3><a href="drivers.html">Which driver</a></h3>
-          <p>v3 → KMDF. v1/v2 → Boot Camp. Keyboard → SDP. Trackpad → battery only. Hardware Ids are the authority.</p>
-        </div>
-        <div class="card">
-          <h3><a href="v3.html">Why v3 ≠ v2</a></h3>
-          <p><code>0323</code> is missing from Boot Camp. HID Mode A/B. Linked research in the kernel repo, not a guessed INF.</p>
-        </div>
-        <div class="card">
-          <h3><a href="funding.html">Stars &amp; signing</a></h3>
-          <p>Star both repos. Goal: EV cert + attestation so KMDF drops Test Mode. No scroll-killing trial.</p>
-        </div>
-      </div>
+      <h2>Start here</h2>
+      <ul class="facts">
+        <li><a href="drivers.html#identify">Which device is this?</a> Look at the bottom, then check Windows.</li>
+        <li><a href="drivers.html">What should I install?</a> Old mouse, new mouse, keyboard, or trackpad.</li>
+        <li><a href="v3.html">Why the 2024 mouse is annoying</a> It is not the same as Magic Mouse 2.</li>
+        <li><a href="funding.html">Stars</a> If this helped, star the GitHub pages. That is free.</li>
+      </ul>
 
-      <h2>Flip the device, then confirm the PID</h2>
-      <p>The charging port (or AA door) is a hint. Device Manager Hardware Ids win. Full walkthrough: <a href="drivers.html#identify">How to tell Magic device versions apart</a>.</p>
+      <h2>Which mouse?</h2>
+      <ul class="facts">
+        <li>Flip the mouse over.</li>
+        <li>Battery door, Lightning hole, or USB-C hole?</li>
+        <li>Then check Device Manager → Details → Hardware Ids. Windows uses a code like <code>PID_0323</code>.</li>
+      </ul>
       <div class="ident-grid cols-4">
         <article class="ident-card">
           <div class="ident-visual">
@@ -85,7 +86,7 @@
           <div class="ident-body">
             <p class="pid-line">030D · AA</p>
             <h3>Mouse v1</h3>
-            <p>Battery door, no port. Boot Camp INF.</p>
+            <p>AA door. Boot Camp INF.</p>
             <a href="drivers.html#v1v2">v1 / v2 path</a>
           </div>
         </article>
@@ -99,7 +100,7 @@
           <div class="ident-body">
             <p class="pid-line">0269 · Lightning</p>
             <h3>Mouse v2</h3>
-            <p>Lightning on the bottom. Same Boot Camp INF as v1.</p>
+            <p>Lightning port. Same INF as v1.</p>
             <a href="drivers.html#v1v2">v1 / v2 path</a>
           </div>
         </article>
@@ -113,7 +114,7 @@
           <div class="ident-body">
             <p class="pid-line">0323 · USB-C</p>
             <h3>Mouse 2024 / v3</h3>
-            <p>USB-C oval. Not in Boot Camp. KMDF.</p>
+            <p>USB-C. Use KMDF, not Boot Camp.</p>
             <a href="drivers.html#v3">v3 KMDF path</a>
           </div>
         </article>
@@ -127,19 +128,25 @@
           <div class="ident-body">
             <p class="pid-line">0310 · AA</p>
             <h3>Wireless Mouse</h3>
-            <p>AA door, no port. Treated like v1.</p>
+            <p>AA door. Treat like v1.</p>
             <a href="drivers.html#v1v2">v1 / v2 path</a>
           </div>
         </article>
       </div>
-
-      <p>Trackpads (<code>030E</code> / <code>0265</code> / <code>0324</code>) and keyboards (2011 AA, Lightning, 2024 USB-C) are in the same catalog. Touch ID and numeric keypad are extra PIDs, not extra drivers. Matrix: <a href="devices.html">Devices</a>.</p>
+      <ul class="facts">
+        <li>Trackpads: <code>030E</code> AA, <code>0265</code> Lightning, <code>0324</code> USB-C. Battery only.</li>
+        <li>Keyboards: 2011 AA, Lightning, or 2024 USB-C. SDP patch, not a mouse driver.</li>
+        <li>Full matrix: <a href="devices.html">Devices</a>.</li>
+      </ul>
     </article>
 
     <aside class="rail">
       <div class="rail-card">
-        <h2>Get the tray</h2>
-        <p>Magic Tray 1.1.0. User-initiated driver install. No subscription.</p>
+        <h2>Get it</h2>
+        <ul class="facts">
+          <li>Download the program.</li>
+          <li>You choose if and when to install a driver.</li>
+        </ul>
         <p class="cta">
           <a class="primary" href="https://github.com/LesleyMurfin/magic-tray/releases/latest">Download v1.1.0</a>
           <a class="ghost" href="https://lesleymurfin.github.io/magic-mouse-v3-windows-fix/">v3 kernel site</a>

--- a/docs/site.css
+++ b/docs/site.css
@@ -1,23 +1,23 @@
-@import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@500;600&family=Source+Sans+3:ital,wght@0,400;0,500;0,600;0,700;1,400&family=Source+Serif+4:opsz,wght@8..60,500;8..60,600;8..60,700&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Source+Code+Pro:wght@500;600&family=Source+Sans+3:ital,wght@0,400;0,500;0,600;0,700;1,400&display=swap");
 
 :root {
-  --bg: #141311;
-  --bg-2: #1b1916;
-  --bg-3: #23201c;
-  --fg: #f3eee6;
-  --muted: #c4bdb2;
-  --faint: #9a9286;
-  --line: #3d382f;
-  --line-strong: #5a5348;
-  --accent: #d4a05a;
-  --accent-2: #e8c48a;
-  --btn: #f3eee6;
-  --btn-fg: #161410;
-  --ok: #9cba86;
-  --radius: 0.7rem;
-  --serif: "Source Serif 4", "Iowan Old Style", Palatino, Georgia, serif;
-  --sans: "Source Sans 3", "Segoe UI", "Helvetica Neue", sans-serif;
-  --mono: "Source Code Pro", "Cascadia Code", ui-monospace, monospace;
+  --bg: #0f0f14;
+  --bg-2: #16161d;
+  --bg-3: #1c1c26;
+  --fg: #f4f4f5;
+  --muted: #c4c4cc;
+  --faint: #8b8b96;
+  --line: #2a2a35;
+  --line-strong: #3f3f4d;
+  --accent: #a78bfa;
+  --accent-2: #c4b5fd;
+  --btn: #7c3aed;
+  --btn-fg: #fff;
+  --ok: #4ade80;
+  --radius: 0.55rem;
+  --serif: ui-sans-serif, system-ui, "Segoe UI", sans-serif;
+  --sans: "Source Sans 3", ui-sans-serif, system-ui, "Segoe UI", sans-serif;
+  --mono: "Source Code Pro", ui-monospace, "Cascadia Code", Consolas, monospace;
   --shell: 76rem;
   --rail: 17.25rem;
   --header-h: 3.6rem;
@@ -33,7 +33,7 @@ html {
 
 body {
   margin: 0;
-  font: 17px/1.55 var(--sans);
+  font: 18px/1.5 var(--sans);
   background: var(--bg);
   color: var(--fg);
 }
@@ -166,36 +166,36 @@ code {
 .kicker a:hover { color: var(--fg); }
 
 h1 {
-  font-family: var(--serif);
-  font-size: clamp(1.85rem, 3.4vw, 2.75rem);
-  font-weight: 600;
-  line-height: 1.15;
+  font-family: var(--sans);
+  font-size: clamp(1.7rem, 3vw, 2.35rem);
+  font-weight: 700;
+  line-height: 1.2;
   letter-spacing: -0.02em;
-  margin: 0 0 0.85rem;
+  margin: 0 0 0.75rem;
 }
 
 h2 {
-  font-family: var(--serif);
-  font-size: 1.45rem;
-  font-weight: 600;
-  letter-spacing: -0.015em;
-  margin: 2.1rem 0 0.7rem;
+  font-family: var(--sans);
+  font-size: 1.28rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 2rem 0 0.55rem;
   scroll-margin-top: 4.6rem;
 }
 
 h3 {
-  font-size: 1.05rem;
+  font-size: 1.02rem;
   font-weight: 650;
-  margin: 1.4rem 0 0.45rem;
+  margin: 1.25rem 0 0.4rem;
   scroll-margin-top: 4.6rem;
 }
 
 .lead {
-  font-size: 1.12rem;
+  font-size: 1.05rem;
   line-height: 1.5;
   color: var(--muted);
-  margin: 0 0 0.4rem;
-  max-width: 40rem;
+  margin: 0 0 0.2rem;
+  max-width: 38rem;
 }
 
 .lead strong { color: var(--fg); font-weight: 650; }
@@ -234,9 +234,9 @@ h3 {
 }
 .cta .primary:hover,
 .btn.primary:hover {
-  background: var(--accent-2);
-  border-color: var(--accent-2);
-  color: var(--btn-fg);
+  background: #8b5cf6;
+  border-color: #8b5cf6;
+  color: #fff;
 }
 
 .cta .ghost,
@@ -437,13 +437,18 @@ img.shot {
   min-width: 0;
 }
 .ident-card .ident-visual {
-  background: #12110f;
+  background: #121218;
   border-bottom: 1px solid var(--line);
   min-height: 8.5rem;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 0.9rem 0.6rem 1.55rem;
+}
+.ident-card .ident-visual.kb-visual {
+  min-height: 11.5rem;
+  align-items: stretch;
+  padding: 0.75rem 0.7rem 0.85rem;
 }
 .ident-card .ident-visual:has(.photo) {
   padding: 0;
@@ -500,9 +505,8 @@ img.shot {
 
 .bottom-view {
   position: relative;
-  background: linear-gradient(180deg, #2f2b26 0%, #1a1815 100%);
+  background: linear-gradient(180deg, #2a2a35 0%, #16161d 100%);
   border: 1px solid var(--line-strong);
-  box-shadow: inset 0 1px 0 rgba(255, 245, 230, 0.06);
 }
 .bottom-view .tag {
   position: absolute;
@@ -524,11 +528,6 @@ img.shot {
   width: 8.4rem;
   height: 5.6rem;
   border-radius: 0.7rem;
-}
-.bottom-view.keyboard {
-  width: 9.6rem;
-  height: 3.5rem;
-  border-radius: 0.45rem;
 }
 .bottom-view.aa::after,
 .bottom-view.lightning::after,
@@ -556,15 +555,14 @@ img.shot {
   transform: translate(-50%, -50%);
   width: 58%;
   height: 58%;
-  border: 1px solid #6d655a;
+  border: 1px solid var(--line-strong);
   border-radius: 0.28rem;
   display: flex;
   flex-direction: column;
   gap: 0.28rem;
   padding: 0.35rem;
 }
-.bottom-view.trackpad .aa-door,
-.bottom-view.keyboard .aa-door {
+.bottom-view.trackpad .aa-door {
   flex-direction: row;
   width: 70%;
   height: 48%;
@@ -572,17 +570,17 @@ img.shot {
 }
 .aa-cell {
   flex: 1;
-  border: 1px dashed #8a8276;
+  border: 1px dashed #71717a;
   border-radius: 0.2rem;
-  background: #0e0d0b;
+  background: #09090b;
 }
 
 .port {
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  background: #0b0a09;
-  border: 1px solid #c9bba6;
+  background: #09090b;
+  border: 1px solid #a1a1aa;
 }
 .port.lightning {
   bottom: 12%;
@@ -596,20 +594,102 @@ img.shot {
   height: 0.72rem;
   border-radius: 0.4rem;
 }
-.bottom-view.trackpad .port,
-.bottom-view.keyboard .port {
+.bottom-view.trackpad .port {
   bottom: auto;
   top: 58%;
   transform: translate(-50%, -50%);
 }
-.bottom-view.keyboard .aa-door { width: 42%; left: 28%; }
-.bottom-view.keyboard .port { left: 78%; }
+
+.kb {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+.kb-face {
+  display: flex;
+  flex-direction: column;
+  gap: 0.18rem;
+  padding: 0.4rem 0.45rem 0.35rem;
+  aspect-ratio: 3.15 / 1;
+  background: #2c2c36;
+  border: 1px solid var(--line-strong);
+  border-radius: 0.45rem;
+  box-shadow: 0 10px 22px rgba(0, 0, 0, 0.35);
+}
+.kb-r {
+  flex: 1;
+  border-radius: 0.12rem;
+  background: repeating-linear-gradient(
+    90deg,
+    #4e4e5c 0 0.52rem,
+    #2c2c36 0.52rem 0.7rem
+  );
+}
+.kb-r.space {
+  background: #2c2c36;
+  display: flex;
+  justify-content: center;
+  align-items: stretch;
+}
+.kb-r.space i {
+  width: 42%;
+  background: #4e4e5c;
+  border-radius: 0.12rem;
+}
+.kb-find {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.45rem 0.5rem;
+  border: 1px solid var(--line);
+  border-radius: 0.4rem;
+  background: var(--bg);
+  min-height: 2.6rem;
+}
+.kb-find p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.82rem;
+  line-height: 1.35;
+}
+.kb-find p strong {
+  display: block;
+  color: var(--fg);
+  font-size: 0.84rem;
+}
+.kb-find .aa-door {
+  position: static;
+  transform: none;
+  width: 2.6rem;
+  height: 1.55rem;
+  flex: 0 0 2.6rem;
+  flex-direction: row;
+  top: auto;
+  left: auto;
+}
+.kb-find .port {
+  position: static;
+  transform: none;
+  left: auto;
+  bottom: auto;
+  flex: 0 0 auto;
+}
 
 ul.plain {
   padding-left: 1.15rem;
   color: var(--muted);
   margin: 0.4rem 0 1rem;
 }
+
+.facts {
+  margin: 0.55rem 0 1.35rem;
+  padding-left: 1.25rem;
+  color: var(--muted);
+}
+.facts li { margin: 0.4rem 0; }
+.facts strong { color: var(--fg); }
+
 ul.plain strong { color: var(--fg); }
 ul.plain li { margin: 0.35rem 0; }
 

--- a/docs/v3.html
+++ b/docs/v3.html
@@ -34,12 +34,20 @@
     <article id="content" class="primary">
       <header class="page-intro">
         <p class="kicker"><a href="./">Magic Tray</a> · research</p>
-        <h1>Why Magic Mouse v3 is not Magic Mouse v2</h1>
-        <p class="lead">Magic Mouse 2024 (v3, USB-C, PID <strong>0323</strong>) is a different Windows device from Magic Mouse v2 (Lightning, PID <strong>0269</strong>). The v2 Boot Camp INF cannot name 0323. v3’s HID collections can also collapse after Bluetooth idle. “Install the Apple mouse driver” is the wrong instruction.</p>
+        <h1>Why the 2024 Magic Mouse is not Magic Mouse 2</h1>
+        <ul class="facts">
+          <li>The new Magic Mouse charges with USB-C. Windows calls it <code>0323</code>.</li>
+          <li>Magic Mouse 2 charges with Lightning. Windows calls it <code>0269</code>.</li>
+          <li>They look similar. Windows does not treat them as the same device.</li>
+          <li>Apple never shipped a Windows driver for the USB-C one. “Install the Apple mouse driver” is the wrong advice.</li>
+        </ul>
       </header>
 
-      <h2 id="sources">Primary sources</h2>
-      <p>Kernel research lives in <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">magic-mouse-v3-windows-fix</a> (stripped from the public tray repo). Site: <a href="https://lesleymurfin.github.io/magic-mouse-v3-windows-fix/">lesleymurfin.github.io/magic-mouse-v3-windows-fix</a>.</p>
+      <h2 id="sources">If you want the long version</h2>
+      <ul class="facts">
+        <li>The kernel work lives in <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">magic-mouse-v3-windows-fix</a>.</li>
+        <li>Site: <a href="https://lesleymurfin.github.io/magic-mouse-v3-windows-fix/">v3 driver site</a>.</li>
+      </ul>
       <div class="grid grid-3">
         <div class="card">
           <h3><a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix/blob/main/v1-binary-patch/docs/bug-analysis.md">Bug analysis</a></h3>
@@ -54,25 +62,37 @@
           <p>COL01 + COL02 healthy vs collapsed stack.</p>
         </div>
       </div>
-      <p>Linux has in-tree <code>hid-magicmouse</code> (including USB-C v3). Windows does not. Apple’s redistributed Boot Camp mouse INF predates 0323.</p>
+      <ul class="facts">
+        <li>Linux already knows this mouse. Windows does not.</li>
+        <li>The old Apple Boot Camp mouse driver lists v1 and v2. It does not list 2024.</li>
+      </ul>
 
-      <h2 id="v2">v2: Apple already wrote a driver</h2>
-      <p>v1 (<code>030D</code>) and v2 (<code>0269</code>) match <code>AppleWirelessMouse.inf</code> from <a href="https://github.com/tealtadpole/MagicMouse2DriversWin11x64">tealtadpole</a>. Catalog-signed. Test Mode not required. Magic Tray opens that INF; it does not invent a new v1/v2 kernel driver.</p>
+      <h2 id="v2">Older mice already have a driver</h2>
+      <ul class="facts">
+        <li>v1 (battery door) and v2 (Lightning) match Apple’s Boot Camp file.</li>
+        <li>We use the copy from <a href="https://github.com/tealtadpole/MagicMouse2DriversWin11x64">tealtadpole</a>.</li>
+        <li>That file is already signed. You do not need Test Mode.</li>
+      </ul>
       <div class="diagram paths" id="paths">
         <div class="panel ok">
           <h3>Magic Mouse v1 / v2</h3>
-          <p>Lightning or AA. Apple listed these PIDs in Boot Camp.</p>
-          <p class="path-steps"><span>Pair</span><span class="sep">→</span><span>Boot Camp INF</span><span class="sep">→</span><span>scroll works</span></p>
+          <p>Battery door or Lightning. Apple already listed these.</p>
+          <p class="path-steps"><span>Pair</span><span class="sep">→</span><span>Apple’s old driver</span><span class="sep">→</span><span>scroll works</span></p>
         </div>
         <div class="panel bad">
-          <h3>Magic Mouse 2024 / v3</h3>
-          <p>USB-C. PID <code>0323</code> is not in that INF. Windows uses generic Bluetooth HID.</p>
-          <p class="path-steps"><span>Pair</span><span class="sep">→</span><span>no Apple driver</span><span class="sep">→</span><span>cursor yes, scroll dies</span></p>
+          <h3>Magic Mouse 2024</h3>
+          <p>USB-C. Apple never listed this one.</p>
+          <p class="path-steps"><span>Pair</span><span class="sep">→</span><span>no Apple driver</span><span class="sep">→</span><span>pointer yes, scroll dies</span></p>
         </div>
       </div>
 
-      <h2 id="mode">v3: two rooms, then Windows knocks the wall down</h2>
-      <p>A healthy 2024 mouse talks to Windows as <strong>two rooms</strong>. After Bluetooth idle, Windows can merge them. Cursor stays. Scroll is gone. Reboot does not put the wall back. That is Mode B.</p>
+      <h2 id="mode">The 2024 mouse: two rooms</h2>
+      <ul class="facts">
+        <li>Think of the mouse as two rooms.</li>
+        <li>Room 1 is the pointer and finger-scroll.</li>
+        <li>Room 2 is the battery percent.</li>
+        <li>After the mouse sleeps, Windows can knock the wall down. The pointer still moves. Scroll is gone. Restarting Windows does not rebuild the wall.</li>
+      </ul>
       <div class="diagram pair" role="img" aria-label="Working two-room mouse versus broken one-room mouse">
         <div class="panel ok">
           <h3>Working — two rooms</h3>
@@ -92,8 +112,12 @@
       </div>
       <p class="caption" style="color:var(--faint);font-size:0.82rem;margin-top:-0.6rem;">Same idea as the Mode A / Mode B diagram in the kernel repo — without HID class names.</p>
 
-      <h2 id="stack">Where the fix sits</h2>
-      <p>Windows does not turn a finger swipe into a wheel by itself on this mouse. A small driver sits <em>under</em> Windows and <em>above</em> Bluetooth. That picture is not ours.</p>
+      <h2 id="stack">Where the extra piece sits</h2>
+      <ul class="facts">
+        <li>Windows will not turn a finger swipe into a scroll wheel by itself on this mouse.</li>
+        <li>Someone has to add a small program under Windows and above Bluetooth.</li>
+        <li>That picture is from sbagirici, not us.</li>
+      </ul>
       <div class="diagram sba-pair" role="img" aria-label="sbagirici LowerFilter stack for v1 v2, same stack with KMDF for v3">
         <div class="sba">
           <h3 class="sba-title">sbagirici · v1 / v2</h3>
@@ -125,13 +149,16 @@
         </div>
       </div>
       <aside class="credit-box" id="sbagirici">
-        <h3>This diagram is sbagirici’s</h3>
-        <p><a href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows">sbagirici/apple-magic-mouse-scroll-fix-windows</a> is the README that made the LowerFilter click: app → Windows → <strong>filter</strong> → Bluetooth → mouse. We redrew it here so v3 is obvious. If that picture helped you, <strong>star their repo</strong> — they did the v1/v2 work we stood on.</p>
+        <h3>This sandwich is sbagirici’s</h3>
+        <ul class="facts">
+          <li>They drew it in <a href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows">apple-magic-mouse-scroll-fix-windows</a>.</li>
+          <li>Please <strong>star their project</strong> if the picture made this click.</li>
+          <li>Their installer is for v1/v2. The 2024 USB-C mouse still needs our KMDF driver.</li>
+        </ul>
         <p class="cta">
           <a class="primary" href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows">Star sbagirici’s scroll fix</a>
           <a class="ghost" href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows#architecture">Their Architecture section</a>
         </p>
-        <p>Their installer uses Apple’s signed <code>applewirelessmouse.sys</code> for v1/v2. Do not put that on Magic Mouse 2024 (<code>0323</code>). That PID still needs KMDF from <a href="https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix">magic-mouse-v3-windows-fix</a>.</p>
       </aside>
       <div class="grid grid-2">
         <div class="card">
@@ -147,8 +174,12 @@
       </div>
       <p class="note">Patched Apple can pin scroll and drop battery. Stock can keep battery and drop scroll. KMDF is the path aimed at both. It is still self-signed — <a href="funding.html">that is the funding goal</a>.</p>
 
-      <h2 id="tray">Why a tray, not only a driver</h2>
-      <p>A filter does not show 30% in the corner or refuse to patch the wrong keyboard MAC. v3 battery is userspace HID. Keyboard battery is an SDP registry patch. Trackpads are percent only. One <code>.sys</code> cannot cover that matrix — <a href="devices.html">Devices</a>.</p>
+      <h2 id="tray">Why there is a tray program too</h2>
+      <ul class="facts">
+        <li>A driver does not show “28%” next to the clock.</li>
+        <li>A driver does not know your keyboard’s Bluetooth address.</li>
+        <li>Mice, keyboards, and trackpads are different jobs. One file cannot do all of them. See <a href="devices.html">Devices</a>.</li>
+      </ul>
     </article>
 
     <aside class="rail">


### PR DESCRIPTION
The brown/gold theme is gone. Black + purple, same as the original Pages.

Copy is short lists. A 12-year-old should be able to follow:

- what the tray is
- flip the mouse / look at the back of the keyboard
- ask Windows the real name (Hardware Ids)

Keyboard cards were soap-bar blobs. They are now a top-view keyboard (keys + spacebar) plus the real tell: AA door, Lightning, or USB-C on the back edge.