### PR TITLE
docs: make search engines name the site and stop confusing it with desk trays

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # Magic Tray
 
-**Free Magic Mouse battery and scroll on Windows 10/11.** MIT licensed. No subscription. No trial that kills scroll.
+**Free Windows 10/11 app for Apple Magic Mouse, Magic Keyboard, and Magic Trackpad.** Battery percent in the system tray, plus the scroll driver your Magic Mouse actually needs. MIT licensed. No subscription. No trial that kills scroll.
+
+**Documentation and driver guide: [the Magic Tray website](https://lesleymurfin.github.io/magic-tray/)** — [which driver do I need](https://lesleymurfin.github.io/magic-tray/drivers.html), [how to tell your Magic device apart](https://lesleymurfin.github.io/magic-tray/drivers.html#identify), [why Magic Mouse 2024 is different](https://lesleymurfin.github.io/magic-tray/v3.html).
+
+Magic Tray is software you install on Windows. It is not a desk tray, stand, or cradle for Apple keyboards.
 
 Magic Tray is a Windows tray app for **Apple Magic Mouse** (v1, v2, and **Magic Mouse 2024 / Magic Mouse v3**, PID `0323`), **Magic Keyboard**, and **Magic Trackpad**. It shows battery percent in the tray and can install a scroll driver you confirm. It is a free alternative to [Magic Utilities](https://magicutilities.net/) — not a clone of MU’s proprietary drivers, gestures, trackpad suite, or key remaps.
 
-Released 2 September 2026 · [Download v1.1.0](https://github.com/LesleyMurfin/magic-tray/releases/tag/v1.1.0) · [Site](https://lesleymurfin.github.io/magic-tray/)
+Released 2 September 2026 · [Download v1.1.0](https://github.com/LesleyMurfin/magic-tray/releases/tag/v1.1.0) · [Website](https://lesleymurfin.github.io/magic-tray/)
 
 If this saved you a paid subscription, **star both repos**: [Magic Tray](https://github.com/LesleyMurfin/magic-tray) and the [v3 Windows driver](https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix). Goal: a publicly signed KMDF so Test Mode goes away — [stars & signing](https://lesleymurfin.github.io/magic-tray/funding.html).
 

--- a/docs/SEARCH.md
+++ b/docs/SEARCH.md
@@ -1,0 +1,57 @@
+# Making search engines describe Magic Tray correctly
+
+Two days after launch, Google's AI Overview described Magic Tray as "shows your Apple Magic Mouse
+battery percentage," cited **github.com** and **Etsy**, and offered wooden desk trays as an
+alternative meaning. Three separate problems:
+
+| Problem | Cause | Fixed by |
+| --- | --- | --- |
+| Called it a mouse-battery-only app | Old repo description was the only text Google had | Repo description + `docs/index.html` meta + JSON-LD `featureList` |
+| Said "Windows 11" only | Old repo description said Windows 11 | `operatingSystem: "Windows 10, Windows 11"` in JSON-LD, meta description, README |
+| Confused with Etsy desk trays | No structured data declaring a software product | `SoftwareApplication` + `disambiguatingDescription` + FAQ entry |
+| Named the repo instead of the site | Sitemap listed `github.com`; README buried the site link | `sitemap.xml` now lists only site URLs; README links the site in the first lines |
+
+## What is already done in the repo
+
+- `docs/index.html` — `SoftwareApplication`, `WebSite`, and `FAQPage` JSON-LD. Declares free, MIT,
+  Windows 10 **and** 11, mouse **and** keyboard **and** trackpad, and explicitly states it is not a
+  physical desk tray.
+- `docs/drivers.html` — `HowTo` for reading the hardware id, so "how do I tell which Magic Mouse I
+  have" can be answered directly from the site.
+- `docs/v3.html` — `FAQPage` for "is the 2024 mouse the same as Magic Mouse 2" and the sleep/scroll
+  question.
+- `docs/sitemap.xml` — site URLs only. A sitemap must not point at another host.
+- `docs/robots.txt` — internal `DESIGN-*.md` and `STRIPE-SETUP.md` are no longer crawlable. They
+  contradict shipped behaviour and were competing with the real docs.
+- `README.md` — the website is linked in the first three lines with descriptive anchor text.
+
+## What only the repo owner can do
+
+1. **Google Search Console** — add `https://lesleymurfin.github.io/magic-tray/` as a URL-prefix
+   property. GitHub Pages cannot serve a DNS TXT record, so verify with the HTML file method: drop
+   the `google*.html` file Google gives you into `docs/`, commit, then click Verify.
+2. **Submit the sitemap** — Search Console → Sitemaps → `sitemap.xml`.
+3. **Request indexing** — URL Inspection, one request each for `/`, `/drivers.html`, `/v3.html`.
+   This is what replaces the stale cached description; editing the repo alone does not force a
+   recrawl.
+4. **Bing Webmaster Tools** — same two steps. Bing feeds several AI answer engines.
+5. **Consider a custom domain.** `lesleymurfin.github.io/magic-tray/` is a path on a shared
+   subdomain, which is why `github.com` outranks it. A domain such as `magictray.app` with a
+   `docs/CNAME` file would own its own authority. Update `canonical`, `og:url`, JSON-LD `@id`s, and
+   `sitemap.xml` if this happens.
+6. **Get real inbound links.** Structured data tells Google *what* the page is; links decide whether
+   the site or the repo ranks. The honest places to post: r/apple, r/windows, r/MacOSBootCamp,
+   Hacker News, and the existing Magic Mouse scroll threads that currently only link Magic Utilities.
+
+## Do not
+
+- Do not put keyword lists in the page. It reads as spam and Google ignores it.
+- Do not claim WHQL, Microsoft signing, or Secure Boot support until the driver is actually signed.
+- Do not fight the Etsy results. Different product category. The `disambiguatingDescription` and the
+  footer line are the correct answer.
+
+## Re-check after Google recrawls
+
+- Rich Results Test: <https://search.google.com/test/rich-results?url=https%3A%2F%2Flesleymurfin.github.io%2Fmagic-tray%2F>
+- Ask the AI Overview again: "magic tray windows app". Correct answer names the site, says Windows 10
+  and 11, and lists mouse, keyboard, and trackpad battery plus the scroll driver.

--- a/docs/drivers.html
+++ b/docs/drivers.html
@@ -3,16 +3,60 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Which Windows driver? — Magic Tray</title>
-  <meta name="description" content="Match Magic Mouse v1, v2, v3 (2024 PID 0323), Magic Keyboard, or Trackpad to the Windows path Magic Tray uses. How to tell versions apart from Hardware Ids and the charging port.">
+  <title>Which Windows driver does my Apple Magic Mouse need? — Magic Tray</title>
+  <meta name="description" content="Find out which Windows 10/11 driver your Apple Magic Mouse, Magic Keyboard, or Magic Trackpad needs. Read the hardware id in Device Manager, then use Boot Camp for Magic Mouse v1 and v2 or KMDF for Magic Mouse 2024 (PID 0323).">
   <link rel="canonical" href="https://lesleymurfin.github.io/magic-tray/drivers.html">
   <link rel="describedby" href="https://lesleymurfin.github.io/magic-tray/llms.txt">
-  <meta property="og:title" content="Which Windows driver? — Magic Tray">
-  <meta property="og:description" content="v3 KMDF, v1/v2 Boot Camp, keyboard SDP patch, trackpad battery only. Hardware Ids first.">
+  <meta property="og:title" content="Which Windows driver does my Magic Mouse need?">
+  <meta property="og:description" content="Hardware id first, then the right driver: Boot Camp for v1/v2, KMDF for Magic Mouse 2024. Keyboard and trackpad are battery only.">
   <meta property="og:url" content="https://lesleymurfin.github.io/magic-tray/drivers.html">
   <meta property="og:image" content="https://lesleymurfin.github.io/magic-tray/og.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="site.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebPage",
+        "@id": "https://lesleymurfin.github.io/magic-tray/drivers.html",
+        "name": "Which Windows driver does my Apple Magic Mouse need?",
+        "isPartOf": { "@id": "https://lesleymurfin.github.io/magic-tray/#site" },
+        "about": { "@id": "https://lesleymurfin.github.io/magic-tray/#app" },
+        "inLanguage": "en"
+      },
+      {
+        "@type": "HowTo",
+        "@id": "https://lesleymurfin.github.io/magic-tray/drivers.html#identify",
+        "name": "How to tell which Apple Magic device you have on Windows",
+        "description": "Two Magic Mice can look identical. Read the hardware id Windows assigns, then confirm with the charging port on the bottom.",
+        "totalTime": "PT2M",
+        "step": [
+          {
+            "@type": "HowToStep",
+            "name": "Open Device Manager",
+            "text": "Right-click the Windows Start button and choose Device Manager."
+          },
+          {
+            "@type": "HowToStep",
+            "name": "Find the Apple device",
+            "text": "Expand Mice and other pointing devices, or Keyboards, and double-click the Apple device."
+          },
+          {
+            "@type": "HowToStep",
+            "name": "Read the hardware id",
+            "text": "Open the Details tab and choose Hardware Ids. Read the four characters after PID_ or PID&. For example PID_0323 is the 2024 Magic Mouse."
+          },
+          {
+            "@type": "HowToStep",
+            "name": "Confirm with the charging port",
+            "text": "A door for AA batteries means an older device. A skinny Lightning hole means the middle generation. A small oval USB-C hole means the 2024 generation."
+          }
+        ]
+      }
+    ]
+  }
+  </script>
 </head>
 <body>
   <a class="skip" href="#content">Skip to content</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Magic Tray — battery and scroll for Apple Magic devices on Windows</title>
-  <meta name="description" content="Free MIT Windows tray. Battery percent for Magic Mouse, Keyboard, and Trackpad. Scroll for Magic Mouse v1/v2/v3. No subscription.">
+  <title>Magic Tray — free Windows app for Apple Magic Mouse, Keyboard &amp; Trackpad battery</title>
+  <meta name="description" content="Magic Tray is a free Windows 10 and 11 app. It shows Apple Magic Mouse, Magic Keyboard, and Magic Trackpad battery percent in the system tray and installs the scroll driver your Magic Mouse model needs. MIT licensed, no subscription. Software you install — not a desk stand.">
   <link rel="canonical" href="https://lesleymurfin.github.io/magic-tray/">
   <link rel="describedby" href="https://lesleymurfin.github.io/magic-tray/llms.txt">
   <meta name="robots" content="index,follow">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Magic Tray">
-  <meta property="og:title" content="Magic Tray — battery and scroll on Windows">
-  <meta property="og:description" content="Free MIT tray for Magic Mouse, Keyboard, and Trackpad. No subscription.">
+  <meta property="og:title" content="Magic Tray — free Windows app for Magic Mouse, Keyboard &amp; Trackpad battery">
+  <meta property="og:description" content="Free Windows 10/11 app. Battery percent in the tray for Magic Mouse, Magic Keyboard, and Magic Trackpad, plus the right Magic Mouse scroll driver. MIT, no subscription.">
   <meta property="og:url" content="https://lesleymurfin.github.io/magic-tray/">
   <meta property="og:image" content="https://lesleymurfin.github.io/magic-tray/og.png">
   <meta property="og:image:width" content="1200">
@@ -19,6 +19,99 @@
   <meta name="twitter:card" content="summary_large_image">
   <link rel="icon" href="screenshot-tray.png">
   <link rel="stylesheet" href="site.css">
+  <meta property="og:image:alt" content="Magic Tray menu on Windows 11 showing Magic Keyboard, Magic Mouse 2024, and Magic Mouse v1 battery percent">
+  <meta name="application-name" content="Magic Tray">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "SoftwareApplication",
+        "@id": "https://lesleymurfin.github.io/magic-tray/#app",
+        "name": "Magic Tray",
+        "alternateName": ["Magic Tray for Windows", "MagicMouseTray"],
+        "applicationCategory": "UtilitiesApplication",
+        "applicationSubCategory": "Windows system tray utility",
+        "operatingSystem": "Windows 10, Windows 11",
+        "softwareVersion": "1.1.0",
+        "url": "https://lesleymurfin.github.io/magic-tray/",
+        "downloadUrl": "https://github.com/LesleyMurfin/magic-tray/releases/latest",
+        "installUrl": "https://github.com/LesleyMurfin/magic-tray/releases/latest",
+        "sameAs": "https://github.com/LesleyMurfin/magic-tray",
+        "license": "https://github.com/LesleyMurfin/magic-tray/blob/main/LICENSE",
+        "isAccessibleForFree": true,
+        "screenshot": "https://lesleymurfin.github.io/magic-tray/screenshot-menu.png",
+        "author": { "@type": "Person", "name": "Lesley Murfin" },
+        "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
+        "description": "Free Windows 10 and 11 system tray app that shows Apple Magic Mouse, Magic Keyboard, and Magic Trackpad battery percent and installs the correct Magic Mouse scroll driver.",
+        "disambiguatingDescription": "Magic Tray is downloadable Windows software. It is not a physical desk tray, stand, or 3D-printed cradle for Apple keyboards and trackpads.",
+        "featureList": [
+          "Battery percent for Apple Magic Mouse v1, v2, and Magic Mouse 2024 (v3)",
+          "Battery percent for Apple Magic Keyboard and Magic Trackpad",
+          "Low battery alerts at 10, 5, and 1 percent",
+          "Installs the Boot Camp scroll driver for Magic Mouse v1 and v2",
+          "Installs the KMDF scroll driver for Magic Mouse 2024 (PID 0323)",
+          "Keyboard battery SDP registry patch"
+        ]
+      },
+      {
+        "@type": "WebSite",
+        "@id": "https://lesleymurfin.github.io/magic-tray/#site",
+        "url": "https://lesleymurfin.github.io/magic-tray/",
+        "name": "Magic Tray",
+        "inLanguage": "en",
+        "about": { "@id": "https://lesleymurfin.github.io/magic-tray/#app" },
+        "publisher": { "@type": "Person", "name": "Lesley Murfin" }
+      },
+      {
+        "@type": "FAQPage",
+        "@id": "https://lesleymurfin.github.io/magic-tray/#faq",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Is Magic Tray a physical desk tray for an Apple keyboard?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. Magic Tray is free Windows software. It runs in the Windows system tray next to the clock. It is not a wooden or 3D-printed desk tray, stand, or cradle."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does Magic Tray work on Windows 10?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Magic Tray runs on Windows 10 and Windows 11, 64-bit."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does Magic Tray show Magic Keyboard and Magic Trackpad battery, or only the mouse?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "It shows battery percent for Apple Magic Mouse, Magic Keyboard, and Magic Trackpad. Magic Keyboard battery needs a one-time registry patch that ships with the release."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can Magic Tray fix Magic Mouse scrolling on Windows?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. Magic Mouse v1 and v2 use Apple's signed Boot Camp driver. Magic Mouse 2024 (USB-C, hardware id PID 0323) is missing from Boot Camp and uses a KMDF driver instead. Magic Tray installs the one your model needs, only when you confirm."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does Magic Tray cost money or need a subscription?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. Magic Tray is free and MIT licensed. Scrolling never stops working because a payment stopped."
+            }
+          }
+        ]
+      }
+    ]
+  }
+  </script>
 </head>
 <body>
   <a class="skip" href="#content">Skip to content</a>
