### PR TITLE
docs: move the site to magictray.app

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
 github: LesleyMurfin
-custom: ["https://lesleymurfin.github.io/magic-tray/funding.html"]
+custom: ["https://magictray.app/funding.html"]

--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 **Free Windows 10/11 app for Apple Magic Mouse, Magic Keyboard, and Magic Trackpad.** Battery percent in the system tray, plus the scroll driver your Magic Mouse actually needs. MIT licensed. No subscription. No trial that kills scroll.
 
-**Documentation and driver guide: [the Magic Tray website](https://lesleymurfin.github.io/magic-tray/)** — [which driver do I need](https://lesleymurfin.github.io/magic-tray/drivers.html), [how to tell your Magic device apart](https://lesleymurfin.github.io/magic-tray/drivers.html#identify), [why Magic Mouse 2024 is different](https://lesleymurfin.github.io/magic-tray/v3.html).
+**Documentation and driver guide: [the Magic Tray website](https://magictray.app/)** — [which driver do I need](https://magictray.app/drivers.html), [how to tell your Magic device apart](https://magictray.app/drivers.html#identify), [why Magic Mouse 2024 is different](https://magictray.app/v3.html).
 
 Magic Tray is software you install on Windows. It is not a desk tray, stand, or cradle for Apple keyboards.
 
 Magic Tray is a Windows tray app for **Apple Magic Mouse** (v1, v2, and **Magic Mouse 2024 / Magic Mouse v3**, PID `0323`), **Magic Keyboard**, and **Magic Trackpad**. It shows battery percent in the tray and can install a scroll driver you confirm. It is a free alternative to [Magic Utilities](https://magicutilities.net/) — not a clone of MU’s proprietary drivers, gestures, trackpad suite, or key remaps.
 
-Released 2 September 2026 · [Download v1.1.0](https://github.com/LesleyMurfin/magic-tray/releases/tag/v1.1.0) · [Website](https://lesleymurfin.github.io/magic-tray/)
+Released 2 September 2026 · [Download v1.1.0](https://github.com/LesleyMurfin/magic-tray/releases/tag/v1.1.0) · [Website](https://magictray.app/)
 
-If this saved you a paid subscription, **star both repos**: [Magic Tray](https://github.com/LesleyMurfin/magic-tray) and the [v3 Windows driver](https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix). Goal: a publicly signed KMDF so Test Mode goes away — [stars & signing](https://lesleymurfin.github.io/magic-tray/funding.html).
+If this saved you a paid subscription, **star both repos**: [Magic Tray](https://github.com/LesleyMurfin/magic-tray) and the [v3 Windows driver](https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix). Goal: a publicly signed KMDF so Test Mode goes away — [stars & signing](https://magictray.app/funding.html).
 
 ![Windows 11 system tray with Magic Tray](docs/screenshot-tray.png)
 
@@ -39,9 +39,9 @@ If this saved you a paid subscription, **star both repos**: [Magic Tray](https:/
 - [Diagnostics](#diagnostics)
 - [Releases](#releases)
 - [License](#license)
-- [Which driver](https://lesleymurfin.github.io/magic-tray/drivers.html)
-- [Why v3 is hard](https://lesleymurfin.github.io/magic-tray/v3.html)
-- [Stars & signing](https://lesleymurfin.github.io/magic-tray/funding.html)
+- [Which driver](https://magictray.app/drivers.html)
+- [Why v3 is hard](https://magictray.app/v3.html)
+- [Stars & signing](https://magictray.app/funding.html)
 - [llms.txt](llms.txt) (for agents)
 
 ---
@@ -343,7 +343,7 @@ CI builds on a `v*` tag: test, publish win-x64, optional Authenticode (`SIGN_PFX
 
 ## Credits
 
-The LowerFilter sandwich (app → Windows HID → **filter** → Bluetooth → mouse) is from [sbagirici/apple-magic-mouse-scroll-fix-windows](https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows). That Architecture diagram is why the v1/v2 scroll path is understandable. **Please star their repo.** We redraw it on [v3.html](https://lesleymurfin.github.io/magic-tray/v3.html#stack). Their installer is for v1/v2 with Apple’s signed `applewirelessmouse.sys`. Magic Mouse 2024 (`0323`) still uses KMDF from [magic-mouse-v3-windows-fix](https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix).
+The LowerFilter sandwich (app → Windows HID → **filter** → Bluetooth → mouse) is from [sbagirici/apple-magic-mouse-scroll-fix-windows](https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows). That Architecture diagram is why the v1/v2 scroll path is understandable. **Please star their repo.** We redraw it on [v3.html](https://magictray.app/v3.html#stack). Their installer is for v1/v2 with Apple’s signed `applewirelessmouse.sys`. Magic Mouse 2024 (`0323`) still uses KMDF from [magic-mouse-v3-windows-fix](https://github.com/LesleyMurfin/magic-mouse-v3-windows-fix).
 
 v1/v2 Boot Camp INF packaging: [tealtadpole/MagicMouse2DriversWin11x64](https://github.com/tealtadpole/MagicMouse2DriversWin11x64).
 

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+magictray.app

--- a/docs/SEARCH.md
+++ b/docs/SEARCH.md
@@ -1,15 +1,97 @@
-# Making search engines describe Magic Tray correctly
+# Domain, search, and how the site gets described
 
-Two days after launch, Google's AI Overview described Magic Tray as "shows your Apple Magic Mouse
-battery percentage," cited **github.com** and **Etsy**, and offered wooden desk trays as an
-alternative meaning. Three separate problems:
+Two days after the 1.1.0 launch, Google's AI Overview described Magic Tray as "shows your Apple
+Magic Mouse battery percentage," said it required Windows 11, cited **github.com** and **Etsy**, and
+offered wooden desk trays as an "alternative meaning." It never named this site. Four separate
+causes, all now fixed in the repo:
 
 | Problem | Cause | Fixed by |
 | --- | --- | --- |
-| Called it a mouse-battery-only app | Old repo description was the only text Google had | Repo description + `docs/index.html` meta + JSON-LD `featureList` |
+| Called it a mouse-battery-only app | Old repo description was the only text Google had | Repo description + `docs/index.html` meta + JSON-LD `featureList` naming mouse, keyboard, trackpad, and both scroll drivers |
 | Said "Windows 11" only | Old repo description said Windows 11 | `operatingSystem: "Windows 10, Windows 11"` in JSON-LD, meta description, README |
-| Confused with Etsy desk trays | No structured data declaring a software product | `SoftwareApplication` + `disambiguatingDescription` + FAQ entry |
+| Confused with Etsy desk trays | No structured data declaring a software product | `SoftwareApplication` + `disambiguatingDescription` + FAQ entry + footer line |
 | Named the repo instead of the site | Sitemap listed `github.com`; README buried the site link | `sitemap.xml` now lists only site URLs; README links the site in the first lines |
+
+## The domain
+
+The site runs on **magictray.app**. `.app` is a Google Registry TLD on the HSTS preload list, so
+HTTPS is mandatory and browsers will not fall back to plain HTTP. That is good for trust, and it has
+one consequence during setup: between pointing DNS and GitHub issuing the certificate, the site is
+unreachable rather than merely insecure.
+
+`lesleymurfin.github.io/magic-tray/` was a path on a shared subdomain, which is why `github.com`
+outranked it regardless of markup quality. GitHub Pages redirects the old `github.io` URLs to the
+custom domain, so existing links keep working.
+
+### DNS records
+
+The domain is registered at Cloudflare and uses Cloudflare nameservers, so the records live in the
+Cloudflare DNS tab. This is the live configuration — apex `magictray.app` has four A and four AAAA
+records, and `www` is a CNAME. Every record is **DNS only (grey cloud)**. Addresses match
+`https://api.github.com/meta`:
+
+```
+A     magictray.app    185.199.108.153
+A     magictray.app    185.199.109.153
+A     magictray.app    185.199.110.153
+A     magictray.app    185.199.111.153
+AAAA  magictray.app    2606:50c0:8000::153
+AAAA  magictray.app    2606:50c0:8001::153
+AAAA  magictray.app    2606:50c0:8002::153
+AAAA  magictray.app    2606:50c0:8003::153
+CNAME www              lesleymurfin.github.io
+```
+
+Resolution is confirmed against both `1.1.1.1` and `8.8.8.8`:
+
+```
+dig +short magictray.app A @1.1.1.1
+dig +short magictray.app AAAA @1.1.1.1
+dig +short www.magictray.app @8.8.8.8
+```
+
+### Cloudflare specifics
+
+**Every record must stay DNS only (grey cloud), not Proxied (orange cloud).** Cloudflare proxies new
+records by default, so this is a deliberate setting rather than the default one. A proxy in front of
+a Pages site that has no certificate yet prevents GitHub's Let's Encrypt validation from completing,
+and the DNS check on the Pages settings page will not pass.
+
+Once HTTPS is enforced on GitHub the proxy may be switched back on, with SSL/TLS mode
+**Full (strict)**. Leaving it DNS-only is also fine; GitHub already serves the site over a CDN.
+
+### Order of operations
+
+`docs/CNAME` must not reach `main` before DNS resolves, or the live site breaks. Steps 1–3 are done.
+
+1. **Done** — register the domain. The registrant email must be correct first; ICANN verification
+   goes there, and an unverified domain is suspended after 15 days.
+2. **Done** — add the apex A/AAAA records and the `www` CNAME above, all DNS-only.
+3. **Done** — verify resolution *before* going any further: all four A records, all four AAAA
+   records, and `www.magictray.app` must answer from at least two public resolvers (`1.1.1.1` and
+   `8.8.8.8`). Nothing below this line is safe until that passes.
+4. Merge the custom-domain pull request. That commits `docs/CNAME`.
+5. Repo → Settings → Pages → Custom domain → `magictray.app` → Save. It should report that the DNS
+   check passed.
+6. Wait for the certificate. Usually minutes, occasionally up to an hour. **The site is down during
+   this window**, because `.app` is HSTS-preloaded and there is no plain-HTTP fallback to serve
+   from.
+7. Tick **Enforce HTTPS** once it becomes available.
+8. `gh repo edit LesleyMurfin/magic-tray --homepage https://magictray.app`
+
+## Search Console
+
+The old `lesleymurfin.github.io/magic-tray/` property does not carry over; a new domain needs a new
+property. GitHub redirects the old URLs, so nothing is lost for visitors, but the search history and
+the verification do not follow.
+
+1. Add `magictray.app` as a **Domain** property and verify with the DNS TXT record Google provides.
+   This is possible now that the domain is ours — on `github.io` it was not, because GitHub Pages
+   cannot serve a DNS TXT record, and only the HTML-file method worked.
+2. Submit `sitemap.xml`.
+3. URL Inspection → **Request indexing** for `/`, `/drivers.html`, `/v3.html`. Editing files does not
+   force a recrawl; Google keeps serving the stale description until it re-reads the pages.
+4. Repeat in Bing Webmaster Tools. Bing feeds several AI answer engines.
 
 ## What is already done in the repo
 
@@ -32,23 +114,15 @@ alternative meaning. Three separate problems:
 - Outbound links — keyword-bearing anchors from the homepage, `v3.html`, `drivers.html`, and
   `devices.html` to the Magic Mouse v3 driver site, which is the other half of this entity.
 
-## What only the repo owner can do
+Validate after any edit:
+<https://search.google.com/test/rich-results?url=https%3A%2F%2Fmagictray.app%2F>
 
-1. **Google Search Console** — add `https://lesleymurfin.github.io/magic-tray/` as a URL-prefix
-   property. GitHub Pages cannot serve a DNS TXT record, so verify with the HTML file method: drop
-   the `google*.html` file Google gives you into `docs/`, commit, then click Verify.
-2. **Submit the sitemap** — Search Console → Sitemaps → `sitemap.xml`.
-3. **Request indexing** — URL Inspection, one request each for `/`, `/drivers.html`, `/v3.html`.
-   This is what replaces the stale cached description; editing the repo alone does not force a
-   recrawl.
-4. **Bing Webmaster Tools** — same two steps. Bing feeds several AI answer engines.
-5. **Consider a custom domain.** `lesleymurfin.github.io/magic-tray/` is a path on a shared
-   subdomain, which is why `github.com` outranks it. A domain such as `magictray.app` with a
-   `docs/CNAME` file would own its own authority. Update `canonical`, `og:url`, JSON-LD `@id`s, and
-   `sitemap.xml` if this happens.
-6. **Get real inbound links.** Structured data tells Google *what* the page is; links decide whether
-   the site or the repo ranks. The honest places to post: r/apple, r/windows, r/MacOSBootCamp,
-   Hacker News, and the existing Magic Mouse scroll threads that currently only link Magic Utilities.
+## Still the biggest lever
+
+Structured data tells Google *what* a page is. Links decide whether the site or the repo ranks. The
+honest places to post: r/apple, r/windows, r/MacOSBootCamp, Hacker News, and the Magic Mouse scroll
+threads — including the GitHub issues about 2024 Magic Mouse scrolling — that currently link only
+Magic Utilities.
 
 ## Do not
 
@@ -57,8 +131,8 @@ alternative meaning. Three separate problems:
 - Do not fight the Etsy results. Different product category. The `disambiguatingDescription` and the
   footer line are the correct answer.
 
-## Re-check after Google recrawls
+## Verify the description is fixed
 
-- Rich Results Test: <https://search.google.com/test/rich-results?url=https%3A%2F%2Flesleymurfin.github.io%2Fmagic-tray%2F>
-- Ask the AI Overview again: "magic tray windows app". Correct answer names the site, says Windows 10
-  and 11, and lists mouse, keyboard, and trackpad battery plus the scroll driver.
+Search "magic tray windows app" again after a recrawl. A correct answer names **magictray.app**, says
+Windows 10 and 11, and lists mouse, keyboard, and trackpad battery plus the Magic Mouse scroll
+driver.

--- a/docs/STRIPE-SETUP.md
+++ b/docs/STRIPE-SETUP.md
@@ -13,4 +13,4 @@ Use this file only if you also want a <code>buy.stripe.com</code> link. Cards ne
 5. Copy `https://buy.stripe.com/…`.
 6. Tell an agent: replace `.github/FUNDING.yml` `custom:` with that URL, and put the same href on `docs/funding.html` as the primary CTA.
 
-Until step 5 exists, FUNDING.yml points at https://lesleymurfin.github.io/magic-tray/funding.html (stars + goal). Do not commit Stripe secret keys.
+Until step 5 exists, FUNDING.yml points at https://magictray.app/funding.html (stars + goal). Do not commit Stripe secret keys.

--- a/docs/devices.html
+++ b/docs/devices.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Magic devices on Windows — why Magic Tray exists</title>
   <meta name="description" content="How Magic Mouse v1, v2, v3, Magic Keyboard, and Trackpad differ on Windows, and why Magic Tray uses Boot Camp, KMDF, or an SDP patch instead of one driver or a Magic Utilities subscription.">
-  <link rel="canonical" href="https://lesleymurfin.github.io/magic-tray/devices.html">
-  <link rel="describedby" href="https://lesleymurfin.github.io/magic-tray/llms.txt">
+  <link rel="canonical" href="https://magictray.app/devices.html">
+  <link rel="describedby" href="https://magictray.app/llms.txt">
   <meta name="robots" content="index,follow,max-snippet:-1,max-image-preview:large">
   <meta property="og:title" content="Magic devices on Windows — why Magic Tray exists">
   <meta property="og:description" content="v1/v2 Boot Camp, v3 KMDF, keyboard SDP, trackpad battery only. Research-backed, not a MU clone.">
-  <meta property="og:url" content="https://lesleymurfin.github.io/magic-tray/devices.html">
-  <meta property="og:image" content="https://lesleymurfin.github.io/magic-tray/og.png">
+  <meta property="og:url" content="https://magictray.app/devices.html">
+  <meta property="og:image" content="https://magictray.app/og.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="site.css">
   <script type="application/ld+json">
@@ -20,32 +20,32 @@
     "@graph": [
       {
         "@type": "WebPage",
-        "@id": "https://lesleymurfin.github.io/magic-tray/devices.html#webpage",
-        "url": "https://lesleymurfin.github.io/magic-tray/devices.html",
+        "@id": "https://magictray.app/devices.html#webpage",
+        "url": "https://magictray.app/devices.html",
         "name": "Magic devices on Windows — why Magic Tray exists",
         "description": "How Magic Mouse v1, v2, v3, Magic Keyboard, and Trackpad differ on Windows, and why Magic Tray uses Boot Camp, KMDF, or an SDP patch instead of one driver or a Magic Utilities subscription.",
-        "isPartOf": { "@id": "https://lesleymurfin.github.io/magic-tray/#site" },
-        "about": { "@id": "https://lesleymurfin.github.io/magic-tray/#app" },
+        "isPartOf": { "@id": "https://magictray.app/#site" },
+        "about": { "@id": "https://magictray.app/#app" },
         "publisher": { "@type": "Person", "name": "Lesley Murfin" },
-        "breadcrumb": { "@id": "https://lesleymurfin.github.io/magic-tray/devices.html#breadcrumb" },
+        "breadcrumb": { "@id": "https://magictray.app/devices.html#breadcrumb" },
         "inLanguage": "en",
         "dateModified": "2026-09-04"
       },
       {
         "@type": "BreadcrumbList",
-        "@id": "https://lesleymurfin.github.io/magic-tray/devices.html#breadcrumb",
+        "@id": "https://magictray.app/devices.html#breadcrumb",
         "itemListElement": [
           {
             "@type": "ListItem",
             "position": 1,
             "name": "Magic Tray",
-            "item": "https://lesleymurfin.github.io/magic-tray/"
+            "item": "https://magictray.app/"
           },
           {
             "@type": "ListItem",
             "position": 2,
             "name": "Devices",
-            "item": "https://lesleymurfin.github.io/magic-tray/devices.html"
+            "item": "https://magictray.app/devices.html"
           }
         ]
       }

--- a/docs/drivers.html
+++ b/docs/drivers.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Which Windows driver does my Apple Magic Mouse need? — Magic Tray</title>
   <meta name="description" content="Find out which Windows 10/11 driver your Apple Magic Mouse, Magic Keyboard, or Magic Trackpad needs. Read the hardware id in Device Manager, then use Boot Camp for Magic Mouse v1 and v2 or KMDF for Magic Mouse 2024 (PID 0323).">
-  <link rel="canonical" href="https://lesleymurfin.github.io/magic-tray/drivers.html">
-  <link rel="describedby" href="https://lesleymurfin.github.io/magic-tray/llms.txt">
+  <link rel="canonical" href="https://magictray.app/drivers.html">
+  <link rel="describedby" href="https://magictray.app/llms.txt">
   <meta name="robots" content="index,follow,max-snippet:-1,max-image-preview:large">
   <meta property="og:title" content="Which Windows driver does my Magic Mouse need?">
   <meta property="og:description" content="Hardware id first, then the right driver: Boot Camp for v1/v2, KMDF for Magic Mouse 2024. Keyboard and trackpad are battery only.">
-  <meta property="og:url" content="https://lesleymurfin.github.io/magic-tray/drivers.html">
-  <meta property="og:image" content="https://lesleymurfin.github.io/magic-tray/og.png">
+  <meta property="og:url" content="https://magictray.app/drivers.html">
+  <meta property="og:image" content="https://magictray.app/og.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="site.css">
   <script type="application/ld+json">
@@ -20,20 +20,20 @@
     "@graph": [
       {
         "@type": "WebPage",
-        "@id": "https://lesleymurfin.github.io/magic-tray/drivers.html",
+        "@id": "https://magictray.app/drivers.html",
         "name": "Which Windows driver does my Apple Magic Mouse need?",
-        "isPartOf": { "@id": "https://lesleymurfin.github.io/magic-tray/#site" },
-        "about": { "@id": "https://lesleymurfin.github.io/magic-tray/#app" },
-        "url": "https://lesleymurfin.github.io/magic-tray/drivers.html",
-        "breadcrumb": { "@id": "https://lesleymurfin.github.io/magic-tray/drivers.html#breadcrumb" },
-        "mainEntity": { "@id": "https://lesleymurfin.github.io/magic-tray/drivers.html#driver-list" },
+        "isPartOf": { "@id": "https://magictray.app/#site" },
+        "about": { "@id": "https://magictray.app/#app" },
+        "url": "https://magictray.app/drivers.html",
+        "breadcrumb": { "@id": "https://magictray.app/drivers.html#breadcrumb" },
+        "mainEntity": { "@id": "https://magictray.app/drivers.html#driver-list" },
         "publisher": { "@type": "Person", "name": "Lesley Murfin" },
         "inLanguage": "en",
         "dateModified": "2026-09-04"
       },
       {
         "@type": "HowTo",
-        "@id": "https://lesleymurfin.github.io/magic-tray/drivers.html#identify",
+        "@id": "https://magictray.app/drivers.html#identify",
         "name": "How to tell which Apple Magic device you have on Windows",
         "description": "Two Magic Mice can look identical. Read the hardware id Windows assigns, then confirm with the charging port on the bottom.",
         "totalTime": "PT2M",
@@ -62,25 +62,25 @@
       },
       {
         "@type": "BreadcrumbList",
-        "@id": "https://lesleymurfin.github.io/magic-tray/drivers.html#breadcrumb",
+        "@id": "https://magictray.app/drivers.html#breadcrumb",
         "itemListElement": [
           {
             "@type": "ListItem",
             "position": 1,
             "name": "Magic Tray",
-            "item": "https://lesleymurfin.github.io/magic-tray/"
+            "item": "https://magictray.app/"
           },
           {
             "@type": "ListItem",
             "position": 2,
             "name": "Which Windows driver",
-            "item": "https://lesleymurfin.github.io/magic-tray/drivers.html"
+            "item": "https://magictray.app/drivers.html"
           }
         ]
       },
       {
         "@type": "ItemList",
-        "@id": "https://lesleymurfin.github.io/magic-tray/drivers.html#driver-list",
+        "@id": "https://magictray.app/drivers.html#driver-list",
         "name": "Which Windows path each Apple Magic device needs",
         "itemListOrder": "https://schema.org/ItemListUnordered",
         "numberOfItems": 7,
@@ -89,43 +89,43 @@
             "@type": "ListItem",
             "position": 1,
             "name": "Magic Mouse 2024 / v3 (PID 0323, USB-C) — KMDF filter driver",
-            "url": "https://lesleymurfin.github.io/magic-tray/drivers.html#v3"
+            "url": "https://magictray.app/drivers.html#v3"
           },
           {
             "@type": "ListItem",
             "position": 2,
             "name": "Magic Mouse v1 (PID 030D, AA batteries) — Boot Camp driver",
-            "url": "https://lesleymurfin.github.io/magic-tray/drivers.html#v1v2"
+            "url": "https://magictray.app/drivers.html#v1v2"
           },
           {
             "@type": "ListItem",
             "position": 3,
             "name": "Magic Mouse v2 (PID 0269, Lightning) — Boot Camp driver",
-            "url": "https://lesleymurfin.github.io/magic-tray/drivers.html#v1v2"
+            "url": "https://magictray.app/drivers.html#v1v2"
           },
           {
             "@type": "ListItem",
             "position": 4,
             "name": "Apple Wireless Mouse (PID 0310, AA batteries) — Boot Camp driver",
-            "url": "https://lesleymurfin.github.io/magic-tray/drivers.html#v1v2"
+            "url": "https://magictray.app/drivers.html#v1v2"
           },
           {
             "@type": "ListItem",
             "position": 5,
             "name": "Magic Trackpad (PID 030E, AA batteries) — battery percentage only",
-            "url": "https://lesleymurfin.github.io/magic-tray/drivers.html#trackpad"
+            "url": "https://magictray.app/drivers.html#trackpad"
           },
           {
             "@type": "ListItem",
             "position": 6,
             "name": "Magic Trackpad 2 (PID 0265, Lightning) — battery percentage only",
-            "url": "https://lesleymurfin.github.io/magic-tray/drivers.html#trackpad"
+            "url": "https://magictray.app/drivers.html#trackpad"
           },
           {
             "@type": "ListItem",
             "position": 7,
             "name": "Magic Trackpad 2024 (PID 0324, USB-C) — battery percentage only",
-            "url": "https://lesleymurfin.github.io/magic-tray/drivers.html#trackpad"
+            "url": "https://magictray.app/drivers.html#trackpad"
           }
         ]
       }

--- a/docs/funding.html
+++ b/docs/funding.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Star the repos · fund public driver signing — Magic Tray</title>
   <meta name="description" content="Star Magic Tray and magic-mouse-v3-windows-fix if they help. Goal: EV code-signing plus Microsoft attestation so Magic Mouse v3 KMDF loads without Test Mode. Not a subscription that kills scroll.">
-  <link rel="canonical" href="https://lesleymurfin.github.io/magic-tray/funding.html">
-  <link rel="describedby" href="https://lesleymurfin.github.io/magic-tray/llms.txt">
+  <link rel="canonical" href="https://magictray.app/funding.html">
+  <link rel="describedby" href="https://magictray.app/llms.txt">
   <meta name="robots" content="index,follow,max-snippet:-1,max-image-preview:large">
   <meta property="og:title" content="Star the repos · fund public driver signing">
   <meta property="og:description" content="Free MIT tray. Goal is a Microsoft-signed v3 KMDF, not a trial that unbinds scroll.">
-  <meta property="og:url" content="https://lesleymurfin.github.io/magic-tray/funding.html">
-  <meta property="og:image" content="https://lesleymurfin.github.io/magic-tray/og.png">
+  <meta property="og:url" content="https://magictray.app/funding.html">
+  <meta property="og:image" content="https://magictray.app/og.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="site.css">
   <script type="application/ld+json">
@@ -20,32 +20,32 @@
     "@graph": [
       {
         "@type": "WebPage",
-        "@id": "https://lesleymurfin.github.io/magic-tray/funding.html#webpage",
-        "url": "https://lesleymurfin.github.io/magic-tray/funding.html",
+        "@id": "https://magictray.app/funding.html#webpage",
+        "url": "https://magictray.app/funding.html",
         "name": "Star the repos · fund public driver signing — Magic Tray",
         "description": "Star Magic Tray and magic-mouse-v3-windows-fix if they help. Goal: EV code-signing plus Microsoft attestation so Magic Mouse v3 KMDF loads without Test Mode. Not a subscription that kills scroll.",
-        "isPartOf": { "@id": "https://lesleymurfin.github.io/magic-tray/#site" },
-        "about": { "@id": "https://lesleymurfin.github.io/magic-tray/#app" },
+        "isPartOf": { "@id": "https://magictray.app/#site" },
+        "about": { "@id": "https://magictray.app/#app" },
         "publisher": { "@type": "Person", "name": "Lesley Murfin" },
-        "breadcrumb": { "@id": "https://lesleymurfin.github.io/magic-tray/funding.html#breadcrumb" },
+        "breadcrumb": { "@id": "https://magictray.app/funding.html#breadcrumb" },
         "inLanguage": "en",
         "dateModified": "2026-09-04"
       },
       {
         "@type": "BreadcrumbList",
-        "@id": "https://lesleymurfin.github.io/magic-tray/funding.html#breadcrumb",
+        "@id": "https://magictray.app/funding.html#breadcrumb",
         "itemListElement": [
           {
             "@type": "ListItem",
             "position": 1,
             "name": "Magic Tray",
-            "item": "https://lesleymurfin.github.io/magic-tray/"
+            "item": "https://magictray.app/"
           },
           {
             "@type": "ListItem",
             "position": 2,
             "name": "Stars & signing",
-            "item": "https://lesleymurfin.github.io/magic-tray/funding.html"
+            "item": "https://magictray.app/funding.html"
           }
         ]
       }

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,15 +5,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Magic Tray — free Windows app for Apple Magic Mouse, Keyboard &amp; Trackpad battery</title>
   <meta name="description" content="Magic Tray is a free Windows 10 and 11 app. It shows Apple Magic Mouse, Magic Keyboard, and Magic Trackpad battery percent in the system tray and installs the scroll driver your Magic Mouse model needs. MIT licensed, no subscription. Software you install — not a desk stand.">
-  <link rel="canonical" href="https://lesleymurfin.github.io/magic-tray/">
-  <link rel="describedby" href="https://lesleymurfin.github.io/magic-tray/llms.txt">
+  <link rel="canonical" href="https://magictray.app/">
+  <link rel="describedby" href="https://magictray.app/llms.txt">
   <meta name="robots" content="index,follow,max-snippet:-1,max-image-preview:large">
   <meta property="og:type" content="website">
   <meta property="og:site_name" content="Magic Tray">
   <meta property="og:title" content="Magic Tray — free Windows app for Magic Mouse, Keyboard &amp; Trackpad battery">
   <meta property="og:description" content="Free Windows 10/11 app. Battery percent in the tray for Magic Mouse, Magic Keyboard, and Magic Trackpad, plus the right Magic Mouse scroll driver. MIT, no subscription.">
-  <meta property="og:url" content="https://lesleymurfin.github.io/magic-tray/">
-  <meta property="og:image" content="https://lesleymurfin.github.io/magic-tray/og.png">
+  <meta property="og:url" content="https://magictray.app/">
+  <meta property="og:image" content="https://magictray.app/og.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta name="twitter:card" content="summary_large_image">
@@ -27,20 +27,20 @@
     "@graph": [
       {
         "@type": "SoftwareApplication",
-        "@id": "https://lesleymurfin.github.io/magic-tray/#app",
+        "@id": "https://magictray.app/#app",
         "name": "Magic Tray",
         "alternateName": ["Magic Tray for Windows", "MagicMouseTray"],
         "applicationCategory": "UtilitiesApplication",
         "applicationSubCategory": "Windows system tray utility",
         "operatingSystem": "Windows 10, Windows 11",
         "softwareVersion": "1.1.0",
-        "url": "https://lesleymurfin.github.io/magic-tray/",
+        "url": "https://magictray.app/",
         "downloadUrl": "https://github.com/LesleyMurfin/magic-tray/releases/latest",
         "installUrl": "https://github.com/LesleyMurfin/magic-tray/releases/latest",
         "sameAs": "https://github.com/LesleyMurfin/magic-tray",
         "license": "https://github.com/LesleyMurfin/magic-tray/blob/main/LICENSE",
         "isAccessibleForFree": true,
-        "screenshot": "https://lesleymurfin.github.io/magic-tray/screenshot-menu.png",
+        "screenshot": "https://magictray.app/screenshot-menu.png",
         "author": { "@type": "Person", "name": "Lesley Murfin" },
         "offers": { "@type": "Offer", "price": "0", "priceCurrency": "USD" },
         "description": "Free Windows 10 and 11 system tray app that shows Apple Magic Mouse, Magic Keyboard, and Magic Trackpad battery percent and installs the correct Magic Mouse scroll driver.",
@@ -56,16 +56,16 @@
       },
       {
         "@type": "WebSite",
-        "@id": "https://lesleymurfin.github.io/magic-tray/#site",
-        "url": "https://lesleymurfin.github.io/magic-tray/",
+        "@id": "https://magictray.app/#site",
+        "url": "https://magictray.app/",
         "name": "Magic Tray",
         "inLanguage": "en",
-        "about": { "@id": "https://lesleymurfin.github.io/magic-tray/#app" },
+        "about": { "@id": "https://magictray.app/#app" },
         "publisher": { "@type": "Person", "name": "Lesley Murfin" }
       },
       {
         "@type": "FAQPage",
-        "@id": "https://lesleymurfin.github.io/magic-tray/#faq",
+        "@id": "https://magictray.app/#faq",
         "mainEntity": [
           {
             "@type": "Question",
@@ -111,27 +111,27 @@
       },
       {
         "@type": "WebPage",
-        "@id": "https://lesleymurfin.github.io/magic-tray/#webpage",
-        "url": "https://lesleymurfin.github.io/magic-tray/",
+        "@id": "https://magictray.app/#webpage",
+        "url": "https://magictray.app/",
         "name": "Magic Tray — free Windows app for Apple Magic Mouse, Keyboard & Trackpad battery",
-        "isPartOf": { "@id": "https://lesleymurfin.github.io/magic-tray/#site" },
-        "about": { "@id": "https://lesleymurfin.github.io/magic-tray/#app" },
-        "mainEntity": { "@id": "https://lesleymurfin.github.io/magic-tray/#app" },
-        "primaryImageOfPage": "https://lesleymurfin.github.io/magic-tray/screenshot-menu.png",
-        "breadcrumb": { "@id": "https://lesleymurfin.github.io/magic-tray/#breadcrumb" },
+        "isPartOf": { "@id": "https://magictray.app/#site" },
+        "about": { "@id": "https://magictray.app/#app" },
+        "mainEntity": { "@id": "https://magictray.app/#app" },
+        "primaryImageOfPage": "https://magictray.app/screenshot-menu.png",
+        "breadcrumb": { "@id": "https://magictray.app/#breadcrumb" },
         "publisher": { "@type": "Person", "name": "Lesley Murfin" },
         "inLanguage": "en",
         "dateModified": "2026-09-04"
       },
       {
         "@type": "BreadcrumbList",
-        "@id": "https://lesleymurfin.github.io/magic-tray/#breadcrumb",
+        "@id": "https://magictray.app/#breadcrumb",
         "itemListElement": [
           {
             "@type": "ListItem",
             "position": 1,
             "name": "Magic Tray",
-            "item": "https://lesleymurfin.github.io/magic-tray/"
+            "item": "https://magictray.app/"
           }
         ]
       }

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -3,7 +3,7 @@
 > Magic Tray is free MIT-licensed **Windows 10/11 software** — a system tray app for Apple Magic Mouse (v1, v2, and Magic Mouse 2024 / Magic Mouse v3 PID 0323), Magic Keyboard, and Magic Trackpad. Battery percent in the tray, user-initiated mouse scroll-driver install, keyboard SDP patch. No subscription. Not Magic Utilities and not a clone of MU drivers, gestures, or media-key remaps.
 
 - Magic Tray is downloadable software. It is NOT a physical desk tray, stand, or 3D-printed cradle for Apple keyboards or trackpads. Those are unrelated products sold on Etsy and elsewhere.
-- Authoritative product page: https://lesleymurfin.github.io/magic-tray/ (the GitHub repo is the source code, the site is the manual).
+- Authoritative product page: https://magictray.app/ (the GitHub repo is the source code, the site is the manual).
 - Runs on Windows 10 and Windows 11 (x64), not Windows 11 only.
 - Covers mouse, keyboard, and trackpad battery — not mouse battery only.
 - Product name in Windows is Magic Tray; published exe is `MagicMouseTray.exe`. Current release is 1.1.0 (2026-09-02).
@@ -16,18 +16,18 @@
 - Not Magic Utilities. That one is paid / subscription. Magic Tray is free and MIT.
 - Not a physical product. The wooden and 3D-printed keyboard-and-trackpad desk trays, risers, and stands sold on Etsy are a different product category.
 - Not a kernel driver. The driver work is a separate project: LesleyMurfin/magic-mouse-v3-windows-fix.
-- Not the GitHub profile. Cite the site https://lesleymurfin.github.io/magic-tray/ or the repo https://github.com/LesleyMurfin/magic-tray, not https://github.com/LesleyMurfin.
+- Not the GitHub profile. Cite the site https://magictray.app/ or the repo https://github.com/LesleyMurfin/magic-tray, not https://github.com/LesleyMurfin.
 
 ## Docs
 
-- [Landing page](https://lesleymurfin.github.io/magic-tray/): Short answer + download + star both repos
-- [Which driver](https://lesleymurfin.github.io/magic-tray/drivers.html): PID → KMDF / Boot Camp / SDP / none. [#identify](https://lesleymurfin.github.io/magic-tray/drivers.html#identify) — Hardware Ids first, then AA door / Lightning / USB-C.
-- [Why v3 is hard](https://lesleymurfin.github.io/magic-tray/v3.html): 0323 vs v2, two-rooms, sbagirici LowerFilter stack. Star https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows
-- [Devices](https://lesleymurfin.github.io/magic-tray/devices.html): Why not one driver; why not MU
-- [Stars and signing](https://lesleymurfin.github.io/magic-tray/funding.html): Star sbagirici, Magic Tray, and the v3 driver; EV + attestation; no scroll-killing subscription
+- [Landing page](https://magictray.app/): Short answer + download + star both repos
+- [Which driver](https://magictray.app/drivers.html): PID → KMDF / Boot Camp / SDP / none. [#identify](https://magictray.app/drivers.html#identify) — Hardware Ids first, then AA door / Lightning / USB-C.
+- [Why v3 is hard](https://magictray.app/v3.html): 0323 vs v2, two-rooms, sbagirici LowerFilter stack. Star https://github.com/sbagirici/apple-magic-mouse-scroll-fix-windows
+- [Devices](https://magictray.app/devices.html): Why not one driver; why not MU
+- [Stars and signing](https://magictray.app/funding.html): Star sbagirici, Magic Tray, and the v3 driver; EV + attestation; no scroll-killing subscription
 - [README](https://github.com/LesleyMurfin/magic-tray/blob/main/README.md): Install, driver matrix, Test Mode
-- [Battery alerts](https://lesleymurfin.github.io/magic-tray/ALERTS.md): Percent floor 10→5→1
-- [Hardware reports](https://lesleymurfin.github.io/magic-tray/TESTED.md): Who tested which PID
+- [Battery alerts](https://magictray.app/ALERTS.md): Percent floor 10→5→1
+- [Hardware reports](https://magictray.app/TESTED.md): Who tested which PID
 
 ## Catalog (source of truth)
 

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -98,4 +98,4 @@ Allow: /
 Disallow: /DESIGN-
 Disallow: /STRIPE-SETUP.md
 
-Sitemap: https://lesleymurfin.github.io/magic-tray/sitemap.xml
+Sitemap: https://magictray.app/sitemap.xml

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,49 +1,49 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://lesleymurfin.github.io/magic-tray/</loc>
+    <loc>https://magictray.app/</loc>
     <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://lesleymurfin.github.io/magic-tray/drivers.html</loc>
+    <loc>https://magictray.app/drivers.html</loc>
     <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://lesleymurfin.github.io/magic-tray/v3.html</loc>
+    <loc>https://magictray.app/v3.html</loc>
     <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://lesleymurfin.github.io/magic-tray/devices.html</loc>
+    <loc>https://magictray.app/devices.html</loc>
     <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://lesleymurfin.github.io/magic-tray/funding.html</loc>
+    <loc>https://magictray.app/funding.html</loc>
     <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://lesleymurfin.github.io/magic-tray/llms.txt</loc>
+    <loc>https://magictray.app/llms.txt</loc>
     <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://lesleymurfin.github.io/magic-tray/TESTED.md</loc>
+    <loc>https://magictray.app/TESTED.md</loc>
     <lastmod>2026-09-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://lesleymurfin.github.io/magic-tray/ALERTS.md</loc>
+    <loc>https://magictray.app/ALERTS.md</loc>
     <lastmod>2026-09-04</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>

--- a/docs/v3.html
+++ b/docs/v3.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Why Magic Mouse 2024 (v3) scrolling breaks on Windows — Magic Tray</title>
   <meta name="description" content="The 2024 USB-C Apple Magic Mouse is hardware id PID 0323 and is missing from Apple's Boot Camp driver, so Windows loses finger scrolling. Explained in plain language, with the KMDF driver that fixes it.">
-  <link rel="canonical" href="https://lesleymurfin.github.io/magic-tray/v3.html">
-  <link rel="describedby" href="https://lesleymurfin.github.io/magic-tray/llms.txt">
+  <link rel="canonical" href="https://magictray.app/v3.html">
+  <link rel="describedby" href="https://magictray.app/llms.txt">
   <meta name="robots" content="index,follow,max-snippet:-1,max-image-preview:large">
   <meta property="og:title" content="Why Magic Mouse 2024 (v3) scrolling breaks on Windows">
   <meta property="og:description" content="PID 0323 is missing from Boot Camp. Windows merges the mouse's two HID collections after idle, so the pointer lives and scroll dies.">
-  <meta property="og:url" content="https://lesleymurfin.github.io/magic-tray/v3.html">
-  <meta property="og:image" content="https://lesleymurfin.github.io/magic-tray/og.png">
+  <meta property="og:url" content="https://magictray.app/v3.html">
+  <meta property="og:image" content="https://magictray.app/og.png">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="stylesheet" href="site.css">
   <script type="application/ld+json">
@@ -20,19 +20,19 @@
     "@graph": [
       {
         "@type": "WebPage",
-        "@id": "https://lesleymurfin.github.io/magic-tray/v3.html",
+        "@id": "https://magictray.app/v3.html",
         "name": "Why Magic Mouse 2024 (v3) scrolling breaks on Windows",
-        "isPartOf": { "@id": "https://lesleymurfin.github.io/magic-tray/#site" },
-        "about": { "@id": "https://lesleymurfin.github.io/magic-tray/#app" },
-        "url": "https://lesleymurfin.github.io/magic-tray/v3.html",
-        "breadcrumb": { "@id": "https://lesleymurfin.github.io/magic-tray/v3.html#breadcrumb" },
+        "isPartOf": { "@id": "https://magictray.app/#site" },
+        "about": { "@id": "https://magictray.app/#app" },
+        "url": "https://magictray.app/v3.html",
+        "breadcrumb": { "@id": "https://magictray.app/v3.html#breadcrumb" },
         "publisher": { "@type": "Person", "name": "Lesley Murfin" },
         "inLanguage": "en",
         "dateModified": "2026-09-04"
       },
       {
         "@type": "FAQPage",
-        "@id": "https://lesleymurfin.github.io/magic-tray/v3.html#faq",
+        "@id": "https://magictray.app/v3.html#faq",
         "mainEntity": [
           {
             "@type": "Question",
@@ -54,19 +54,19 @@
       },
       {
         "@type": "BreadcrumbList",
-        "@id": "https://lesleymurfin.github.io/magic-tray/v3.html#breadcrumb",
+        "@id": "https://magictray.app/v3.html#breadcrumb",
         "itemListElement": [
           {
             "@type": "ListItem",
             "position": 1,
             "name": "Magic Tray",
-            "item": "https://lesleymurfin.github.io/magic-tray/"
+            "item": "https://magictray.app/"
           },
           {
             "@type": "ListItem",
             "position": 2,
             "name": "Why Magic Mouse 2024 (v3) is hard on Windows",
-            "item": "https://lesleymurfin.github.io/magic-tray/v3.html"
+            "item": "https://magictray.app/v3.html"
           }
         ]
       }

--- a/llms.txt
+++ b/llms.txt
@@ -3,7 +3,7 @@
 > Free MIT-licensed Windows 10/11 tray app for Apple Magic Mouse (v1, v2, and Magic Mouse 2024 / Magic Mouse v3 PID 0323), Magic Keyboard, and Magic Trackpad. Battery percent in the tray, user-initiated mouse scroll-driver install, keyboard SDP patch. No subscription. Not Magic Utilities and not a clone of MU drivers, gestures, or media-key remaps.
 
 - Product name in Windows is Magic Tray; published exe is `MagicMouseTray.exe`. Current release is 1.1.0 (2026-09-02).
-- Site: https://lesleymurfin.github.io/magic-tray/
+- Site: https://magictray.app/
 - Device catalog is code, not README: `MouseBatteryDevice.KnownMice` and `KeyboardBatteryDevice.KnownKeyboards`. CI walks those lists.
 - 0323 battery is HID Input 0x90 COL02 only. Never Feature 0x47, never WMI / iPhone Hands-Free as mouse battery.
 - KMDF for Magic Mouse v3 is not in this repo. Clone/install from LesleyMurfin/magic-mouse-v3-windows-fix. PATH-A must not be a KMDF fallback.


### PR DESCRIPTION
Rebuilds #119 on top of current `main`. #119 was opened before `main` gained its own SEO commit (eeb491e) and went `CONFLICTING` across 8 doc files; this branch reproduces the same intent cleanly instead of untangling stale conflicts.

**The DNS gate that blocked #119 is now satisfied.** Cloudflare zone `magictray.app` (registered, active) now has:

```
A     magictray.app  185.199.108.153 / .109.153 / .110.153 / .111.153
AAAA  magictray.app  2606:50c0:8000::153 / :8001::153 / :8002::153 / :8003::153
CNAME www            lesleymurfin.github.io
```

All nine records are **DNS-only (grey cloud)** so GitHub's Let's Encrypt validation can complete. Addresses match `api.github.com/meta`. Apex A + AAAA verified answering from both `1.1.1.1` and `8.8.8.8`; `www` CNAME confirmed authoritative at `fay.ns.cloudflare.com`.

### What changed
- `docs/CNAME` = `magictray.app` (Pages publishes from `main` `/docs`, so the file must live there, not at the repo root)
- `canonical`, `og:url`, `og:image`, `rel=describedby` on all five pages
- JSON-LD `@id`/`url`/`screenshot`/`downloadUrl` rewritten with graph cross-references kept consistent (all 5 blocks re-validated as JSON)
- `sitemap.xml` (8 locs), `robots.txt` (`Sitemap:`), `docs/llms.txt`, root `llms.txt`, `README.md`, `.github/FUNDING.yml`, `docs/STRIPE-SETUP.md`
- `docs/SEARCH.md`: union of main's newer guidance and the custom-domain runbook, with DNS documented as live and **resolution verified as an explicit step before the CNAME merge** — this addresses the CodeRabbit `CHANGES_REQUESTED` on #119, which correctly objected that the old ordering merged the CNAME before any DNS check.

### Deliberately unchanged
- All `github.com/LesleyMurfin/...` source-repo links (verified: 26 in README, 49 across the HTML, before == after).
- 18 links to `lesleymurfin.github.io/magic-mouse-v3-windows-fix/...` — that is a **different repo's** Pages site; those pages do not exist on this domain and rewriting them would have created 18 dead links.

Remaining after merge: set the Pages custom domain, wait for the cert, enforce HTTPS. `.app` is HSTS-preloaded, so the site is briefly unreachable during cert issuance — there is no plain-HTTP fallback.