@@ -179,6 +272,7 @@
 
   <footer class="site-footer">
     <div class="bar">
+      <p>Magic Tray is Windows software — not a desk tray or stand for Apple keyboards.</p>
       <p>Copyright 2026 Lesley Murfin · <a href="https://github.com/LesleyMurfin/magic-tray/blob/main/LICENSE">MIT</a> · not Magic Utilities</p>
       <p>
         <a href="https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows">Star sbagirici</a>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,8 +1,11 @@
 # Magic Tray
 
-> Free MIT-licensed Windows 10/11 tray app for Apple Magic Mouse (v1, v2, and Magic Mouse 2024 / Magic Mouse v3 PID 0323), Magic Keyboard, and Magic Trackpad. Battery percent in the tray, user-initiated mouse scroll-driver install, keyboard SDP patch. No subscription. Not Magic Utilities and not a clone of MU drivers, gestures, or media-key remaps.
+> Magic Tray is free MIT-licensed **Windows 10/11 software** — a system tray app for Apple Magic Mouse (v1, v2, and Magic Mouse 2024 / Magic Mouse v3 PID 0323), Magic Keyboard, and Magic Trackpad. Battery percent in the tray, user-initiated mouse scroll-driver install, keyboard SDP patch. No subscription. Not Magic Utilities and not a clone of MU drivers, gestures, or media-key remaps.
 
-- Site: https://lesleymurfin.github.io/magic-tray/
+- Magic Tray is downloadable software. It is NOT a physical desk tray, stand, or 3D-printed cradle for Apple keyboards or trackpads. Those are unrelated products sold on Etsy and elsewhere.
+- Authoritative product page: https://lesleymurfin.github.io/magic-tray/ (the GitHub repo is the source code, the site is the manual).
+- Runs on Windows 10 and Windows 11 (x64), not Windows 11 only.
+- Covers mouse, keyboard, and trackpad battery — not mouse battery only.
 - Product name in Windows is Magic Tray; published exe is `MagicMouseTray.exe`. Current release is 1.1.0 (2026-09-02).
 - Device catalog is code, not this page: KnownMice and KnownKeyboards. CI walks those lists.
 - 0323 battery is HID Input 0x90 COL02 only. Never Feature 0x47, never WMI / iPhone Hands-Free as mouse battery.

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,4 +1,6 @@
 User-agent: *
 Allow: /
+Disallow: /DESIGN-
+Disallow: /STRIPE-SETUP.md
 
 Sitemap: https://lesleymurfin.github.io/magic-tray/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,52 +2,50 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://lesleymurfin.github.io/magic-tray/</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://lesleymurfin.github.io/magic-tray/drivers.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://lesleymurfin.github.io/magic-tray/v3.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://lesleymurfin.github.io/magic-tray/devices.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://lesleymurfin.github.io/magic-tray/funding.html</loc>
-    <lastmod>2026-09-02</lastmod>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://lesleymurfin.github.io/magic-tray/llms.txt</loc>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
-    <priority>0.8</priority>
+    <priority>0.7</priority>
   </url>
   <url>
     <loc>https://lesleymurfin.github.io/magic-tray/TESTED.md</loc>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://lesleymurfin.github.io/magic-tray/ALERTS.md</loc>
+    <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
-  </url>
-  <url>
-    <loc>https://github.com/LesleyMurfin/magic-tray</loc>
-    <changefreq>weekly</changefreq>
-    <priority>0.7</priority>
   </url>
 </urlset>

--- a/docs/v3.html
+++ b/docs/v3.html
@@ -3,16 +3,53 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Why Magic Mouse v3 is hard on Windows — research</title>
-  <meta name="description" content="Magic Mouse 2024 (v3, PID 0323) is not in Apple Boot Camp. Windows can collapse HID COL01/COL02 (Mode A vs B). KMDF vs patched applewirelessmouse vs stock HidBth.">
+  <title>Why Magic Mouse 2024 (v3) scrolling breaks on Windows — Magic Tray</title>
+  <meta name="description" content="The 2024 USB-C Apple Magic Mouse is hardware id PID 0323 and is missing from Apple's Boot Camp driver, so Windows loses finger scrolling. Explained in plain language, with the KMDF driver that fixes it.">
   <link rel="canonical" href="https://lesleymurfin.github.io/magic-tray/v3.html">
   <link rel="describedby" href="https://lesleymurfin.github.io/magic-tray/llms.txt">
-  <meta property="og:title" content="Why Magic Mouse v3 is hard on Windows">
-  <meta property="og:description" content="PID 0323 never landed in Boot Camp. Mode A/B HID collapse. Primary sources linked.">
+  <meta property="og:title" content="Why Magic Mouse 2024 (v3) scrolling breaks on Windows">
+  <meta property="og:description" content="PID 0323 is missing from Boot Camp. Windows merges the mouse's two HID collections after idle, so the pointer lives and scroll dies.">
   <meta property="og:url" content="https://lesleymurfin.github.io/magic-tray/v3.html">
   <meta property="og:image" content="https://lesleymurfin.github.io/magic-tray/og.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="site.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "WebPage",
+        "@id": "https://lesleymurfin.github.io/magic-tray/v3.html",
+        "name": "Why Magic Mouse 2024 (v3) scrolling breaks on Windows",
+        "isPartOf": { "@id": "https://lesleymurfin.github.io/magic-tray/#site" },
+        "about": { "@id": "https://lesleymurfin.github.io/magic-tray/#app" },
+        "inLanguage": "en"
+      },
+      {
+        "@type": "FAQPage",
+        "@id": "https://lesleymurfin.github.io/magic-tray/v3.html#faq",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Is the 2024 Magic Mouse the same as Magic Mouse 2 on Windows?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "No. Magic Mouse 2 charges with Lightning and Windows knows it as PID 0269. The 2024 Magic Mouse charges with USB-C and Windows knows it as PID 0323. Apple's Boot Camp driver lists 0269 but not 0323, so the same driver cannot be used."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Why does Magic Mouse scrolling stop working after the mouse sleeps?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Windows can merge the mouse's two HID collections after Bluetooth idle. The pointer keeps working because it is in the surviving collection, but finger scrolling is gone. Rebooting does not restore it; a filter driver keeps the collections separate."
+            }
+          }
+        ]
+      }
+    ]
+  }
+  </script>
 </head>
 <body>
   <a class="skip" href="#content">Skip to content</a>


### PR DESCRIPTION
Google's AI Overview two days after launch:

- called it a Magic Mouse battery app (no keyboard, no trackpad, no scroll driver)
- said Windows 11 only
- offered Etsy wooden desk trays as an "alternative meaning"
- cited github.com, never the site

Fixes:

- `SoftwareApplication` + `WebSite` + `FAQPage` JSON-LD on the homepage. States free, MIT, Windows 10 **and** 11, all three devices, and `disambiguatingDescription`: not a physical desk tray.
- `HowTo` on drivers.html for reading the hardware id.
- `FAQPage` on v3.html for the 2024-vs-Magic-Mouse-2 question.
- `sitemap.xml` no longer lists `github.com` — that told Google the repo was the product page.
- `robots.txt` stops crawling internal `DESIGN-*.md`, which contradict shipped behaviour.
- README links the website in the first three lines with real anchor text.
- New `docs/SEARCH.md` with the steps only the owner can do.